### PR TITLE
Add some margin to checkboxes

### DIFF
--- a/src/components/Checkbox/PCheckbox.vue
+++ b/src/components/Checkbox/PCheckbox.vue
@@ -60,6 +60,10 @@
 </script>
 
 <style>
+.p-checkbox { @apply
+  my-1
+}
+
 .p-checkbox--disabled,
 :disabled .p-checkbox { @apply
   cursor-not-allowed


### PR DESCRIPTION
Without any margin the focus ring around a checkbox overlaps other content. Since checkboxes will frequently appear in a list of other checkboxes I think it might make sense to have a little margin built in. 

Before
<img width="107" alt="image" src="https://user-images.githubusercontent.com/6200442/165851650-50d11420-a84a-47aa-86f0-12dd5b232521.png">

After
<img width="192" alt="image" src="https://user-images.githubusercontent.com/6200442/165851906-86b034a7-a343-4eec-8a84-01160dff2153.png">
