### PR TITLE
Fix icon copy-paste, use our toasts instead of alert

### DIFF
--- a/demo/Icons.vue
+++ b/demo/Icons.vue
@@ -30,13 +30,15 @@
   import * as heroIcons from '@heroicons/vue/solid'
   import * as prefectIcons from '@/components/Icon/icons'
 
+  import { showToast } from '@/plugins/Toast'
+
   const prefectIconKeys = Object.keys(prefectIcons)
   const heroIconKeys = Object.keys(heroIcons)
 
-  function copy(icon: string): void {
-    navigator.clipboard.writeText(`<p-icon icon="${icon}" />`)
+  async function copy(icon: string): Promise<void> {
+    await navigator.clipboard.writeText(`<p-icon icon="${icon}" />`)
 
     // eslint-disable-next-line no-alert
-    alert('Copied to clipboard!')
+    showToast(`Copied ${icon} to clipboard!`, 'success', undefined, 3000)
   }
 </script>


### PR DESCRIPTION
Fixes an issue where the alert when copy-pasting icons failed because the navigator.write operation is async and expects document focus.

Switches the icons section from using browser native alerts to the new toasts plugin! 👯 