### PR TITLE
PCheckbox - support checkboxes without labels

### DIFF
--- a/src/components/Checkbox/PCheckbox.vue
+++ b/src/components/Checkbox/PCheckbox.vue
@@ -2,9 +2,11 @@
   <div class="p-checkbox" :class="classes">
     <label class="p-checkbox__label">
       <slot name="label">
-        <div class="p-checkbox__label-text">
-          {{ label }}
-        </div>
+        <template v-if="label">
+          <div class="p-checkbox__label-text">
+            {{ label }}
+          </div>
+        </template>
       </slot>
       <input
         v-model="value"


### PR DESCRIPTION
`gap` is used to put some space between the label and checkbox elements. So if you don't use a label at all you end up with that whitespace still. Added a `v-if` so that element doesn't even show up if there is no label to show.