### PR TITLE
Fix Sidebar style inconsistencies and add missing imports

### DIFF
--- a/src/components/ContextNavItem/PContextNavItem.vue
+++ b/src/components/ContextNavItem/PContextNavItem.vue
@@ -13,6 +13,7 @@
 
 <script setup lang="ts">
   import { RouteLocationRaw } from 'vue-router'
+  import PIcon from '@/components/Icon/PIcon.vue'
   import { Icon } from '@/types/icon'
 
   defineProps<{

--- a/src/components/ContextSidebar/PContextSidebar.vue
+++ b/src/components/ContextSidebar/PContextSidebar.vue
@@ -18,26 +18,25 @@
   sticky
   top-0
   w-screen
-  pl-3
-  pr-7
+  px-3
+  py-2
   z-10
   sm:flex
   sm:h-screen
   sm:w-64
   sm:flex-col
-  sm:py-5
-  sm:px-3
 }
 
 .p-context-sidebar__nav-items {
   @apply
   flex
   flex-col
-  sm:gap-1
+  gap-1
 }
 
 .p-context-sidebar__nav-items--bottom {
   @apply
-  mt-auto
+  sm:mt-auto
+  mt-1
 }
 </style>

--- a/src/components/GlobalNavItem/PGlobalNavItem.vue
+++ b/src/components/GlobalNavItem/PGlobalNavItem.vue
@@ -8,6 +8,7 @@
 </template>
 
 <script lang="ts" setup>
+  import PIcon from '@/components/Icon/PIcon.vue'
   import { Icon } from '@/types/icon'
 
   defineProps<{


### PR DESCRIPTION
While working on the context sidebar component in orion-design, I noticed some style mistakes and missing imports