### PR TITLE
Tags justification and margins

### DIFF
--- a/demo/sections/TagsSection.vue
+++ b/demo/sections/TagsSection.vue
@@ -14,9 +14,9 @@
       <ResizableSection>
         <div class="bg-slate-200 absolute h-full left-[50px] right-[50px]" />
         <div class="bg-white px-[50px]">
-          <p-tag-wrapper class="h-[48px]" :tags="numberArr" />
+          <p-tag-wrapper class="h-[48px]" :tags="numberArr" justify="center" />
 
-          <p-tag-wrapper class="h-[48px]" :tags="numberArr" justify="center">
+          <p-tag-wrapper class="h-[48px]" :tags="numberArr">
             <template #tag="{ tag }">
               <p-tag icon="Prefect">
                 {{ tag }}

--- a/src/components/TagWrapper/PTagWrapper.vue
+++ b/src/components/TagWrapper/PTagWrapper.vue
@@ -4,7 +4,7 @@
       <slot>
         <template v-for="tag in tags">
           <slot name="tag" :tag="tag">
-            <p-tag>
+            <p-tag class="p-tag-wrapper__tag" :class="classes.tag">
               {{ tag }}
             </p-tag>
           </slot>
@@ -37,6 +37,7 @@
 
   const classes = computed(() => {
     return {
+      tag: [`p-tag-wrapper__tag--${props.justify ?? 'left'}`],
       tagContainer:
         [`p-tag-wrapper__tag-container--${props.justify ?? 'left'}`],
 
@@ -117,12 +118,24 @@
   whitespace-nowrap;
 }
 
-.p-tag-wrapper__tag--hidden {
-  display: none !important;
+.p-tag-wrapper__tag--hidden { @apply
+  !hidden;
 }
 
 .p-tag-wrapper__tag--invisible {
   visibility: hidden !important;
+}
+
+.p-tag-wrapper__tag--right { @apply
+  ml-1;
+}
+
+.p-tag-wrapper__tag--center { @apply
+  mx-[0.125rem];
+}
+
+.p-tag-wrapper__tag--left { @apply
+  mr-1;
 }
 
 .p-tag-wrapper__tag-overflow {


### PR DESCRIPTION
Adds a `justify` prop to the tag wrapper to allow alignment of tags; tags that aren't overridden by the slot will also get a 0.125rem margin, those in a slot will need to be manually padded.

Closes: #116 
Closes: #112 