### PR TITLE
Reduce padding in PIconText

### DIFF
--- a/src/components/IconText/PIconText.vue
+++ b/src/components/IconText/PIconText.vue
@@ -25,7 +25,7 @@
   text-slate-400
   w-4
   h-5
-  mr-2
+  mr-1
 }
 
 .p-text__label { @apply


### PR DESCRIPTION
Bumps down the padding between the icon and text in the PIconText by 0.25rem

Closes: #124  