### PR TITLE
Feature: p-icon and base-input style defaults

### DIFF
--- a/src/components/BaseInput/BaseInput.vue
+++ b/src/components/BaseInput/BaseInput.vue
@@ -74,6 +74,7 @@
   flex
   items-center
   focus-within:ring-1
+  bg-white
   focus-within:border-prefect-600
   focus-within:ring-prefect-600
   border-gray-300

--- a/src/components/Icon/PIcon.vue
+++ b/src/components/Icon/PIcon.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="component" />
+  <component :is="component" class="p-icon" />
 </template>
 
 
@@ -36,3 +36,10 @@
     return icons.includes(value)
   }
 </script>
+
+<style>
+.p-icon { @apply
+  w-5
+  h-5
+}
+</style>


### PR DESCRIPTION
 - default size of PIcon `w-5 h-5`
I believe the default size for PIcon is too large, so everywhere we use PIcon we inevitably need classes to resize it.
 - class for PIcon `class="p-icon"`
This will aid us in trying to target the PIcon for settings size/color
 - default background for BaseInput `bg-white`
This is important for when #prepend or #append slots are used, because they are physically within the border of the input, the background should be white as well to match the `input`s background. We probably didn't notice this before because the demo's background is also white?

without: 
<img width="253" alt="image" src="https://user-images.githubusercontent.com/6098901/170999275-c1c3758b-2f7c-4a06-ac33-0dd4d5989c8c.png">

with:
<img width="261" alt="image" src="https://user-images.githubusercontent.com/6098901/170999118-ce9529c9-0440-47b6-a07a-d5ff229a1956.png">
