### PR TITLE
BugFix: dependency tree error trying to update from other projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "vue-tsc": "0.34.15"
       },
       "peerDependencies": {
-        "vue": "3.2.36",
+        "vue": "^3.2.36",
         "vue-router": "^4.0.12"
       }
     },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "vue-tsc": "0.34.15"
   },
   "peerDependencies": {
-    "vue": "3.2.36",
+    "vue": "^3.2.36",
     "vue-router": "^4.0.12"
   },
   "dependencies": {


### PR DESCRIPTION
updated and pinned to latest vue to fix dependency tree error from trying to update to latest from other projects

not sure if it was prefect-design that needed this or only orion-design?