### PR TITLE
PLayoutFull: Respect parent container

### DIFF
--- a/src/layouts/PLayoutFull/PLayoutFull.vue
+++ b/src/layouts/PLayoutFull/PLayoutFull.vue
@@ -11,6 +11,8 @@
 <style>
 .p-layout-full { @apply
   relative
+  w-full
+  h-full
 }
 
 .p-layout-full__header { @apply


### PR DESCRIPTION
# Description
the layout might not be a dependent of the body so using `w-full` isn't correct. The layout should still respect its parent container. 