### PR TITLE
PBaseInput: Spread the attrs themselves not the ref

### DIFF
--- a/src/components/BaseInput/PBaseInput.vue
+++ b/src/components/BaseInput/PBaseInput.vue
@@ -56,7 +56,7 @@
 
   const attrsWithDisabled = computed(() => ({
     ...attrs.value,
-    disabled: true,
+    disabled: props.disabled,
   }))
 </script>
 


### PR DESCRIPTION
# Description
`attrsWithDisabled` was spreading the `ref` object itself rather than the value of the ref. this caused all attrs to be lost. 