### PR TITLE
Feature: PCardButton component

### DIFF
--- a/demo/sections/CardSection.vue
+++ b/demo/sections/CardSection.vue
@@ -1,11 +1,24 @@
 <template>
   <Section heading="Card">
-    <p-card>
-      <h1>This is a Card component</h1>
-    </p-card>
+    <SubSection heading="Regular">
+      <p-card>
+        <h1>This is a Card component</h1>
+      </p-card>
+    </SubSection>
+    <SubSection heading="Button">
+      <p-card-button>
+        <h1>This is a Card button component</h1>
+      </p-card-button>
+    </SubSection>
+    <SubSection heading="Button with router-link">
+      <p-card-button to="/tables">
+        <h1>This is a Card button component using a router link</h1>
+      </p-card-button>
+    </SubSection>
   </Section>
 </template>
 
 <script lang="ts" setup>
   import Section from '../components/Section.vue'
+  import SubSection from '../components/SubSection.vue'
 </script>

--- a/src/components/CardButton/PCardButton.vue
+++ b/src/components/CardButton/PCardButton.vue
@@ -1,0 +1,51 @@
+<template>
+  <component :is="element" v-bind="elementProps" :class="classes" class="p-card-button">
+    <slot />
+  </component>
+</template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+  import { RouterLink, RouteLocationRaw } from 'vue-router'
+
+  const props = defineProps<{
+    flat?: boolean,
+    to?: RouteLocationRaw,
+  }>()
+
+  const element = computed(() => props.to ? RouterLink : 'button')
+  const elementProps = computed(() => {
+    if (props.to) {
+      return { to: props.to }
+    }
+
+    return {}
+  })
+
+  const classes = computed(() => ({
+    'p-card-button--flat': props.flat,
+  }))
+</script>
+
+<style>
+.p-card-button { @apply
+  block
+  w-full
+  text-left
+  bg-white
+  border
+  border-gray-300
+  p-6
+  rounded-lg
+  shadow-sm
+}
+
+.p-card-button:hover { @apply
+  shadow-lg
+  border-primary
+}
+
+.p-card-button--flat:hover { @apply
+  shadow-sm
+}
+</style>

--- a/src/components/CardButton/index.ts
+++ b/src/components/CardButton/index.ts
@@ -1,0 +1,8 @@
+import { App } from 'vue'
+import PCardButton from './PCardButton.vue'
+
+const install = (app: App): void => {
+  app.component('PCardButton', PCardButton)
+}
+
+export { PCardButton, install }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,7 @@
 import { PBaseInput, install as installPBaseInput } from './BaseInput'
 import { PBreadCrumbs, install as installPBreadCrumbs } from './BreadCrumbs'
 import { PButton, install as installPButton } from './Button'
+import { PCardButton, install as installPCardButton } from './CardButton'
 import { PCalendar, install as installPCalendar } from './Calendar'
 import { PCard, install as installPCard } from './Card'
 import { PCheckbox, install as installPCheckbox } from './Checkbox'
@@ -53,6 +54,7 @@ export {
   PBaseInput,
   PBreadCrumbs,
   PButton,
+  PCardButton,
   PCalendar,
   PCard,
   PCheckbox,
@@ -112,6 +114,7 @@ export const installs = [
   installPBaseInput,
   installPBreadCrumbs,
   installPButton,
+  installPCardButton,
   installPCalendar,
   installPCard,
   installPCheckbox,
@@ -166,6 +169,7 @@ declare module '@vue/runtime-core' {
     PBaseInput: typeof PBaseInput,
     PBreadCrumbs: typeof PBreadCrumbs,
     PButton: typeof PButton,
+    PCardButton: typeof PCardButton,
     PCalendar: typeof PCalendar,
     PCard: typeof PCard,
     PCheckbox: typeof PCheckbox,


### PR DESCRIPTION
# Description
New PCardButton component for clickable cards. 

## props
- `to` for easily using a router-link
- `flat` for removing the box shadow when hovering

<img width="816" alt="image" src="https://user-images.githubusercontent.com/6200442/174323770-0e446e11-68d6-45c5-9178-30555b710989.png">

**hover**
<img width="804" alt="image" src="https://user-images.githubusercontent.com/6200442/174323858-de7670d2-6755-4cdf-b21a-2904e9806984.png">
