### PR TITLE
Enhancement: Reduce the amount of whitespace between the label and value

### DIFF
--- a/src/components/KeyValue/PKeyValue.vue
+++ b/src/components/KeyValue/PKeyValue.vue
@@ -58,7 +58,7 @@
   text-sm
   flex
   flex-col
-  gap-y-2
+  gap-y-1
   leading-6
 }
 


### PR DESCRIPTION
# Description
The primary format for `PKeyValue` uses `gap-y-2` between the label and value. But `gap-2` is also the standard format for general content (`PContent` for example). Which means if you have a list of `PKeyValue` there's an equal amount of space between a label and its value as well as a label and the previous value which makes for a very unclear UI. We need to reduce the gap used.

# Previous
<img width="269" alt="image" src="https://user-images.githubusercontent.com/6200442/175661543-227b718d-b11d-452b-b390-59c8b45ad9e8.png">

# New
<img width="177" alt="image" src="https://user-images.githubusercontent.com/6200442/175661825-5739e4fc-ae2e-474c-8163-e1b3d021bcc8.png">

