### PR TITLE
Feature: removed default implementation for p-form footer

### DIFF
--- a/src/components/Form/PForm.vue
+++ b/src/components/Form/PForm.vue
@@ -26,7 +26,6 @@
   }>()
 
   const emits = defineEmits<{
-    (event: 'cancel'): void,
     (event: 'submit', value: Event): void,
   }>()
 


### PR DESCRIPTION
removed default implementation of form footer with "cancel" and "submit" buttons

if developer wants to have actions in footer, they can provide them as such
```html
      <template #footer="{ disabled, loading }">
        <PButton inset>
          Cancel
        </PButton>
        <PButton type="submit" :disabled="disabled" :loading="loading">
          Submit
        </PButton>
      </template>
```