### PR TITLE
BugFix: PKeyValue overflows parent when containing long words

### DIFF
--- a/demo/sections/KeyValueSection.vue
+++ b/demo/sections/KeyValueSection.vue
@@ -44,6 +44,13 @@
       </p-key-value>
 
 
+      <p-key-value label="Super Long Word">
+        <template #value>
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit. Impedit aspernatur error someSuperLongWordInTheMiddleOfAnOtherWiseNormalSentenceThatShouldWrapWhenItCannotFitOnScreenAnymoreButItHasToBeReallyLongToEnsureThatItAlwaysHasToOverlapPleaseDontTryMakingYourBrowserSoLargeThatThisFitsAllInOneLineBecauseITriedReallyHardNotToMakeThatPossibleAndItWillHurtMyFeelingsIfItIsPossible ipsa ullam dolore incidunt, rerum consequuntur dicta facilis excepturi eius maxime quis autem tempora expedita perspiciatis rem obcaecati. Atque.
+        </template>
+      </p-key-value>
+
+
       <p-divider />
 
       <p-key-value label="Leader" value="Leonardo" />

--- a/src/components/KeyValue/PKeyValue.vue
+++ b/src/components/KeyValue/PKeyValue.vue
@@ -68,6 +68,10 @@
   cursor-default
 }
 
+.p-key-value__value {
+  overflow-wrap: anywhere;
+}
+
 .p-key-value__empty {
   @apply
   text-slate-400


### PR DESCRIPTION
# Description

## Before
<img width="946" alt="image" src="https://user-images.githubusercontent.com/6200442/176553165-b01f0f9d-69a8-44da-a515-db6c9c43e19b.png">

## After
<img width="943" alt="image" src="https://user-images.githubusercontent.com/6200442/176553113-7ff7977a-8092-4605-8608-37bacaf455dc.png">
