### PR TITLE
BugFix: p-link icon absolute

### DIFF
--- a/src/components/IconText/PIconText.vue
+++ b/src/components/IconText/PIconText.vue
@@ -21,7 +21,7 @@
 <style>
 .p-text { @apply
   flex
-  items-center
+  items-start
   gap-1
 }
 


### PR DESCRIPTION
the issue: 
because `p-link` displays an icon with `align-super`, it ends up expanding the height of the element displaying the link. 
this ends up throwing off the centering of things like `p-icon-text`, which tries to align the icon at the start with the text. 

p-link not using position-absolute:
<img width="598" alt="image" src="https://user-images.githubusercontent.com/6098901/177342733-a90a3aad-1664-4779-8d18-5daced10d950.png">

fixed:
<img width="577" alt="image" src="https://user-images.githubusercontent.com/6098901/177341994-6e42aff0-1b44-4011-9c71-90e3d66ab531.png">
