### PR TITLE
BugFix: using additional keys & input blur to submit tags

### DIFF
--- a/src/components/TagsArea/PTagsArea.vue
+++ b/src/components/TagsArea/PTagsArea.vue
@@ -16,7 +16,14 @@
         <slot :name="name" v-bind="data" />
       </template>
       <template #control="{ attrs }">
-        <input v-model="newTag" type="text" class="p-tags-area__input" v-bind="attrs" @keydown="handleKeydown">
+        <input
+          v-model="newTag"
+          type="text"
+          class="p-tags-area__input"
+          v-bind="attrs"
+          @keydown="handleKeydown"
+          @blur="handleBlur"
+        >
       </template>
     </PBaseInput>
   </div>
@@ -35,7 +42,7 @@
 <script lang="ts" setup>
   import PBaseInput from '@/components/BaseInput/PBaseInput.vue'
   import PTag from '@/components/Tag/PTag.vue'
-  import { keys } from '@/types'
+  import { Key, keys } from '@/types/keyEvent'
 
   const props = defineProps<{
     tags: string[] | null | undefined,
@@ -63,9 +70,16 @@
   }
 
   function handleKeydown(event: KeyboardEvent): void {
-    if (event.key === keys.enter) {
+    const submitKeys: Key[] = [keys.enter, keys.comma, keys.space]
+
+    if (submitKeys.includes(event.key as Key)) {
       submitNewTag()
+      event.preventDefault()
     }
+  }
+
+  function handleBlur(): void {
+    submitNewTag()
   }
 
   function validateNewTag(tag: string | null): tag is string  {

--- a/src/types/keyEvent.ts
+++ b/src/types/keyEvent.ts
@@ -131,6 +131,7 @@ export const keys = {
   'closeBracket': ']',
   'singleQuote': '\'',
 } as const
+export type Key = typeof keys[keyof typeof keys]
 
 export const alphaKeys = [
   keys.a,


### PR DESCRIPTION
previously only `enter` key would submit tag, and it didn't prevent default behavior. This means that if the p-tags-area was inside of a form, you couldn't add tags without also attempting to submit the form. 

I fixed that, and added `keys.space` and `keys.comma` to list of keycodes that will attempt to submit new tag

I also added @blur event to input element that also will try to submit new tags if the user leaves the field with a value in the input.