### PR TITLE
BugFix: conditionally add footer div only when slot.footer is provided

### DIFF
--- a/src/components/Form/PForm.vue
+++ b/src/components/Form/PForm.vue
@@ -10,9 +10,11 @@
       </div>
     </template>
     <slot />
-    <div class="p-form__footer">
-      <slot name="footer" />
-    </div>
+    <template v-if="slots.footer">
+      <div class="p-form__footer">
+        <slot name="footer" />
+      </div>
+    </template>
   </form>
 </template>
 


### PR DESCRIPTION
issue: because p-form always renders a div for `p-form__footer`, and it has `row-gap: 1.5rem` we end up with a big gap below content always.

solution: only render `p-form__footer` when `slots.footer` is truthy

<img width="560" alt="image" src="https://user-images.githubusercontent.com/6098901/177440250-6608a033-0110-4bb9-8b94-493554e45bbc.png">
