### PR TITLE
BugFix: Fix PTagsArea v-model reactivity & Fix model prop

### DIFF
--- a/demo/sections/FormsSection.vue
+++ b/demo/sections/FormsSection.vue
@@ -107,11 +107,11 @@
       </p-label>
 
       <p-label label="Tags Input" :message="JSON.stringify(exampleTagsValue)" :state="exampleState">
-        <PTagsInput v-model:tags="exampleTagsValue" :disabled="disabled" :state="exampleState" />
+        <PTagsInput v-model="exampleTagsValue" :disabled="disabled" :state="exampleState" />
       </p-label>
 
       <p-label label="Tags Area" :message="JSON.stringify(exampleTagsValue)" :state="exampleState">
-        <PTagsArea v-model:tags="exampleTagsValue" :disabled="disabled" :state="exampleState" />
+        <PTagsArea v-model="exampleTagsValue" :disabled="disabled" :state="exampleState" />
       </p-label>
 
       <p-label label="Validation State">

--- a/src/components/TagsArea/PTagsArea.vue
+++ b/src/components/TagsArea/PTagsArea.vue
@@ -45,19 +45,19 @@
   import { Key, keys } from '@/types/keyEvent'
 
   const props = defineProps<{
-    tags: string[] | null | undefined,
+    modelValue: string[] | null | undefined,
   }>()
 
   const emits = defineEmits<{
-    (event: 'update:tags', value: string[]): void,
+    (event: 'update:modelValue', value: string[]): void,
   }>()
 
   const internalValue = computed({
     get() {
-      return props.tags ?? []
+      return props.modelValue ?? []
     },
     set(value: string[]) {
-      emits('update:tags', value)
+      emits('update:modelValue', value)
     },
   })
 

--- a/src/components/TagsInput/PTagsInput.vue
+++ b/src/components/TagsInput/PTagsInput.vue
@@ -19,22 +19,22 @@
   import PCombobox from '@/components/Combobox/PCombobox.vue'
 
   const props = withDefaults(defineProps<{
-    tags: string[] | null | undefined,
+    modelValue: string[] | null | undefined,
     placeholder?: string,
   }>(), {
     placeholder: 'Add Tag',
   })
 
   const emits = defineEmits<{
-    (event: 'update:tags', value: string[]): void,
+    (event: 'update:modelValue', value: string[]): void,
   }>()
 
   const internalValue = computed({
     get() {
-      return props.tags ?? []
+      return props.modelValue ?? []
     },
     set(value: string[]) {
-      emits('update:tags', value)
+      emits('update:modelValue', value)
     },
   })
 </script>


### PR DESCRIPTION
# Description
`PTagsArea` wouldn't v-model correctly if `null` or `undefined` were used. Also `PTagsArea` and `PTagsInput` used a named v-model which non of the other input components. do. 