### PR TITLE
BugFix: exposing base-input slots through p-select

### DIFF
--- a/src/components/Select/PSelect.vue
+++ b/src/components/Select/PSelect.vue
@@ -20,6 +20,9 @@
           :options="selectOptions"
           @click="toggleSelect"
         >
+          <template v-for="(index, name) in $slots" #[name]="data">
+            <slot :name="name" v-bind="data" />
+          </template>
           <template #default="scope">
             <slot v-bind="scope" :is-open="isOpen" :open="openSelect" :close="closeSelect" />
           </template>


### PR DESCRIPTION
base-input has many slots like `prepend` and `append`, which are only accessible through higher level components like `p-select` if they pass the slots through.