### PR TITLE
BugFix: fixed console error from p-select-options when all options are disabled

### DIFF
--- a/src/components/Select/PSelectOptions.vue
+++ b/src/components/Select/PSelectOptions.vue
@@ -104,7 +104,6 @@
 
     if (props.options[props.highlightedIndex].disabled) {
       const newIndex = indexValue.value + difference
-      console.log(newIndex)
       if (newIndex > 0 && newIndex < props.options.length) {
         indexValue.value += difference
       }


### PR DESCRIPTION
when all options are disabled in p-select, attempts to skip over disabled option end up putting selected index out of valid range, which results in console errors. This fixes that