### PR TITLE
Chore: death to defineComponent

### DIFF
--- a/.vscode/vue.code-snippets
+++ b/.vscode/vue.code-snippets
@@ -71,13 +71,11 @@
         "prefix": "script",
         "body": [
             "<script lang=\"ts\">",
-            "import { defineComponent } from 'vue';",
-            "",
-            "export default defineComponent({",
+            "export default {",
             "  name: '$1',",
             "  expose: [],",
             "  $2",
-            "});",
+            "};",
             "</script>"
         ],
         "description": "Create <script> block"

--- a/src/components/BaseInput/PBaseInput.vue
+++ b/src/components/BaseInput/PBaseInput.vue
@@ -19,16 +19,15 @@
 </template>
 
 <script lang="ts">
-  import { defineComponent, computed, ref } from 'vue'
-
-  export default defineComponent({
+  export default {
     name: 'BaseInput',
     expose: [],
     inheritAttrs: false,
-  })
+  }
 </script>
 
 <script lang="ts" setup>
+  import { computed, ref } from 'vue'
   import PIcon from '@/components/Icon/PIcon.vue'
   import { useAttrsStylesClassesAndListeners } from '@/compositions/attributes'
   import { State } from '@/types/state'

--- a/src/components/Checkbox/PCheckbox.vue
+++ b/src/components/Checkbox/PCheckbox.vue
@@ -20,16 +20,15 @@
 </template>
 
 <script lang="ts">
-  import { defineComponent, computed } from 'vue'
-
-  export default defineComponent({
+  export default {
     name: 'PCheckbox',
     expose: [],
     inheritAttrs: false,
-  })
+  }
 </script>
 
 <script lang="ts" setup>
+  import { computed } from 'vue'
   import { CheckboxModel } from '@/types/checkbox'
   import { State } from '@/types/state'
 

--- a/src/components/Code/PCode.vue
+++ b/src/components/Code/PCode.vue
@@ -6,12 +6,10 @@
 </template>
 
 <script lang="ts">
-  import { defineComponent } from 'vue'
-
-  export default defineComponent({
+  export default {
     name: 'PCode',
     expose: [],
-  })
+  }
 </script>
 
 <script lang="ts" setup>

--- a/src/components/Modal/PModal.vue
+++ b/src/components/Modal/PModal.vue
@@ -59,17 +59,16 @@
 </template>
 
 <script lang="ts">
-  import { TransitionChild, TransitionRoot } from '@headlessui/vue'
-  import { defineComponent, computed, useSlots, watchEffect } from 'vue'
-
-  export default defineComponent({
+  export default {
     name: 'PModal',
     expose: [],
     inheritAttrs: false,
-  })
+  }
 </script>
 
 <script setup lang="ts">
+  import { TransitionChild, TransitionRoot } from '@headlessui/vue'
+  import { computed, useSlots, watchEffect } from 'vue'
   import { Icon } from '@/types/icon'
 
   const props = defineProps<{

--- a/src/components/PopOver/PPopOver.vue
+++ b/src/components/PopOver/PPopOver.vue
@@ -10,16 +10,15 @@
 </template>
 
 <script lang="ts">
-  import { defineComponent, withDefaults, ref, watch, computed, useAttrs, onMounted, onUnmounted } from 'vue'
-
-  export default defineComponent({
+  export default {
     name: 'PPopOver',
     expose: [],
     inheritAttrs: false,
-  })
+  }
 </script>
 
 <script lang="ts" setup>
+  import { withDefaults, ref, watch, computed, useAttrs, onMounted, onUnmounted } from 'vue'
   import { useMostVisiblePositionStyles } from '@/compositions/position'
   import { PositionMethod } from '@/types/position'
   import { left, right, bottom, top } from '@/utilities/position'

--- a/src/components/TagsArea/PTagsArea.vue
+++ b/src/components/TagsArea/PTagsArea.vue
@@ -30,16 +30,15 @@
 </template>
 
 <script lang="ts">
-  import { defineComponent, computed, ref } from 'vue'
-
-  export default defineComponent({
+  export default {
     name: 'PTagsArea',
     expose: [],
     inheritAttrs: false,
-  })
+  }
 </script>
 
 <script lang="ts" setup>
+  import { computed, ref } from 'vue'
   import PBaseInput from '@/components/BaseInput/PBaseInput.vue'
   import PTag from '@/components/Tag/PTag.vue'
   import { Key, keys } from '@/types/keyEvent'


### PR DESCRIPTION
we've gotten into the habit of using

```ts
export default {
   //defineComponent options here
}
```

instead of

```ts
import {defineComponent} from 'vue'

export default defineComponent({
    //defineComponent options here
})
```

since it works the same way, and this way doesn't require that imports for `vue` (and any imports that alphabetically come before) have to be in the inheritAttrs script block