### PR TITLE
BugFix: Remove breaking import of router-link

### DIFF
--- a/src/components/Link/PLink.vue
+++ b/src/components/Link/PLink.vue
@@ -20,7 +20,7 @@
 
 <script lang="ts" setup>
   import { computed } from 'vue'
-  import { RouterLink, RouteLocationRaw } from 'vue-router'
+  import { RouteLocationRaw } from 'vue-router'
   import PIcon from '@/components/Icon/PIcon.vue'
 
   const props = defineProps<{


### PR DESCRIPTION
When router-link is imported directly into the p-link component, pages in orion-ui that use a p-link and I get the following error
<img width="1437" alt="image (1)" src="https://user-images.githubusercontent.com/40272060/179544516-3a77ab87-e391-40e4-afa4-adbc0d5bd7fc.png">

Removing the import fixes it for me.