### PR TITLE
Bugfix: Flow name is not clickable in radar

### DIFF
--- a/src/layouts/PLayoutFull/PLayoutFull.vue
+++ b/src/layouts/PLayoutFull/PLayoutFull.vue
@@ -20,5 +20,6 @@
   top-8
   left-8
   right-8
+  z-10
 }
 </style>


### PR DESCRIPTION
This PR fixes a bug when the flow name is not clickable in the radar

Closes https://github.com/PrefectHQ/orion/issues/2222