### PR TITLE
Enhancement: Toast message design clarity

### DIFF
--- a/src/components/Toast/PToast.vue
+++ b/src/components/Toast/PToast.vue
@@ -85,7 +85,7 @@
   max-w-sm
   w-full
   bg-slate-700
-  text-slate-100
+  text-slate-50
   shadow-lg
   rounded-lg
   pointer-events-auto
@@ -115,7 +115,7 @@
 
 .p-toast__message { @apply
   text-sm
-  text-slate-300
+  text-slate-100
 }
 
 .p-toast__close { @apply


### PR DESCRIPTION
This PR inverts the default background and font colors for the `PToast` component. This provides more visual clarity against other components and backgrounds, which default to a very light gray:

Before:

https://user-images.githubusercontent.com/27291717/180060296-23397b6c-61c4-4c6b-bf9c-a4935386e2bf.mov

After:

https://user-images.githubusercontent.com/27291717/180060295-d4420284-1b25-460b-92ad-63f05b52fd28.mov





