### PR TITLE
BugFix: PLink external icon position

### DIFF
--- a/src/components/Link/PLink.vue
+++ b/src/components/Link/PLink.vue
@@ -46,7 +46,7 @@
 .p-link__external-icon { @apply
   inline
   relative
-  -top-2
+  -top-[0.4em]
   w-3
   h-3
 }


### PR DESCRIPTION
# Description
PLink was using `-top-2` which transforms into `-0.5rem` which causes issues when the font size of the link is larger or smaller than 1rem. Converting this to use em's so its positioned in relation to the link's font size and I also bumped it down to -0.4.

## Before
<img width="489" alt="image" src="https://user-images.githubusercontent.com/6200442/180307589-ae212d33-3775-4373-b81c-77fbdb7345c4.png">

## After
<img width="496" alt="image" src="https://user-images.githubusercontent.com/6200442/180307529-d7e49f40-e035-4809-b034-c949a035386a.png">

Closes #300 
