### PR TITLE
Enhancement: Fix unknown option typing; pass empty styles to slot

### DIFF
--- a/src/components/Combobox/PCombobox.vue
+++ b/src/components/Combobox/PCombobox.vue
@@ -129,7 +129,7 @@
     return options
   })
 
-  const filteredSelectOptions = computed(() => selectOptions.value.filter(option => optionStartsWith(option, typedValue.value)))
+  const filteredSelectOptions = computed(() => selectOptionsWithUnknown.value.filter(option => optionStartsWith(option, typedValue.value)))
   function filterOptions(option: SelectOption): boolean {
     return filteredSelectOptions.value.includes(option)
   }


### PR DESCRIPTION
This PR fixes an issue with unknown option typing for PCombobox and inverts the empty state class inheritance so slot consumers receive sensible default styling.


References: https://github.com/PrefectHQ/orion-design/pull/390#discussion_r928989992