### PR TITLE
BugFix: missing divide border when menu-item is an anchor tag

### DIFF
--- a/src/components/OverflowMenu/POverflowMenu.vue
+++ b/src/components/OverflowMenu/POverflowMenu.vue
@@ -12,6 +12,7 @@
   shadow-lg
   bg-white
   border-2
+  border-gray-200
   divide-y-2
   divide-gray-100
 }


### PR DESCRIPTION
<img width="229" alt="Screen Shot 2022-07-25 at 12 26 16 PM" src="https://user-images.githubusercontent.com/6098901/180839053-d9fc360d-0005-4488-b10f-58d9e7b0239a.png">

<img width="232" alt="image" src="https://user-images.githubusercontent.com/6098901/180839038-a7c76f8f-ef62-4d37-93d6-6ab817a6d865.png">