### PR TITLE
Feature: PContextNavItem - Highlight the nav item when active and not just when exact

### DIFF
--- a/src/components/ContextNavItem/PContextNavItem.vue
+++ b/src/components/ContextNavItem/PContextNavItem.vue
@@ -1,6 +1,6 @@
 <template>
   <router-link
-    exact-active-class="p-context-nav-item--active"
+    active-class="p-context-nav-item--active"
     class="p-context-nav-item"
     :to="to"
   >


### PR DESCRIPTION
# Description
Currently nav items only get highlighted when they match the exact route. This PR changes that so it is highlighted when it matches any part of the route. That way when you're viewing a child route its still highlighted. 

## Before
<img width="1070" alt="image" src="https://user-images.githubusercontent.com/6200442/181306362-e9572858-7677-4f7d-ba64-9fa227d705ce.png">

## After
<img width="1083" alt="image" src="https://user-images.githubusercontent.com/6200442/181306307-44f7caf9-7827-466d-8f07-9edd651a9882.png">
