### PR TITLE
Enhancement: Improve control over modal dimensions

### DIFF
--- a/demo/sections/ModalsSection.vue
+++ b/demo/sections/ModalsSection.vue
@@ -4,10 +4,20 @@
       Open Modal
     </p-button>
 
-    <p-modal v-model:showModal="showModal" title="Modal Title" icon="CakeIcon">
+    <p-modal
+      v-model:showModal="showModal"
+      class="modals-section__modal-1"
+      :style="styles.modal1"
+      title="Modal Title"
+      icon="CakeIcon"
+    >
       <p class="text-sm text-gray-500">
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque in aliquam erat. Proin elit dui, tristique non consequat at, gravida ac lectus
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque in aliquam erat. Proin elit dui, tristique non
+        consequat at, gravida ac lectus
       </p>
+
+      <p-select v-model="selectedHeight" :options="heightOptions" />
+      <p-select v-model="selectedWidth" :options="widthOptions" />
 
       <template #actions>
         <p-button @click="showModal = false">
@@ -19,8 +29,30 @@
 </template>
 
 <script setup lang="ts">
-  import { ref } from 'vue'
+  import { computed, ref } from 'vue'
   import Section from '../components/Section.vue'
 
   const showModal = ref(false)
+
+  const widthOptions = ['min-content', '16rem', '32rem', '50%', '100%', '100vw']
+  const heightOptions = ['min-content', '32rem', '500px', '100vh']
+
+  const selectedWidth = ref('min-content')
+  const selectedHeight = ref('min-content')
+
+  const styles = computed(() => {
+    return {
+      modal1: {
+        height: selectedHeight.value,
+        width: selectedWidth.value,
+      },
+    }
+  })
 </script>
+
+<style>
+.modals-section__modal-1 {
+  max-height: calc(100vh - 2rem);
+  max-width: calc(100vh - 2rem);
+}
+</style>

--- a/src/components/Modal/PModal.vue
+++ b/src/components/Modal/PModal.vue
@@ -1,6 +1,6 @@
 <template>
   <teleport to="body">
-    <TransitionRoot as="div" :show="showModal" v-bind="$attrs">
+    <TransitionRoot as="div" :show="showModal">
       <div
         ref="modalRoot"
         class="p-modal"
@@ -31,7 +31,7 @@
             leave-from="opacity-100 translate-y-0 sm:scale-100"
             leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
           >
-            <div class="p-modal__card">
+            <div class="p-modal__card" v-bind="$attrs">
               <div class="p-modal__header" :class="classes">
                 <div class="p-modal__tile-icon-group">
                   <slot name="icon" :close="closeModal">
@@ -167,13 +167,14 @@
 
 .p-modal__card { @apply
   relative
-  inline-block
+  inline-flex
+  flex-col
   bg-white
   rounded-lg
   shadow-xl
   transition-all
-  sm:max-w-lg
-  sm:w-full
+  w-full
+  sm:w-[32rem]
 }
 
 .p-modal__header { @apply
@@ -204,6 +205,7 @@
   flex-col
   gap-3
   p-5
+  grow
   sm:py-6
   sm:gap-4
 }


### PR DESCRIPTION
This PR changes the way modals inherit attrs by passing attrs directly to the modal card instead of to the transition background. It also removes the max-width on the modal card in favor of a sensible default that can be easily overridden. 