### PR TITLE
Enhancement: Persist toasts on hover

### DIFF
--- a/src/components/Toast/PToast.vue
+++ b/src/components/Toast/PToast.vue
@@ -1,5 +1,11 @@
 <template>
-  <div class="p-toast__card" @mouseenter="stopTimeout" @mouseleave="startTimeout">
+  <div
+    class="p-toast__card"
+    @mouseenter="stopTimeout"
+    @mouseleave="startTimeout"
+    @focusin.capture="stopTimeout"
+    @focusout.capture="startTimeout"
+  >
     <div class="p-toast__card-container">
       <div class="p-toast__info">
         <p-icon :icon="icon" aria-hidden="true" class="p-toast__icon" :class="color" />


### PR DESCRIPTION
This PR adds mouse/focus enter and mouse/focus leave event handlers to the `PToast` component that persist the component while a user has their cursor over it.