### PR TITLE
Enhancement: Toasts exit stage left

### DIFF
--- a/src/components/Toast/ToastContainer.vue
+++ b/src/components/Toast/ToastContainer.vue
@@ -70,19 +70,20 @@
 
   @apply
   opacity-100
-  translate-y-0
+  translate-x-0
 }
 
 .toast-leave-active ~ .p-toast-container__toast { @apply
-  translate-y-0
+  translate-x-0
   transition-transform
   duration-700
 }
 
 .toast-leave-to { @apply
   opacity-0
-  translate-y-full
+  translate-x-full
 }
+
 .toast-leave-to ~ .p-toast-container__toast { @apply
   translate-y-full
 }


### PR DESCRIPTION
This PR shifts the exit animation toward the right of the screen instead of the bottom of the screen for a more natural dismissal relative to other toasts. Previously they were exiting from the same direction they entered, meaning they would exit behind or in front of other toasts.

Entrance behavior is untouched.