### PR TITLE
BugFix: removed implicit use of current time on selected date

### DIFF
--- a/demo/sections/FormsSection.vue
+++ b/demo/sections/FormsSection.vue
@@ -83,7 +83,13 @@
       </p-label>
 
       <p-label label="Native Date Input" :message="JSON.stringify(exampleDate)" :state="exampleState">
-        <p-native-date-input v-model="exampleDate" :disabled="disabled" :state="exampleState" />
+        <p-native-date-input
+          v-model="exampleDate"
+          :min="minDate"
+          :max="maxDate"
+          :disabled="disabled"
+          :state="exampleState"
+        />
       </p-label>
 
       <p-label label="Hybrid Date Input" :message="JSON.stringify(exampleDate)" :state="exampleState">
@@ -180,7 +186,7 @@
   const exampleCombobox = ref('Space-X')
   const exampleCombobox2 = ref([])
   const exampleMultiSelect = ref<string[]>([])
-  const exampleDate = ref<Date | null>(new Date())
+  const exampleDate = ref<Date | null>()
   const minDate = ref<Date | null>(null)
   const maxDate = ref<Date | null>(null)
 

--- a/src/components/DatePicker/PDatePicker.vue
+++ b/src/components/DatePicker/PDatePicker.vue
@@ -190,7 +190,7 @@
   }
 
   function updateSelectedDate(date: Date): void {
-    selectedDate.value = set(selectedDate.value ?? new Date(), {
+    selectedDate.value = set(selectedDate.value ?? startOfDay(new Date()), {
       year: date.getFullYear(),
       month: date.getMonth(),
       date: date.getDate(),


### PR DESCRIPTION
closes #331 

p-date-picker defaulted model value to `new Date()`, which includes time even though from the users perspective they are dealing with dates without time.

before: 
https://user-images.githubusercontent.com/6098901/183987334-fdca13f3-d1bb-48bd-a888-c13139f59e9a.mov

after: 
https://user-images.githubusercontent.com/6098901/183987349-0ed41c3e-7a7a-4e6d-99b6-3d10f89a282d.mov


