### PR TITLE
Chore: fixed console warnings of prop types

### DIFF
--- a/src/components/ButtonGroup/PButtonGroup.vue
+++ b/src/components/ButtonGroup/PButtonGroup.vue
@@ -21,9 +21,10 @@
 
   const props = withDefaults(defineProps<{
     options: ButtonGroupOption[],
-    modelValue: string | number | null | undefined,
+    modelValue?: string | number | null,
     size?: Size,
   }>(), {
+    modelValue: undefined,
     size: 'md',
   })
 

--- a/src/components/DateInput/PDateButton.vue
+++ b/src/components/DateInput/PDateButton.vue
@@ -30,7 +30,7 @@
   import PBaseInput from '@/components/BaseInput/PBaseInput.vue'
 
   const props = defineProps<{
-    date: Date | null | undefined,
+    date?: Date | null,
   }>()
 
   const buttonElement = ref<HTMLButtonElement>()

--- a/src/components/DateInput/PDateInput.vue
+++ b/src/components/DateInput/PDateInput.vue
@@ -70,12 +70,12 @@
   import { bottomRight, topRight, bottomLeft, topLeft } from '@/utilities/position'
 
   const props = defineProps<{
-    modelValue: Date | null | undefined,
+    modelValue?: Date | null,
     showTime?: boolean,
     clearable?: boolean,
     disabled?: boolean,
-    min?: Date | null | undefined,
-    max?: Date | null | undefined,
+    min?: Date | null,
+    max?: Date | null,
   }>()
 
   const emits = defineEmits<{

--- a/src/components/DatePicker/PDatePicker.vue
+++ b/src/components/DatePicker/PDatePicker.vue
@@ -102,11 +102,11 @@
   type Overlay = 'year' | 'month' | 'time' | null
 
   const props = defineProps<{
-    modelValue: Date | null | undefined,
+    modelValue?: Date | null,
     showTime?: boolean,
     clearable?: boolean,
-    min?: Date | null | undefined,
-    max?: Date | null | undefined,
+    min?: Date | null,
+    max?: Date | null,
   }>()
 
   const emits = defineEmits<{

--- a/src/components/DatePicker/PMonthPicker.vue
+++ b/src/components/DatePicker/PMonthPicker.vue
@@ -25,9 +25,9 @@
   import { isDateAfter, isDateBefore, keepDateInRange } from '@/utilities/dates'
 
   const props = defineProps<{
-    modelValue: Date | null | undefined,
-    min?: Date | null | undefined,
-    max?: Date | null | undefined,
+    modelValue?: Date | null,
+    min?: Date | null,
+    max?: Date | null,
   }>()
 
   const emits = defineEmits<{

--- a/src/components/DatePicker/PTimePicker.vue
+++ b/src/components/DatePicker/PTimePicker.vue
@@ -35,9 +35,9 @@
   import { isDateAfter, isDateBefore, isDateInRange, keepDateInRange } from '@/utilities/dates'
 
   const props = defineProps<{
-    modelValue: Date | null | undefined,
-    min?: Date | null | undefined,
-    max?: Date | null | undefined,
+    modelValue?: Date | null,
+    min?: Date | null,
+    max?: Date | null,
   }>()
 
   const emits = defineEmits<{

--- a/src/components/DatePicker/PYearPicker.vue
+++ b/src/components/DatePicker/PYearPicker.vue
@@ -23,9 +23,9 @@
   import { isDateInRange, keepDateInRange } from '@/utilities/dates'
 
   const props = defineProps<{
-    modelValue: Date | null | undefined,
-    min?: Date | null | undefined,
-    max?: Date | null | undefined,
+    modelValue?: Date | null,
+    min?: Date | null,
+    max?: Date | null,
   }>()
 
   const emits = defineEmits<{

--- a/src/components/DatePicker/ScrollingPicker.vue
+++ b/src/components/DatePicker/ScrollingPicker.vue
@@ -22,7 +22,7 @@
   import { isSelectOption, SelectModelValue, SelectOption } from '@/types/selectOption'
 
   const props = defineProps<{
-    modelValue: string | number | null | undefined,
+    modelValue?: string | number | null,
     options: (string | number | SelectOption)[],
     preventFocus?: boolean,
   }>()

--- a/src/components/NativeDateInput/PNativeDateInput.vue
+++ b/src/components/NativeDateInput/PNativeDateInput.vue
@@ -39,7 +39,7 @@
   import PIcon from '@/components/Icon/PIcon.vue'
 
   const props = defineProps<{
-    modelValue: Date | null | undefined,
+    modelValue?: Date | null,
     min?: Date | null,
     max?: Date | null,
   }>()

--- a/src/components/NumberInput/PNumberInput.vue
+++ b/src/components/NumberInput/PNumberInput.vue
@@ -22,7 +22,7 @@
   import { keys } from '@/types/keyEvent'
 
   const props = defineProps<{
-    modelValue: number | null | undefined,
+    modelValue?: number | null,
   }>()
 
   const emits = defineEmits<{

--- a/src/components/TagsArea/PTagsArea.vue
+++ b/src/components/TagsArea/PTagsArea.vue
@@ -46,7 +46,7 @@
   import { keys } from '@/types/keyEvent'
 
   const props = defineProps<{
-    modelValue: string[] | null | undefined,
+    modelValue?: string[] | null,
   }>()
 
   const emits = defineEmits<{

--- a/src/components/TagsInput/PTagsInput.vue
+++ b/src/components/TagsInput/PTagsInput.vue
@@ -19,9 +19,10 @@
   import PCombobox from '@/components/Combobox/PCombobox.vue'
 
   const props = withDefaults(defineProps<{
-    modelValue: string[] | null | undefined,
+    modelValue?: string[] | null,
     placeholder?: string,
   }>(), {
+    modelValue: undefined,
     placeholder: 'Add tag',
   })
 

--- a/src/components/TextInput/PTextInput.vue
+++ b/src/components/TextInput/PTextInput.vue
@@ -14,7 +14,7 @@
   import PBaseInput from '@/components/BaseInput/PBaseInput.vue'
 
   const props = defineProps<{
-    modelValue: string | null | undefined,
+    modelValue?: string | null,
   }>()
 
   const emits = defineEmits<{

--- a/src/components/Textarea/PTextarea.vue
+++ b/src/components/Textarea/PTextarea.vue
@@ -14,7 +14,7 @@
   import PBaseInput from '@/components/BaseInput/PBaseInput.vue'
 
   const props = defineProps<{
-    modelValue: string | null | undefined,
+    modelValue?: string | null,
   }>()
 
   const emits = defineEmits<{

--- a/src/utilities/dates.ts
+++ b/src/utilities/dates.ts
@@ -3,8 +3,8 @@ import { useAdjustedDate } from '@/compositions/useAdjustedDate'
 import { secondsToApproximateString } from '@/utilities/seconds'
 
 export type DateRange = {
-  min?: Date | null | undefined,
-  max?: Date | null | undefined,
+  min?: Date | null,
+  max?: Date | null,
 }
 export type Precision = 'minute' | 'hour' | 'day' | 'month' | 'year'
 


### PR DESCRIPTION
from a typescript perspective `modalValue: T | null | undefined` === `modalValue?: T | null`
vue's defineProp perspective must be different, because the former results in a bunch of console warnings

<img width="1477" alt="Screen Shot 2022-08-26 at 7 51 41 AM" src="https://user-images.githubusercontent.com/6098901/186909949-17761634-12b9-474c-b587-3eddcee97e22.png">

