### PR TITLE
Enhancement: reposition checkmark in select dropdown to 

### DIFF
--- a/src/components/SelectOption/PSelectOption.vue
+++ b/src/components/SelectOption/PSelectOption.vue
@@ -9,7 +9,6 @@
   </span>
 </template>
 
-
 <script lang="ts" setup>
   import { computed } from 'vue'
   import PCheckbox from '@/components/Checkbox/PCheckbox.vue'


### PR DESCRIPTION
This PR repositions checkmark in the select dropdown to be on the right side of the label to avoid odd alignment

<img width="221" alt="Screen Shot 2022-08-31 at 10 47 20 AM" src="https://user-images.githubusercontent.com/40467112/187708259-67ca23bd-a48c-4a70-a83e-69ad7597b180.png">
<img width="212" alt="Screen Shot 2022-08-31 at 10 47 33 AM" src="https://user-images.githubusercontent.com/40467112/187708261-d05589da-1669-4627-a781-c9658782e328.png">


Closes https://github.com/PrefectHQ/prefect/issues/6257