### PR TITLE
Feature: PKeyValue - Support empty objects

### DIFF
--- a/src/components/KeyValue/PKeyValue.vue
+++ b/src/components/KeyValue/PKeyValue.vue
@@ -30,6 +30,14 @@
   }>()
 
   const isDefined = (val: unknown): boolean => {
+    if (typeof val === 'object' && val !== null) {
+      if (Array.isArray(val)) {
+        return val.length > 0
+      }
+
+      return Object.keys(val).length > 0
+    }
+
     return typeof val !== 'undefined' && val !== null && val !== ''
   }
 


### PR DESCRIPTION
# Description
Adds support for `[]` and `{}` in PKeyValue so if an empty array or object is given for the value the `None` label will be displayed. 