### PR TITLE
Feature: exposing wizard methods at p-wizard

### DIFF
--- a/src/components/Wizard/PWizard.vue
+++ b/src/components/Wizard/PWizard.vue
@@ -58,7 +58,33 @@
     (event: 'cancel' | 'next' | 'previous' | 'submit'): void,
   }>()
 
-  const { steps, currentStepIndex, loading, next, previous } = useWizard(props.steps)
+  const {
+    steps,
+    currentStepIndex,
+    currentStep,
+    loading,
+    next,
+    previous,
+    goto,
+    getStepIndex,
+    getStep,
+    setStep,
+    isValid,
+  } = useWizard(props.steps)
+
+  defineExpose({
+    steps,
+    currentStepIndex,
+    currentStep,
+    loading,
+    next,
+    previous,
+    goto,
+    getStepIndex,
+    getStep,
+    setStep,
+    isValid,
+  })
 
   const isOnFirstStep = computed(() => currentStepIndex.value === 0)
   const isOnLastStep = computed(() => currentStepIndex.value === steps.value.length -1)


### PR DESCRIPTION
pages like the new org create can now add a template ref to `p-wizard` that gives them access to do things like `wizard.value.goto(2)`, which would attempt to start the wizard on step 2 assuming step 1 passes validation