### PR TITLE
BugFix: PKeyValue considering all dates empty values

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -1,0 +1,45 @@
+{
+  "name": "@prefecthq/prefect-design-docs",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@prefecthq/prefect-design-docs",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/prismjs": "^1.26.0",
+        "prismjs": "^1.29.0"
+      }
+    },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.0.tgz",
+      "integrity": "sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ==",
+      "dev": true
+    },
+    "node_modules/prismjs": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
+      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  },
+  "dependencies": {
+    "@types/prismjs": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.0.tgz",
+      "integrity": "sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ==",
+      "dev": true
+    },
+    "prismjs": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
+      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "dev": true
+    }
+  }
+}

--- a/demo/sections/components/KeyValue.vue
+++ b/demo/sections/components/KeyValue.vue
@@ -6,6 +6,7 @@
       { title: 'Using Slots' },
       { title: 'Empty Value' },
       { title: 'Empty Value Slot' },
+      { title: 'Dates' },
     ]"
   >
     <template #description>
@@ -42,6 +43,10 @@
         </template>
       </p-key-value>
     </template>
+
+    <template #dates>
+      <p-key-value label="Displays a date" :value="dateValue" :alternate="alternate" />
+    </template>
   </ComponentPage>
 </template>
 
@@ -50,6 +55,7 @@
   import ComponentPage from '@/demo/components/ComponentPage.vue'
 
   const alternate = ref(true)
+  const dateValue = new Date()
 </script>
 
 <style>

--- a/src/components/KeyValue/PKeyValue.vue
+++ b/src/components/KeyValue/PKeyValue.vue
@@ -19,6 +19,7 @@
 </template>
 
 <script lang="ts" setup>
+  import { isDate, isValid } from 'date-fns'
   import { computed, useSlots } from 'vue'
 
   const slots = useSlots()
@@ -31,6 +32,10 @@
 
   const isDefined = (val: unknown): boolean => {
     if (typeof val === 'object' && val !== null) {
+      if (isDate(val)) {
+        return isValid(val)
+      }
+
       if (Array.isArray(val)) {
         return val.length > 0
       }


### PR DESCRIPTION
# Description
The `isDefined` logic in PKeyValue ensured that all dates were considered empty values. Used date-fns `isDate` and `isValid` to make sure dates show up