### PR TITLE
Chore: removes sass from vs code recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
   "recommendations": [
     "vue.volar",
     "dbaeumer.vscode-eslint",
-    "syler.sass-indented",
     "bradlc.vscode-tailwindcss"
   ]
 }


### PR DESCRIPTION
Removes sass from vs code recommended extensions