### PR TITLE
Feature: Add security headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,88 @@
   from = "/*"
   to = "/index.html"
   status = 200
+
+[[headers]]
+  # Define which paths this specific [[headers]] block will cover.
+  for = "/*"
+
+  [headers.values]
+    # X-Content-Type-Options controls whether browsers attempt to detect
+    # the content type, rather than relyihng on the Content-Type header.
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options
+    X-Content-Type-Options = "nosniff"
+
+    # Strict-Transport-Security to require HTTPS connections in supported
+    # browsers. These settings are required to be eligible for inclusion
+    # in the HSTS Preload list; see: https://hstspreload.org/
+    Strict-Transport-Security = """\
+      max-age=63072000; \
+      includeSubDomains; \
+      preload \
+      """
+
+    # Content-Security-Policy to prevent XSS attacks.
+    Content-Security-Policy = """\
+      default-src 'none'; \
+      base-uri 'none'; \
+      child-src 'none'; \
+      connect-src 'none'; \
+      font-src 'self'; \
+      form-action 'none'; \
+      frame-ancestors 'none'; \
+      frame-src 'none'; \
+      img-src 'self' data:; \
+      manifest-src 'none'; \
+      media-src 'none'; \
+      object-src 'none'; \
+      prefetch-src 'none'; \
+      script-src 'self' 'unsafe-eval'; \
+      script-src-elem 'self'; \
+      style-src 'self' 'unsafe-inline'; \
+      worker-src 'none'; \
+      """
+
+    # Referrer-Policy controls the Referer header in requests.
+    #
+    # same-origin allows analytics tools to understand user journeys.
+    Referrer-Policy = "same-origin"
+
+    # X-Permitted-Cross-Domain-Policies controls whether this site can be
+    # embedded into Flash applications or PDF documents.
+    X-Permitted-Cross-Domain-Policies = "none"
+
+    # Permissions-Policy controls the features that the site can request.
+    #
+    # https://developer.chrome.com/en/docs/privacy-sandbox/permissions-policy/
+    # https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md
+    Permissions-Policy = """\
+      accelerometer=(), \
+      ambient-light-sensor=(), \
+      autoplay=(), \
+      battery=(), \
+      camera=(), \
+      cross-origin-isolated=(), \
+      display-capture=(), \
+      document-domain=(), \
+      encrypted-media=(), \
+      execution-while-not-rendered=(), \
+      execution-while-out-of-viewport=(), \
+      fullscreen=(), \
+      geolocation=(), \
+      gyroscope=(), \
+      hid=(), \
+      idle-detection=(), \
+      magnetometer=(), \
+      microphone=(), \
+      midi=(), \
+      navigation-override=(), \
+      payment=(), \
+      picture-in-picture=(), \
+      publickey-credentials-get=(), \
+      screen-wake-lock=(), \
+      serial=(), \
+      sync-xhr=(), \
+      usb=(), \
+      web-share=(), \
+      xr-spatial-tracking=() \
+      """


### PR DESCRIPTION
I used April King's Laboratory browser extension to create this. I enabled the plugin, clicked through all the different pages (or at least the majority of them) and manually adjusted the policies to add some more explicit restrictive rules.

These headers provide protection against cross-site scripting and other types of attacks, and does not really matter for this static design site, since it does not host any valuable content. However, the headers are good hygiene and make it easier to ensure an appropriate policy for nebula-ui, which includes prefect-design as a dependency, since the CSP of the main site is necessarily a union of all policies of the dependent sites that it includes (e.g. if prefect-design requires granting specific permissions to a given site, then nebula-ui likely also needs to grant the same permissions)

Validation tools:

* https://csp-evaluator.withgoogle.com/?csp=https://deploy-preview-421--prefect-design.netlify.app/
* https://observatory.mozilla.org/analyze/deploy-preview-421--prefect-design.netlify.app?third-party=false
* https://securityheaders.com/?q=deploy-preview-421--prefect-design.netlify.app&followRedirects=on
* https://hstspreload.org/?domain=deploy-preview-421--prefect-design.netlify.app