### PR TITLE
BugFix: Remove CSP directives with less than 95% support

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -23,8 +23,39 @@
       """
 
     # Content-Security-Policy to prevent XSS attacks.
+    #
+    # default-src
+    #   'self' - all resources from current origin are permitted by default
+    # base-uri
+    #   'none' - no external resources are allowed
+    # child-src
+    #   'none' - no external resources are allowed
+    # connect-src
+    #   'none' - no external resources are allowed
+    # font-src
+    #   'self' - all fonts are embedded with FontSource
+    # form-action
+    #   'none' - no forms submissions allowed
+    # frame-ancestors
+    #   'none' - no external sites are permitted to embed this
+    # frame-src
+    #  'none' - no external resources are allowed
+    # img-src
+    #   'self' - all images from current origin are permitted
+    #   data: - images embedded inline are permitted
+    # media-src
+    #   'none' - no audio or video files are permitted
+    # object-src
+    #   'none' - no legacy objects are allowed; see
+    #            https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/object-src
+    # script-src
+    #   'self' - all resources from current origin are permitted
+    #   (we cannot use script-src-elem because it has worse browser support)
+    # style-src
+    #   'unsafe-inline' - Tailwind styles are injected inline
+    #   (we cannot use script-src-elem because it has worse browser support)
     Content-Security-Policy = """\
-      default-src 'none'; \
+      default-src 'self'; \
       base-uri 'none'; \
       child-src 'none'; \
       connect-src 'none'; \
@@ -33,14 +64,10 @@
       frame-ancestors 'none'; \
       frame-src 'none'; \
       img-src 'self' data:; \
-      manifest-src 'none'; \
       media-src 'none'; \
       object-src 'none'; \
-      prefetch-src 'none'; \
       script-src 'self' 'unsafe-eval'; \
-      script-src-elem 'self'; \
-      style-src 'self' 'unsafe-inline'; \
-      worker-src 'none'; \
+      style-src 'self' 'unsafe-inline' \
       """
 
     # Referrer-Policy controls the Referer header in requests.


### PR DESCRIPTION
WebKit has an error when there are Content-Security-Policy directives that it does not understand, rather than ignoring them.

Therefore, we remove any directives with less than 95% compatibility indicated on Can I Use.

--

Verified that this works on a 2020-era iPad Pro (12.9) via Browserstack

![image](https://user-images.githubusercontent.com/52710/193726367-b3b54c7c-8c85-455a-a61f-df8a3211072a.png)
