### PR TITLE
make links underline on hover

### DIFF
--- a/src/components/Link/PLink.vue
+++ b/src/components/Link/PLink.vue
@@ -41,6 +41,7 @@
   font-semibold
   cursor-pointer
   whitespace-nowrap
+  hover:underline
 }
 
 .p-link__external-icon { @apply


### PR DESCRIPTION
This PR makes links display an underline on hover. This provides extra feedback that the link is interactive and distinguishes clickable text when seen close by other link text.

<img width="178" alt="Screen Shot 2022-10-12 at 4 25 56 PM" src="https://user-images.githubusercontent.com/6776415/195450988-3388d6a6-6a7d-4897-94a0-aa9f8ef775ff.png">
