### PR TITLE
BugFix: moved cursor-hover off of p-tabs and onto individual p-tab components

### DIFF
--- a/src/components/Tab/PTab.vue
+++ b/src/components/Tab/PTab.vue
@@ -27,6 +27,7 @@
   text-sm
   flex
   items-center
+  cursor-pointer
 }
 
 .p-tab__active { @apply

--- a/src/components/Tabs/PTabs.vue
+++ b/src/components/Tabs/PTabs.vue
@@ -134,7 +134,6 @@
   flex
   items-center
   -mb-px
-  cursor-pointer;
 }
 
 .p-tabs__content {


### PR DESCRIPTION
`cursor-pointer` was applied to group of p-tabs, which meant you had a pointer even when there was no button below

before:

https://user-images.githubusercontent.com/6098901/196187787-ba786d11-1124-407f-bc86-2d21feb487ac.mov

after: 

https://user-images.githubusercontent.com/6098901/196187813-b1536e3c-4bda-4723-a902-469ecba94416.mov

