### PR TITLE
Feature: PComboBox search using `includes` rather than `startsWith`

### DIFF
--- a/src/components/Combobox/PCombobox.vue
+++ b/src/components/Combobox/PCombobox.vue
@@ -57,7 +57,7 @@
   import PButton from '@/components/Button/PButton.vue'
   import PSelect from '@/components/Select/PSelect.vue'
   import { keys } from '@/types/keyEvent'
-  import { isSelectOption, optionStartsWith, SelectModelValue, SelectOption } from '@/types/selectOption'
+  import { isSelectOption, optionIncludes, SelectModelValue, SelectOption } from '@/types/selectOption'
 
   const props = withDefaults(defineProps<{
     modelValue: string | number | boolean | null | SelectModelValue[] | undefined,
@@ -127,7 +127,8 @@
     return options
   })
 
-  const filteredSelectOptions = computed(() => selectOptionsWithUnknown.value.filter(option => optionStartsWith(option, typedValue.value)))
+  const filteredSelectOptions = computed(() => selectOptionsWithUnknown.value.filter(option => optionIncludes(option, typedValue.value)))
+
   function filterOptions(option: SelectOption): boolean {
     return filteredSelectOptions.value.includes(option)
   }

--- a/src/components/TypeAhead/PTypeAhead.vue
+++ b/src/components/TypeAhead/PTypeAhead.vue
@@ -56,7 +56,7 @@
   import PTextInput from '@/components/TextInput/PTextInput.vue'
   import { useAttrsStylesAndClasses } from '@/compositions/attributes'
   import { isAlphaNumeric, keys } from '@/types/keyEvent'
-  import { SelectOption, isSelectOption, optionStartsWith, SelectModelValue } from '@/types/selectOption'
+  import { SelectOption, isSelectOption, optionIncludes, SelectModelValue } from '@/types/selectOption'
   import { topLeft, bottomLeft, bottomRight, topRight } from '@/utilities/position'
 
   const props = defineProps<{
@@ -99,7 +99,7 @@
     })
   })
 
-  const filteredSelectOptions = computed(() => selectOptions.value.filter(option => optionStartsWith(option, internalValue.value)))
+  const filteredSelectOptions = computed(() => selectOptions.value.filter(option => optionIncludes(option, internalValue.value)))
 
   const classes = computed(() => ({
     control: {

--- a/src/types/selectOption.ts
+++ b/src/types/selectOption.ts
@@ -10,10 +10,10 @@ export function isSelectOption(input: string | number | boolean | SelectOption):
   return typeof input === 'object'
 }
 
-export function optionStartsWith(option: SelectOption, target: string | null): boolean {
+export function optionIncludes(option: SelectOption, target: string | null): boolean {
   if (typeof target !== 'string') {
     return true
   }
 
-  return option.label.toLowerCase().startsWith(target.toLowerCase())
+  return option.label.toLowerCase().includes(target.toLowerCase())
 }


### PR DESCRIPTION
# Description
Currently PComboBox uses `string.prototype.startsWith`. Changing this to `string.prototype.includes` produces a much better user experience. 