### PR TITLE
BugFix: Global sidebar to wide when page has scrollbars

### DIFF
--- a/src/components/GlobalSidebar/PGlobalSidebar.vue
+++ b/src/components/GlobalSidebar/PGlobalSidebar.vue
@@ -11,13 +11,11 @@
 </template>
 
 <style>
-.p-global-sidebar {
-  @apply
+.p-global-sidebar { @apply
   bg-slate-800
   sticky
   top-0
   h-16
-  w-screen
   flex
   flex-row
   items-center
@@ -30,8 +28,7 @@
   lg:py-5
 }
 
-.p-global-sidebar__nav-links {
-  @apply
+.p-global-sidebar__nav-links { @apply
   flex
   items-center
   gap-4


### PR DESCRIPTION
# Description
PGlobalSidebar has `w-screen` which is `width: 100vw`. This causes issues when there is a scrollbar because that is not subtracted from the viewport. Removing that and letting the sidebar size itself naturally fixes that issue. 

## Before
<img width="1059" alt="image" src="https://user-images.githubusercontent.com/6200442/196798669-d3e3ad4e-2942-4f4c-8a27-32ffdc8180bf.png">

## After
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/6200442/196798718-07d3543a-c3ee-4564-a7ed-549044ac28b9.png">
