### PR TITLE
Enhancement: Allow PLink to wrap by default

### DIFF
--- a/src/components/Link/PLink.vue
+++ b/src/components/Link/PLink.vue
@@ -40,7 +40,6 @@
   text-primary
   font-semibold
   cursor-pointer
-  whitespace-nowrap
   hover:underline
 }
 


### PR DESCRIPTION
# Description
PLink has `whitespace: nowrap` added by default to try and help keep the external link icon together with the text. However that mean that no link could wrap which causes issues with response UI. Removing that in favor of letting links wrap by default even if that means occasionally the external link icon will wrap on its own. 