### PR TITLE
BugFix: application of gap between virtual scroller items

### DIFF
--- a/src/components/VirtualScroller/PVirtualScrollerChunk.vue
+++ b/src/components/VirtualScroller/PVirtualScrollerChunk.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="el" class="virtual-scroller-chunk" :style="styles">
+  <div ref="el" class="p-virtual-scroller-chunk" :style="styles">
     <template v-if="visible">
       <slot />
     </template>


### PR DESCRIPTION
this style 

```css
  .p-virtual-scroller-chunk > *,
  .p-virtual-scroller-chunk:nth-last-child(2) > *:not(:last-child) {
    margin-bottom: var(--virtual-scroller-item-gap)
  }
```

wasn't being applied because when I renamed `VirtualScrollerChunk` to `PVirtualScrollerChunk`, I forgot to update bem class accordingly