### PR TITLE
BugFix: when setting a time, remove seconds and milliseconds

### DIFF
--- a/src/components/DatePicker/PTimePicker.vue
+++ b/src/components/DatePicker/PTimePicker.vue
@@ -69,7 +69,7 @@
       return parseInt(format(selectedDate.value, 'mm'))
     },
     set(value: SelectModelValue) {
-      selectedDate.value = applyMinutes(selectedDate.value, parseInt(value))
+      selectedDate.value = applyMinutes(selectedDate.value, value as number)
     },
   })
 


### PR DESCRIPTION
when using p-time-picker, only `hour`, `minute` (and `meridian`) are editable. Since `show-time` assumes `new Date()` as starting value, you always end up with seconds and milliseconds on your date value that you can never change. 

This PR makes it so that if you explicitly set a date, seconds and milliseconds are set to `0`