### PR TITLE
BugFix: narrow any incoming value to be without seconds and milliseconds

### DIFF
--- a/src/components/DatePicker/PTimePicker.vue
+++ b/src/components/DatePicker/PTimePicker.vue
@@ -51,7 +51,9 @@
       return props.modelValue ?? startOfMinute(new Date())
     },
     set(value: Date) {
-      emits('update:modelValue', keepDateInRange(value, range.value))
+      const withoutSeconds = startOfMinute(value)
+
+      emits('update:modelValue', keepDateInRange(withoutSeconds, range.value))
     },
   })
 


### PR DESCRIPTION
I thought we could just add `startOfMinute` to default value, but when parent component passes in value, we still want to make sure date gets narrowed to exclude seconds/milliseconds on any time change