### PR TITLE
BugFix: PRadio breaks multi word labels onto separate lines

### DIFF
--- a/demo/sections/components/RadioGroup.vue
+++ b/demo/sections/components/RadioGroup.vue
@@ -45,7 +45,7 @@
 
   const value = ref(null)
   const slotValue = ref(null)
-  const options = ['first', 'second', 'third']
+  const options = ['first option', 'second option', 'third option']
 </script>
 
 <style>

--- a/src/components/Radio/PRadio.vue
+++ b/src/components/Radio/PRadio.vue
@@ -78,7 +78,6 @@
   flex
   flex-row
   items-center
-  w-min
   gap-2
 }
 


### PR DESCRIPTION
# Description
Because of `w-min` (`width: min-content`) if a radio's label is multiple words it gets broken into multiple lines. Removing `w-min` doesn't appear to have any negative side effects (label is still correctly sized). 

## Before
<img width="406" alt="image" src="https://user-images.githubusercontent.com/6200442/200931932-0ddcae63-60eb-4cdf-a3ae-b68aaf29014b.png">

## After
<img width="315" alt="image" src="https://user-images.githubusercontent.com/6200442/200932318-85e22839-cc89-4eba-8619-0497d0e8487b.png">
