### PR TITLE
Bug Fix: fix p-tabs p-select to only display selected tab

### DIFF
--- a/src/components/Tabs/PTabs.vue
+++ b/src/components/Tabs/PTabs.vue
@@ -28,15 +28,7 @@
         v-model="selectedTab"
         :options="options"
         name="tabs"
-      >
-        <option
-          v-for="tab in innerTabs"
-          :key="kebabCase(tab.label)"
-          :selected="selectedTab === tab.label"
-        >
-          {{ tab.label }}
-        </option>
-      </PSelect>
+      />
     </div>
     <template v-for="tab in innerTabs" :key="tab">
       <section


### PR DESCRIPTION
I'm not really sure what the block of code I deleted was trying to do, but it was causing the names of every tab to appear in the p-select rather than just the currently selected one.

## Before:
<img width="459" alt="Screen Shot 2022-11-10 at 10 49 13 AM" src="https://user-images.githubusercontent.com/11204953/201157367-2c74c24a-2754-4599-8244-ec391c9e4958.png">

## After:
<img width="460" alt="Screen Shot 2022-11-10 at 10 49 30 AM" src="https://user-images.githubusercontent.com/11204953/201157776-e63e9f42-23d3-4aa9-b8e2-00cf1d8e49da.png">
