### PR TITLE
Enhancement: lessens p-layout padding on small screens

### DIFF
--- a/src/components/GlobalSidebar/PGlobalSidebar.vue
+++ b/src/components/GlobalSidebar/PGlobalSidebar.vue
@@ -20,8 +20,9 @@
   flex-row
   items-center
   justify-between
-  px-5
   z-10
+  px-4
+  lg:px-5
   lg:h-screen
   lg:w-16
   lg:flex-col

--- a/src/layouts/PLayoutDefault/PLayoutDefault.vue
+++ b/src/layouts/PLayoutDefault/PLayoutDefault.vue
@@ -12,7 +12,7 @@
 <style>
 .p-layout-default {
   @apply
-  p-3
+  p-4
   lg:p-8
   grid
   grid-rows-[max-content_max-content]

--- a/src/layouts/PLayoutWell/PLayoutWell.vue
+++ b/src/layouts/PLayoutWell/PLayoutWell.vue
@@ -15,7 +15,7 @@
 <style>
 .p-layout-well {
   @apply
-  p-3
+  p-4
   lg:p-8
   grid
   grid-cols-[1fr_1fr_250px]


### PR DESCRIPTION
Lessens the padding on `p-layout-default` and `p-layout-well` for mobile/small screens, as part of the overall mobile revamp outlined in this design doc: https://www.figma.com/file/oaTFiG9hrhPaS5rUjVOj0G/Mobile-Details-Page-Updates?node-id=0%3A1

## Before
![Screen Shot 2022-11-10 at 4 13 45 PM](https://user-images.githubusercontent.com/11204953/201218374-30ced104-1d5a-40e0-b70a-2fac57392949.png)

## After
![Screen Shot 2022-11-10 at 4 14 03 PM](https://user-images.githubusercontent.com/11204953/201218383-e50c372a-c335-4c62-84b1-7ef34667dda0.png)

## Before
![Screen Shot 2022-11-10 at 3 56 32 PM](https://user-images.githubusercontent.com/11204953/201218420-1982cff7-10b2-4a52-8b10-7668f621e4ad.png)

## After
![Screen Shot 2022-11-10 at 3 56 45 PM](https://user-images.githubusercontent.com/11204953/201218429-43b1f2fe-f79d-4e80-beab-b880b5584cf3.png)
