### PR TITLE
Enhancement: set p-breadcrumbs to wrap and break words by default

### DIFF
--- a/src/components/BreadCrumbs/PBreadCrumbs.vue
+++ b/src/components/BreadCrumbs/PBreadCrumbs.vue
@@ -32,16 +32,15 @@
 <style>
 .p-bread-crumbs { @apply
   flex
-  flex-nowrap
+  flex-wrap
   font-bold
   text-xl
   text-slate-700
 }
 
 .p-bread-crumbs__crumb { @apply
-  whitespace-nowrap
   overflow-hidden
-  text-ellipsis
+  break-words;
 }
 
 .p-bread-crumbs__crumb:not(:first-child) { @apply


### PR DESCRIPTION
This change lets breadcrumbs flex-wrap to new lines, and allows whitespace breaking as well as work-breaking for a better mobile user experience.

![image](https://user-images.githubusercontent.com/11204953/201762416-ef729a4e-aa24-45fd-b13e-03fcfa90892b.png)
![image](https://user-images.githubusercontent.com/11204953/201762466-cdbd3b7a-db77-40b6-943d-4be49dcccded.png)
![image](https://user-images.githubusercontent.com/11204953/201762664-7910cfb4-56da-4e61-80ea-b899458480fb.png)
![image](https://user-images.githubusercontent.com/11204953/201762715-ef98016d-ba21-4661-a970-7d3b6e656e6b.png)
