### PR TITLE
BugFix: PLink injection error

### DIFF
--- a/src/components/Link/PLink.vue
+++ b/src/components/Link/PLink.vue
@@ -9,7 +9,7 @@
 
 <script lang="ts" setup>
   import { computed } from 'vue'
-  import { RouteLocationRaw, RouterLink } from 'vue-router'
+  import { RouteLocationRaw } from 'vue-router'
   import PIcon from '@/components/Icon/PIcon.vue'
   import { isRouteExternal } from '@/utilities/router'
 
@@ -18,7 +18,7 @@
   }>()
 
   const isExternal = computed(() => !!props.to && isRouteExternal(props.to))
-  const component = computed(() => !props.to || isExternal.value ? 'a' : RouterLink)
+  const component = computed(() => !props.to || isExternal.value ? 'a' : 'router-link')
   const componentProps = computed(() => {
     if (!props.to) {
       return {}


### PR DESCRIPTION
# Description
Since 1.1.30 PLink hasn't played nicely with projects. Tracked this down to [this change](https://github.com/PrefectHQ/prefect-design/commit/8ffff1e68198a3b538be7b1e4478eded7ec697b7). Trial and error showed that something about using `RouterLink` with `<component :is"">` was producing the error. Referencing the globally installed router link rather than importing it solves the problem though I'm not sure why. 

<img width="1475" alt="image" src="https://user-images.githubusercontent.com/6200442/202041454-ede52eab-219a-41e6-8f13-063728b5d2d2.png">
