### PR TITLE
add secondary danger button style

### DIFF
--- a/demo/sections/components/Buttons.vue
+++ b/demo/sections/components/Buttons.vue
@@ -37,6 +37,10 @@
         <p-button danger>
           danger
         </p-button>
+
+        <p-button secondary danger>
+          secondary danger
+        </p-button>
       </div>
     </template>
 
@@ -61,6 +65,10 @@
         <p-button danger icon="BeakerIcon">
           icon with text
         </p-button>
+
+        <p-button secondary danger icon="BeakerIcon">
+          icon with text
+        </p-button>
       </div>
     </template>
 
@@ -71,6 +79,7 @@
         <p-button inset icon="BeakerIcon" />
         <p-button flat icon="BeakerIcon" />
         <p-button danger icon="BeakerIcon" />
+        <p-button secondary danger icon="BeakerIcon" />
       </div>
     </template>
 
@@ -81,6 +90,7 @@
         <p-button inset rounded icon="BeakerIcon" />
         <p-button flat rounded icon="BeakerIcon" />
         <p-button danger rounded icon="BeakerIcon" />
+        <p-button secondary danger rounded icon="BeakerIcon" />
       </div>
     </template>
 
@@ -125,6 +135,7 @@
         <p-button disabled inset icon="BeakerIcon" />
         <p-button disabled flat icon="BeakerIcon" />
         <p-button disabled danger icon="BeakerIcon" />
+        <p-button secondary disabled danger icon="BeakerIcon" />
       </div>
     </template>
 

--- a/src/components/Button/PButton.vue
+++ b/src/components/Button/PButton.vue
@@ -28,7 +28,7 @@
   import { Size } from '@/types/size'
   import { isRouteExternal } from '@/utilities/router'
 
-  type ButtonClass = 'primary' | 'secondary' | 'inset' | 'flat' | 'danger'
+  type ButtonClass = 'primary' | 'secondary' | 'inset' | 'flat' | 'danger' | 'danger-secondary'
 
   const props = defineProps({
     secondary: Boolean,
@@ -93,6 +93,7 @@
     'p-button--inset': buttonClass.value === 'inset',
     'p-button--flat': buttonClass.value === 'flat',
     'p-button--danger': buttonClass.value === 'danger',
+    'p-button--danger--secondary': buttonClass.value === 'danger-secondary',
     'p-button--rounded': props.rounded,
     'p-button--equal-padding': props.icon && !slots.default,
     'p-button-xs': props.size === 'xs',
@@ -105,6 +106,10 @@
   }))
 
   const buttonClass = computed<ButtonClass>(() => {
+    if (props.danger && props.secondary) {
+      return 'danger-secondary'
+    }
+
     if (props.danger) {
       return 'danger'
     }
@@ -162,7 +167,7 @@
 .p-button--secondary { @apply
   text-prefect-600
   bg-prefect-100
-  focus:ring-prefect-100
+  focus:ring-prefect-600
 }
 .p-button--secondary:not(.p-button--disabled) { @apply
   hover:bg-prefect-200
@@ -201,6 +206,14 @@
 }
 .p-button--danger:not(.p-button--disabled) { @apply
   hover:bg-red-700
+}
+.p-button--danger--secondary { @apply
+  text-red-700
+  bg-red-100
+  focus:ring-red-600
+}
+.p-button--danger--secondary:not(.p-button--disabled) { @apply
+  hover:bg-red-200
 }
 
 .p-button-xs { @apply


### PR DESCRIPTION
Adds secondary danger button styling when a button has both modifiers (`<PButton secondary danger />`).

<img width="1042" alt="Screenshot 2022-11-18 at 4 35 53 PM" src="https://user-images.githubusercontent.com/6776415/202807005-a96d49e5-a854-42f4-bbd9-c08e968cc499.png">

Also increases the contrast on the secondary focus ring.

<img width="268" alt="image" src="https://user-images.githubusercontent.com/6776415/202807074-e3e1ef10-93ea-4a60-a911-909cf6863cc8.png">
