### PR TITLE
Feature: updated styling on copy button of p-terminal

### DIFF
--- a/src/components/Terminal/PTerminal.vue
+++ b/src/components/Terminal/PTerminal.vue
@@ -2,7 +2,8 @@
   <PWindow class="p-terminal">
     <template #actions>
       <PButton size="xs" inset class="p-terminal__copy-button" @click="copy">
-        Copy
+        <span class="p-terminal__copy-text">Copy</span>
+        <p-icon icon="DuplicateIcon" />
       </PButton>
     </template>
 
@@ -32,6 +33,10 @@
 .p-terminal__copy-button { @apply
   opacity-50
   hover:opacity-100
+}
+
+.p-terminal__copy-text { @apply
+  font-medium
 }
 
 .p-terminal__code { @apply


### PR DESCRIPTION
I noticed that on other copy buttons, we use the duplicate icon

pictured here is the `CodeSnippet` component from orion-design
<img width="482" alt="image" src="https://user-images.githubusercontent.com/6098901/205943337-90cf1794-0f19-4b8a-8d65-71b07d065d92.png">

this pr adds the same icon and similar styling to the copy button on `p-terminal`

before
<img width="491" alt="Screen Shot 2022-12-06 at 8 41 53 AM" src="https://user-images.githubusercontent.com/6098901/205943521-cedcd52f-a12d-4947-88c1-a2a2e78ac9e9.png">

after
<img width="688" alt="Screen Shot 2022-12-06 at 8 45 19 AM" src="https://user-images.githubusercontent.com/6098901/205943546-2436e975-d606-4f85-9c50-73985f2b7459.png">

