### PR TITLE
Bugfix: PContextSidebar z-index

### DIFF
--- a/src/components/ContextSidebar/PContextSidebar.vue
+++ b/src/components/ContextSidebar/PContextSidebar.vue
@@ -27,11 +27,14 @@
   bottom-0
   lg:bottom-auto
   w-screen
-  z-10
   flex
   flex-col
   lg:h-screen
   lg:w-64
+}
+
+.p-context-sidebar {
+  z-index: var(--p-context-sidebar-z-index, 20)
 }
 
 .p-context-sidebar__header,


### PR DESCRIPTION
This PR makes the context sidebar z-index configurable and increases the default from 10 => 20. This should fix some issues where other components with absolutely-positioned elements were incorrectly rendering on top of the context sidebar because they shared the same z-index value.