### PR TITLE
Chore: Replace release commands with version command

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,7 @@
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "changelog": "auto-changelog --package --commit-limit 0",
-    "changelog:commit": "npm run changelog && git add -A && git commit -m 'Update CHANGELOG.md'",
-    "release:patch": "npm version patch && npm run changelog:commit",
-    "release:minor": "npm version minor && npm run changelog:commit",
-    "release:major": "npm version major && npm run changelog:commit'"
+    "version": "npm run changelog && git add CHANGELOG.md"
   },
   "main": "./dist/prefect-design.umd.js",
   "module": "./dist/prefect-design.mjs",


### PR DESCRIPTION
# Description
Following change in orion-design to use the version command