### PR TITLE
Enhancement: Adjust padding for empty state on mobile screens 

### DIFF
--- a/src/components/EmptyState/PEmptyState.vue
+++ b/src/components/EmptyState/PEmptyState.vue
@@ -44,7 +44,9 @@
 
 .p-empty-state__text { @apply
   text-center
-  p-16
+  p-4
+  md:p-10
+  lg:p-16
 }
 
 .p-empty-state__icon { @apply


### PR DESCRIPTION
old:

<img width="370" alt="image" src="https://user-images.githubusercontent.com/40272060/206780984-0063fa7e-5bc3-4bf6-a761-6c093ac66b60.png">

updated:

<img width="369" alt="image" src="https://user-images.githubusercontent.com/40272060/206781056-68e652ae-3101-4eb7-b427-6ec75c5fd646.png">
