### PR TITLE
Feature: p-select `filterOptions` prop now supporting Promise<boolean>

### DIFF
--- a/src/components/Select/PSelect.vue
+++ b/src/components/Select/PSelect.vue
@@ -80,7 +80,7 @@
     modelValue: string | number | boolean | null | SelectModelValue[] | undefined,
     disabled?: boolean,
     options: (string | number | boolean | SelectOption)[],
-    filterOptions?: (option: SelectOption) => boolean,
+    filterOptions?: (option: SelectOption) => boolean | Promise<boolean>,
   }>()
 
   const emits = defineEmits<{
@@ -118,7 +118,7 @@
   })
 
   const filteredSelectOptions = computed(() => {
-    return selectOptions.value.filter(option => !props.filterOptions || props.filterOptions(option))
+    return selectOptions.value.filter(async option => !props.filterOptions || await props.filterOptions(option))
   })
 
   const classes = computed(() => ({


### PR DESCRIPTION
this should allow us to have a p-select with filterOptions that has an async action. For example..

```html
<p-select v-model="selected" options="accounts" filter-options="hasPermisson" />
```

```ts
async function hasPermission(option: SelectOption): Promise<boolean> {
 return await meApi.hasAccountPermission(option.value, 'delete:account')
}
```