### PR TITLE
BugFix: fixed bug in p-button using to prop

### DIFF
--- a/src/components/Button/PButton.vue
+++ b/src/components/Button/PButton.vue
@@ -21,7 +21,7 @@
 
 <script lang="ts" setup>
   import { computed, useSlots, PropType, ref } from 'vue'
-  import { RouteLocationRaw, RouterLink } from 'vue-router'
+  import { RouteLocationRaw } from 'vue-router'
   import PIcon from '@/components/Icon/PIcon.vue'
   import PLoadingIcon from '@/components/LoadingIcon/PLoadingIcon.vue'
   import { Icon } from '@/types/icon'
@@ -61,7 +61,7 @@
 
   const component = computed(() => {
     if (props.to) {
-      return isRouteExternal(props.to) ? 'a' : RouterLink
+      return isRouteExternal(props.to) ? 'a' : 'router-link'
     }
 
     return 'button'


### PR DESCRIPTION
at some point, I added `to` prop to p-button, but if you tried using it you would have seen errors like this
<img width="1179" alt="image" src="https://user-images.githubusercontent.com/6098901/208761865-3a14b46d-cf12-48de-bfd0-7c2545f9234f.png">


this PR fixes that error by using the [same approach as p-link](https://github.com/PrefectHQ/prefect-design/blob/main/src/components/Link/PLink.vue#L21)