### PR TITLE
Feature: add option to set and observe viewingDate from p-date-picker

### DIFF
--- a/src/components/DateInput/PDateInput.vue
+++ b/src/components/DateInput/PDateInput.vue
@@ -29,6 +29,7 @@
 
     <PDatePicker
       v-model="internalModelValue"
+      v-model:viewingDate="internalViewingDate"
       class="p-date-input__date-picker"
       :show-time="showTime"
       :clearable="clearable"
@@ -57,6 +58,7 @@
 
   const props = defineProps<{
     modelValue: Date | null | undefined,
+    viewingDate?: Date,
     showTime?: boolean,
     clearable?: boolean,
     disabled?: boolean,
@@ -64,8 +66,9 @@
     max?: Date | null | undefined,
   }>()
 
-  const emits = defineEmits<{
+  const emit = defineEmits<{
     (event: 'update:modelValue', value: Date | null): void,
+    (event: 'update:viewingDate', value: Date | undefined): void,
     (event: 'open' | 'close'): void,
   }>()
 
@@ -76,7 +79,16 @@
       return props.modelValue ?? null
     },
     set(value: Date | null) {
-      emits('update:modelValue', keepDateInRange(value, { min: props.min, max: props.max }))
+      emit('update:modelValue', keepDateInRange(value, { min: props.min, max: props.max }))
+    },
+  })
+
+  const internalViewingDate = computed({
+    get() {
+      return props.viewingDate
+    },
+    set(value) {
+      emit('update:viewingDate', value)
     },
   })
 
@@ -110,9 +122,9 @@
 
   function handleOpenChange(open: boolean): void {
     if (open) {
-      emits('open')
+      emit('open')
     } else {
-      emits('close')
+      emit('close')
     }
   }
 

--- a/src/components/DateRangeInput/PDateRangeInput.vue
+++ b/src/components/DateRangeInput/PDateRangeInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <PDateInput v-model="rangeValue" :clearable="clearable">
+  <PDateInput v-model="rangeValue" v-model:viewingDate="internalViewingDate" :clearable="clearable">
     <template #default="{ openPicker, isOpen, disabled }">
       <template v-if="media.hover">
         <PDateButton
@@ -63,11 +63,13 @@
   const props = defineProps<{
     startDate: Date | null | undefined,
     endDate: Date | null | undefined,
+    viewingDate?: Date,
     clearable?: boolean,
   }>()
 
-  const emits = defineEmits<{
+  const emit = defineEmits<{
     (event: 'update:startDate' | 'update:endDate', value: Date | null): void,
+    (event: 'update:viewingDate', value: Date | undefined): void,
   }>()
 
   const internalStartDate = computed({
@@ -75,7 +77,7 @@
       return props.startDate ?? null
     },
     set(value: Date | null) {
-      emits('update:startDate', value)
+      emit('update:startDate', value)
     },
   })
 
@@ -92,7 +94,7 @@
       return props.endDate ?? null
     },
     set(value: Date | null) {
-      emits('update:endDate', value)
+      emit('update:endDate', value)
     },
   })
 
@@ -130,6 +132,15 @@
 
       internalStartDate.value = value
       internalEndDate.value = null
+    },
+  })
+
+  const internalViewingDate = computed({
+    get() {
+      return props.viewingDate
+    },
+    set(value) {
+      emit('update:viewingDate', value)
     },
   })
 


### PR DESCRIPTION
add support for setting and observing viewingDate from inside of p-date-picker.

This would allow us to override what a date starts at when a p-date-input's (or p-date-range-input) calendar is opened.

This also allows us to respond to viewing date changes.

I plan to use this feature to update meta-data displayed on calendar that follows that dates are currently being viewed on the calendar

<img width="447" alt="image" src="https://user-images.githubusercontent.com/6098901/209729995-0fafe875-27f3-46c4-845d-90d6231400ef.png">

(currently only dates inside the range have meta. After this change, all dates in viewing range, including when user clicks next month for example, will fetch and display meta)