### PR TITLE
Bugfix: Move light scale up, change default

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -31,6 +31,8 @@
   --800: 217deg 33% 17%;
   /* #0f172a; */
   --900: 222deg 47% 11%;
+  /* #ffffff */
+  --white: 0deg 0% 100%;
 
 
   /* Primary default palette */
@@ -185,7 +187,7 @@
     color-scheme: light;
 
     --foreground: var(--800);
-    --background: var(--100);
+    --background: var(--white);
     --primary: var(--primary-default-500);
     --danger: var(--danger-default-500);
 
@@ -205,11 +207,11 @@
     --background-200: var(--500);
     --background-300: var(--400);
     --background-400: var(--300);
-    --background-500: var(--background);
-    --background-600: var(--50);
+    --background-500: var(--200);
+    --background-600: var(--100);
     --background-700: var(--50);
     --background-800: var(--50);
-    --background-900: var(--50);
+    --background-900: var(--background);
 
     --primary-50: var(--primary-default-50);
     --primary-100: var(--primary-default-100);


### PR DESCRIPTION
This PR fixes an issue where the light scale default background color was a slightly off-grey instead of the intended white. It also shifts the background scale a bit to make the default make sense; since there aren't any intensities greater than white I've made the background-900 the default and shifted the rest of the scale accordingly. 

**Result**

_Before_:
<img width="1127" alt="Screen Shot 2023-01-04 at 1 27 19 PM" src="https://user-images.githubusercontent.com/27291717/210624709-c1ebd9f0-e177-424f-bc3e-459db3cf3709.png">

_After_:
<img width="1127" alt="Screen Shot 2023-01-04 at 1 27 28 PM" src="https://user-images.githubusercontent.com/27291717/210624683-27e1f986-6a70-47b2-b36a-54c0d3c34e70.png">
