### PR TITLE
Enhancement: Discrete prefect palette

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -116,8 +116,20 @@
     --primary: var(--primary-default-400);
     --danger: var(--danger-default-400);
     --success: var(--success-default-400);
+    --prefect: var(--primary-default-500);
+
+    --prefect-50: var(--primary-default-50);
+    --prefect-100: var(--primary-default-100);
+    --prefect-200: var(--primary-default-200);
+    --prefect-300: var(--primary-default-300);
+    --prefect-400: var(--primary-default-400);
+    --prefect-500: var(--prefect);
+    --prefect-600: var(--primary-default-600);
+    --prefect-700: var(--primary-default-700);
+    --prefect-800: var(--primary-default-800);
+    --prefect-900: var(--primary-default-900);
   }
-  
+
   .dark {
     color-scheme: dark;
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,11 +12,9 @@ const generateColorPalette = (base) => {
 }
 
 const colors = () => {
-  const primary = generateColorPalette('primary')
-
   return {
-    prefect: primary,
-    primary: primary,
+    prefect: generateColorPalette('prefect'),
+    primary: generateColorPalette('primary'),
     danger: generateColorPalette('danger'),
     success: generateColorPalette('success'),
     foreground: generateColorPalette('foreground'),


### PR DESCRIPTION
This PR modifies the way the base `prefect` CSS palette is generated, generating it discretely instead of off the `primary` palette. This means that `--prefect` CSS variables won't change their values when global color selection takes place so no inversion is needed.

Note: we don't really use this palette directly in any components (using `primary` is preferred) but downstream consumers need a way to access the palette from which `primary` is derived