### PR TITLE
Chore: adds new slot to p-wizard between steps & footer

### DIFF
--- a/src/components/Wizard/PWizard.vue
+++ b/src/components/Wizard/PWizard.vue
@@ -9,6 +9,8 @@
     </PCard>
 
     <PCard>
+      <slot name="before-steps" />
+
       <template v-for="(step, index) in steps" :key="index">
         <div v-show="index === currentStepIndex" class="p-wizard__step">
           <PWizardStep :step="step">
@@ -16,6 +18,7 @@
           </PWizardStep>
         </div>
       </template>
+
       <slot name="after-steps" />
 
       <div class="p-wizard__footer">


### PR DESCRIPTION
adds new slot to p-wizard between steps & footer
for if you want something to appear on the wizard below each step but above the action buttons, such as a message