### PR TITLE
Enhancement: Add `multiple` prop to PSelect

### DIFF
--- a/demo/sections/components/Combobox.vue
+++ b/demo/sections/components/Combobox.vue
@@ -3,6 +3,7 @@
     title="Combobox"
     :demos="[
       { title: 'Combobox' },
+      { title: 'Multiple' },
       { title: 'Allows custom values' },
       { title: 'Grouped' },
     ]"
@@ -19,6 +20,23 @@
 
         <p-code>
           value: {{ JSON.stringify(exampleCombobox) }}
+        </p-code>
+      </div>
+    </template>
+
+    <template #multiple>
+      <div class="combobox__demo">
+        <p-combobox
+          v-model="exampleMultiple"
+          :disabled="disabled"
+          allow-deselect
+          :options="exampleOptions"
+          :state="exampleState"
+          multiple
+        />
+
+        <p-code>
+          value: {{ JSON.stringify(exampleMultiple) }}
         </p-code>
       </div>
     </template>
@@ -55,6 +73,7 @@
   const disabled = ref(false)
 
   const exampleCombobox = ref('Space-X')
+  const exampleMultiple = ref<string[] | undefined>()
   const exampleCombobox2 = ref([])
   const exampleCombobox3 = ref([])
 

--- a/demo/sections/components/Select.vue
+++ b/demo/sections/components/Select.vue
@@ -23,7 +23,7 @@
     </template>
     <template #multi-select>
       <div class="select__demo">
-        <p-select v-model="exampleMultiSelect" :disabled="disabled" :options="exampleOptions" :state="exampleState" />
+        <p-select v-model="exampleMultiSelect" :disabled="disabled" :options="exampleOptions" :state="exampleState" multiple />
 
         <p-code>
           value: {{ JSON.stringify(exampleMultiSelect) }}
@@ -52,7 +52,7 @@
   const disabled = ref(false)
 
   const exampleSelect = ref(null)
-  const exampleMultiSelect = ref<string[]>([])
+  const exampleMultiSelect = ref<string[] | undefined>(undefined)
   const exampleGroupedSelect = ref(null)
 
   const exampleOptions: SelectOption[] = [

--- a/src/components/Select/PSelect.vue
+++ b/src/components/Select/PSelect.vue
@@ -28,7 +28,7 @@
               </slot>
             </template>
 
-            <template v-else-if="isArray(modelValue)">
+            <template v-else-if="multiple">
               <PTagWrapper class="p-select-button__value" :tags="tags">
                 <template #tag="{ tag }">
                   <slot name="tag" :label="getLabel(tag)" :value="tag" :dismiss="() => unselectOptionValue(tag)">
@@ -46,7 +46,7 @@
               </PTagWrapper>
             </template>
 
-            <template v-else>
+            <template v-else-if="!Array.isArray(modelValue)">
               <slot :label="getLabel(modelValue)" :value="modelValue">
                 {{ getLabel(modelValue) }}
               </slot>
@@ -74,7 +74,8 @@
       class="p-select__options"
       :options="selectOptions"
       :style="styles.option"
-      @update:model-value="closeIfNotArray"
+      :multiple="multiple"
+      @update:model-value="closeIfNotMultiple"
       @keydown="handleKeydown"
       @mouseleave="setHighlightedValueUnselected"
     >
@@ -115,6 +116,7 @@
     disabled?: boolean,
     options: (SelectOption | SelectOptionGroup)[],
     emptyMessage?: string,
+    multiple?: boolean,
   }>()
 
   const emit = defineEmits<{
@@ -141,7 +143,9 @@
     return asArray(modelValue.value).map(option => option?.toString() ?? '')
   })
 
-  const multiple = computed(() => isArray(modelValue.value))
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  const multiple = computed(() => props.multiple || isArray(modelValue.value))
+
   const isOpen = computed(() => popOver.value?.visible ?? false)
   const showShowEmptyMessage = computed(() => {
     if (isArray(modelValue.value)) {
@@ -172,8 +176,8 @@
     }
   }
 
-  function closeIfNotArray(newValue: SelectModelValue | SelectModelValue[]): void {
-    if (Array.isArray(newValue)) {
+  function closeIfNotMultiple(newValue: SelectModelValue | SelectModelValue[]): void {
+    if (multiple.value) {
       return
     }
 

--- a/src/components/Select/PSelectOptions.vue
+++ b/src/components/Select/PSelectOptions.vue
@@ -17,6 +17,7 @@
               v-model="internalValue"
               v-model:highlightedValue="highlightedValue"
               :option="option"
+              :multiple="multiple"
             >
               <template #default="scope">
                 <slot name="option" v-bind="scope" />
@@ -48,6 +49,7 @@
     modelValue: string | number | boolean | null | SelectModelValue[] | undefined,
     options: (SelectOptionNormalized | SelectOptionGroupNormalized)[],
     highlightedValue: string | number | boolean | null | symbol,
+    multiple?: boolean,
   }>()
 
   const emit = defineEmits<{
@@ -57,6 +59,10 @@
 
   const internalValue = computed({
     get() {
+      if (props.multiple) {
+        return props.modelValue ?? []
+      }
+
       return props.modelValue ?? null
     },
     set(value) {

--- a/src/components/SelectOption/PSelectOption.vue
+++ b/src/components/SelectOption/PSelectOption.vue
@@ -30,6 +30,7 @@
     modelValue: string | number | boolean | null | SelectModelValue[],
     highlightedValue: string | number | boolean | null | symbol,
     option: SelectOptionNormalized,
+    multiple?: boolean,
   }>()
 
   const emit = defineEmits<{
@@ -52,7 +53,8 @@
     },
   })
 
-  const multiple = computed(() => Array.isArray(modelValue.value))
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  const multiple = computed(() => props.multiple || Array.isArray(modelValue.value))
 
   const selected = computed(() => {
     if (Array.isArray(modelValue.value)) {


### PR DESCRIPTION
# Description
PSelect will automatically determine if multiple values should be allowed by checking if the `modelValue` is an array. This is a nice developer convenience but by itself it means we cannot support types like `string[] | undefined` which is not uncommon. 

Adding a `multiple` prop that if set will override the default logic. Setting `multiple` to `false` does nothing and will continue to use the default logic. 

Adding this to PSelect means PCombobox also supports the `multiple` prop. 