### PR TITLE
BugFix: PSelect value unselects when clicking on selected value

### DIFF
--- a/src/components/SelectOption/PSelectOption.vue
+++ b/src/components/SelectOption/PSelectOption.vue
@@ -80,11 +80,12 @@
   }))
 
   function handleClick(): void {
-    if (selected.value) {
+    if (multiple.value && selected.value) {
       unsetValue()
-    } else {
-      setValue()
+      return
     }
+
+    setValue()
   }
 
   function handleMouseEnter(): void {


### PR DESCRIPTION
# Description
Fixes a bug where if the selected value was clicked it would set the modelValue to null. Clicking an option should only unselect if `multiple === true`. 