### PR TITLE
Enhancement: Add the full option to slot scope of PSelect and PCombobox

### DIFF
--- a/src/components/Combobox/PCombobox.vue
+++ b/src/components/Combobox/PCombobox.vue
@@ -8,8 +8,8 @@
     @open="focusOnTextInput"
     @keydown="handleComboboxKeydown"
   >
-    <template #default="{ value }">
-      <slot :value="value" :label="displayValue(value)">
+    <template #default="{ value, option }">
+      <slot :value="value" :label="displayValue(value)" :option="option">
         {{ displayValue(value) }}
       </slot>
     </template>

--- a/src/components/Select/PSelect.vue
+++ b/src/components/Select/PSelect.vue
@@ -33,7 +33,7 @@
                 <template #tag="{ tag }">
                   <slot name="tag" :label="tag.label" :value="tag" :dismiss="() => dismissTag(tag)">
                     <PTag :dismissible="isDismissible(tag)" @dismiss="dismissTag(tag)">
-                      <slot :label="tag.label" :value="tag.value">
+                      <slot :label="tag.label" :value="tag.value" :option="getSelectOption(tag.value)">
                         {{ tag.label }}
                       </slot>
                     </PTag>
@@ -47,7 +47,7 @@
             </template>
 
             <template v-else-if="!Array.isArray(modelValue)">
-              <slot :label="getLabel(modelValue)" :value="modelValue">
+              <slot :label="getLabel(modelValue)" :value="modelValue" :option="getSelectOption(modelValue)">
                 {{ getLabel(modelValue) }}
               </slot>
             </template>


### PR DESCRIPTION
# Description
`value` and `label` are passed as the slot scope in PSelect and PCombobox. But the `label` in PCombobox is the possibly modified label (with quotes if its a custom value) and the option itself isn't available. Binding the option itself means you can access the original label and any additional properties. This is useful for controls that have more complex options like 
```
{
  label: string,
  value: string,
  type: string,
  somethingElseSpecial: boolean,
}
```