### PR TITLE
update radio and checkbox input styles

### DIFF
--- a/src/components/Checkbox/PCheckbox.vue
+++ b/src/components/Checkbox/PCheckbox.vue
@@ -2,7 +2,9 @@
   <PLabel class="p-checkbox" :class="classes" :style="attrStyles">
     <template #label>
       <slot name="label">
-        {{ label }}
+        <span class="p-checkbox__label">
+          {{ label }}
+        </span>
       </slot>
     </template>
     <template #default="{ id }">
@@ -12,7 +14,7 @@
         v-model="value"
         type="checkbox"
         :disabled="disabled"
-        class="p-checkbox__control"
+        class="p-checkbox__input"
       >
     </template>
   </PLabel>
@@ -68,7 +70,7 @@
 <style>
 .p-checkbox.p-checkbox { @apply
   my-1
-  inline-flex
+  flex
   flex-row-reverse
   justify-end
   items-center
@@ -76,18 +78,19 @@
   text-foreground
 }
 
-.p-checkbox label,
-.p-checkbox input { @apply
+.p-checkbox__label,
+.p-checkbox__input { @apply
   cursor-pointer
 }
 
-.p-checkbox__control { @apply
+.p-checkbox__input { @apply
   h-4
   w-4
   rounded
   transition-colors
   ring-offset-2
   focus-within:ring-2
+  block
 
   text-primary-600
   bg-background
@@ -104,21 +107,20 @@
   scroll-margin: var(--prefect-scroll-margin);
 }
 
-.p-checkbox--failed .p-checkbox__control { @apply
+.p-checkbox--failed .p-checkbox__input { @apply
   ring-1
   ring-danger
   focus-within:ring-2
   focus-within:ring-danger
 }
 
-
-.p-checkbox--disabled label,
-.p-checkbox--disabled input { @apply
+.p-checkbox--disabled .p-radio__label,
+.p-checkbox--disabled .p-radio__input { @apply
   opacity-50
   cursor-not-allowed
 }
 
-.p-checkbox--pending .p-checkbox__control { @apply
+.p-checkbox--pending .p-checkbox__input { @apply
   ring-1
   ring-primary-300
   focus-within:ring-2

--- a/src/components/Radio/PRadio.vue
+++ b/src/components/Radio/PRadio.vue
@@ -2,7 +2,9 @@
   <PLabel class="p-radio" :class="classes" :style="styles">
     <template #label>
       <slot name="label">
-        {{ label }}
+        <span class="p-radio__label">
+          {{ label }}
+        </span>
       </slot>
     </template>
     <template #default="{ id }">
@@ -69,7 +71,7 @@
 
 <style>
 .p-radio.p-radio { @apply
-  inline-flex
+  flex
   flex-row-reverse
   justify-end
   items-center
@@ -77,8 +79,8 @@
   text-foreground
 }
 
-.p-radio label,
-.p-radio input { @apply
+.p-radio__label,
+.p-radio__control { @apply
   cursor-pointer
 }
 
@@ -88,6 +90,7 @@
   transition-colors
   ring-offset-2
   focus-within:ring-2
+  block
 
   text-primary-600
   bg-background
@@ -111,8 +114,8 @@
   focus-within:ring-danger
 }
 
-.p-radio--disabled label,
-.p-radio--disabled input { @apply
+.p-radio--disabled .p-radio__label,
+.p-radio--disabled .p-radio__input { @apply
   opacity-50
   cursor-not-allowed
 }


### PR DESCRIPTION
I needed to add `cursor-pointer` to radio inputs, but noticed they had a few issues. I ran a find-all in orion-design, orion-ui, and nebula-ui and found no instances of individual radios, only instances of `p-radio-group`, so I figured they haven't gotten some love in a while. I updated them to be more in line with `p-checkbox`.

Before:
<img width="306" alt="image" src="https://user-images.githubusercontent.com/6776415/217852018-322a05e2-707b-47ef-819d-bbf25831390b.png">

After:
<img width="321" alt="image" src="https://user-images.githubusercontent.com/6776415/217851938-2738c13d-7d4e-412f-8629-a6fed3bde14b.png">

### Update
Now both radio and checkbox have been updated to use the `PLabel` component instead of a vanilla label. 