### PR TITLE
Chore: applying styles to p-window so nested p-code-highlight looks nice

### DIFF
--- a/demo/sections/components/Window.vue
+++ b/demo/sections/components/Window.vue
@@ -13,7 +13,7 @@
             Actions slot
           </p-button>
         </template>
-        window slot!
+        <p-code-highlight text="const works = true" lang="js" />
       </p-window>
     </template>
   </ComponentPage>

--- a/src/components/Window/PWindow.vue
+++ b/src/components/Window/PWindow.vue
@@ -81,4 +81,12 @@
   px-5
   py-4
 }
+
+.p-window__body .p-code-highlight{
+  background-color: unset;
+}
+
+.p-window__body .p-code-highlight__code-wrapper {
+  color: unset;
+}
 </style>


### PR DESCRIPTION
before: 
<img width="861" alt="image" src="https://user-images.githubusercontent.com/6098901/219698129-36b6a5db-298e-41c2-b7aa-1279f67dfdc0.png">

after:
<img width="878" alt="image" src="https://user-images.githubusercontent.com/6098901/219698204-99e1ed9b-80cd-44b5-8970-0061f899b210.png">
