### PR TITLE
fix checkbox and radio widths

### DIFF
--- a/src/components/Checkbox/PCheckbox.vue
+++ b/src/components/Checkbox/PCheckbox.vue
@@ -78,6 +78,7 @@
   justify-end
   items-center
   gap-x-2
+  w-auto
   text-foreground
 }
 

--- a/src/components/Radio/PRadio.vue
+++ b/src/components/Radio/PRadio.vue
@@ -79,6 +79,7 @@
   justify-end
   items-center
   gap-x-2
+  w-auto
   text-foreground
 }
 

--- a/src/components/SelectOption/PSelectOption.vue
+++ b/src/components/SelectOption/PSelectOption.vue
@@ -122,10 +122,9 @@
   px-3
   font-normal
   text-sm
+  flex
   gap-2
   items-center
-  grid;
-  grid-template-columns: min-content 1fr;
 }
 
 .p-select-option--selected { @apply


### PR DESCRIPTION
Since checkbox and radio now use the PLabel component, which has a `width: 100%` by default, layout issues were happening since the radio/checkbox were previously `width: auto`. Since we have a class and are already overriding certain syltes from PLabel, this adds the `width: auto` to only the radio and checkbox implementation of PLabel so it plays nicely like before.

@pleek91 made a [PR](https://github.com/PrefectHQ/prefect-design/pull/653) to fix an issue happening in select menus. I reverted that just so that rows of content in the select menus that may have multiple elements don't have to wrestle against the grid styles. That may never happen, but the previous `flex` style works well enough with the updated radio/checkbox anyway.

<img width="527" alt="Screenshot 2023-02-21 at 8 38 03 AM" src="https://user-images.githubusercontent.com/6776415/220374915-e2224dc5-6f49-440d-9f92-1a423040c4e6.png">
<img width="335" alt="Screenshot 2023-02-21 at 8 38 17 AM" src="https://user-images.githubusercontent.com/6776415/220374918-9465b76a-7864-466b-8dd8-8a3c5f9bae16.png">
<img width="312" alt="Screenshot 2023-02-21 at 8 38 34 AM" src="https://user-images.githubusercontent.com/6776415/220374920-7a5c97d5-1241-4fde-a7ea-bbbc75f6a773.png">
<img width="311" alt="Screenshot 2023-02-21 at 8 38 44 AM" src="https://user-images.githubusercontent.com/6776415/220374923-ca2aca1c-8473-4bc1-a12d-8ecdacf526d8.png">
