### PR TITLE
Feature: styles secondary styles p-button in dark-mode

### DIFF
--- a/src/components/Button/PButton.vue
+++ b/src/components/Button/PButton.vue
@@ -138,13 +138,14 @@
   focus:outline-none
   focus:ring-2
   focus:ring-offset-2
+  focus:ring-primary
   focus:z-10
   font-medium
   inline-flex
   items-center
   rounded-md
   shadow-sm
-
+  text-foreground
   dark:ring-offset-background-400
 }
 
@@ -160,10 +161,7 @@
 .p-button--primary { @apply
   text-white
   bg-primary-600
-  focus:ring-primary-700
-
   dark:bg-primary-500
-  dark:focus:ring-primary-400
 }
 .p-button--primary:not(.p-button--disabled) { @apply
   hover:bg-primary-700
@@ -171,12 +169,8 @@
 }
 
 .p-button--secondary { @apply
-  text-primary-600
   bg-primary-100
-  focus:ring-primary-200
-
   dark:bg-primary-100
-  dark:focus:ring-primary-50
 }
 .p-button--secondary:not(.p-button--disabled) { @apply
   hover:bg-primary-200
@@ -186,26 +180,16 @@
 .p-button--inset { @apply
   border
   focus:border-transparent
-
-  text-foreground-300
   border-background-400
   bg-background-600
-  focus:ring-background-400
-
-  dark:text-foreground-400
   dark:bg-background-600
-  dark:focus:ring-background-500
 }
 .p-button--inset:not(.p-button--disabled) { @apply
   hover:bg-background-400
   dark:hover:bg-background-500
 }
 
-.p-button--flat { @apply
-  text-foreground-300
-  focus:ring-background-400
-  dark:focus:ring-background-500
-}
+
 .p-button--flat:not(.p-button--disabled) { @apply
   hover:bg-background-400
   dark:hover:bg-background-500
@@ -215,8 +199,6 @@
 .p-button--danger { @apply
   text-white
   bg-danger-600
-  focus:ring-danger-700
-  dark:focus:ring-danger-400
   dark:bg-danger-500
 }
 .p-button--danger:not(.p-button--disabled) { @apply
@@ -225,13 +207,8 @@
 }
 
 .p-button--danger--secondary { @apply
-  text-danger
   bg-danger-100
-  focus:ring-danger-200
-
-  dark:text-danger-700
   dark:bg-danger-200
-  dark:focus:ring-danger-200
 }
 .p-button--danger--secondary:not(.p-button--disabled) { @apply
   hover:bg-danger-200


### PR DESCRIPTION
the motivation for this PR is primarily to address inconsistencies with "secondary" colors on dark mode. IMO if you apply "secondary" to your button you want to downplay it's significance on the page. It's still primary (blue) or danger (red), but it just shouldn't stand out quite as aggressively. We were inconsistent with this on dark mode. Secondary primary was no longer blue, and secondary for danger was actually closer to white on dark-mode, which has the effect of even more attention grabbing than the non-secondary version. 

Here are a couple motivating screenshots from main
<img width="286" alt="image" src="https://user-images.githubusercontent.com/6098901/220454987-12cc0f21-6092-4221-8a82-d60657d38007.png">

<img width="922" alt="image" src="https://user-images.githubusercontent.com/6098901/220455045-30c8520c-7402-4619-a4dc-3834b7b15796.png">

every style of button should now follow these rules
- the ring color (focused) is the same (ring-primary)
- the bg gets darker when hovered, regardless of light-mode/dark-mode
  - "flat" in dark-mode actually gets lighter when hovered
- "secondary" colors by default start with bg that is closer to the background (lighter on light-mode, darker on dark-mode)
- every button uses text-foreground for max contrast except for when text-white is actually higher contrast (primary & danger in light-mode)

"inset" has some unique traits like border, otherwise follows rules above.

notable changes from current functionality to adhere to rules above: 
- secondary (blue) stays blue in dark-mode
- secondary (danger) is darker than non-secondary danger in dark-mode
- danger button has a different color on hover in light-mode
- ring colors are always ring-primary
- text colors are consistently text-foreground or text-white

before

https://user-images.githubusercontent.com/6098901/220457223-2e92c5bf-cc21-495d-af7d-8b53b3403870.mov


after

https://user-images.githubusercontent.com/6098901/220457339-d5195d93-ae95-42e0-95fd-3921e655814d.mov

after code review suggestions

https://user-images.githubusercontent.com/6098901/220497498-6e813aa0-9d74-473a-9e67-22a8f1547a2f.mov

