### PR TITLE
Bugfix: `PCodeInput` wrapping 

### DIFF
--- a/src/components/CodeInput/PCodeInput.vue
+++ b/src/components/CodeInput/PCodeInput.vue
@@ -179,7 +179,7 @@
   text-transparent
   top-0
   w-full
-  whitespace-nowrap
+  whitespace-pre-wrap
   z-0
 }
 


### PR DESCRIPTION
Fixes a bug in Safari and Firefox where the textarea had no line breaks and so didn't match with the highlight component