### PR TITLE
BugFix: Code component overflow

### DIFF
--- a/demo/sections/components/CodeHighlight.vue
+++ b/demo/sections/components/CodeHighlight.vue
@@ -11,6 +11,7 @@
       { title: 'Jinja' },
       { title: 'HTML' },
       { title: 'CSS' },
+      { title: 'Long lines' },
     ]"
   >
     <template #description>
@@ -45,6 +46,10 @@
 
     <template #jinja>
       <PCodeHighlight :text="jinjaContent" lang="jinja" :show-line-numbers="showLineNumbers" />
+    </template>
+
+    <template #long-lines>
+      <PCodeHighlight :text="long" lang="md" :show-line-numbers="showLineNumbers" />
     </template>
   </ComponentPage>
 </template>
@@ -170,4 +175,6 @@ State message: {{ flow_run.state.message }}
   {{ i }}
 {% endfor %}
 `
+
+  const long = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
 </script>

--- a/demo/sections/components/CodeInput.vue
+++ b/demo/sections/components/CodeInput.vue
@@ -6,6 +6,7 @@
       { title: 'Markdown' },
       { title: 'Python' },
       { title: 'Vue' },
+      { title: 'Long lines' },
     ]"
   >
     <template #description>
@@ -32,6 +33,10 @@
 
     <template #vue>
       <PCodeInput v-model="vueInput" class="code-input__input" lang="vue" :show-line-numbers="showLineNumbers" />
+    </template>
+
+    <template #long-lines>
+      <PCodeHighlight :text="long" lang="md" :show-line-numbers="showLineNumbers" />
     </template>
   </ComponentPage>
 </template>
@@ -111,6 +116,8 @@ And sighs that waft to heav'n
 
  *[Alexander Pope](https://www.poetryfoundation.org/poems/44892/eloisa-to-abelard)*
 `)
+
+  const long = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
 </script>
 
 <style>

--- a/src/components/CodeHighlight/PCodeHighlight.vue
+++ b/src/components/CodeHighlight/PCodeHighlight.vue
@@ -61,6 +61,7 @@
   font-mono
   py-0
   px-1
+  overflow-auto
 }
 
 .p-code-highlight--inline { @apply


### PR DESCRIPTION
# Description
Effects both p-code-highlight and p-code-input. Adding `overflow-auto` to p-code-highlight fixes it for both. Closes https://github.com/PrefectHQ/prefect-ui-library/issues/604
Before
<img width="1296" alt="image" src="https://user-images.githubusercontent.com/6200442/221983452-b6a99ff4-12eb-483a-ae10-3f8dd3269cbe.png">
After
<img width="1292" alt="image" src="https://user-images.githubusercontent.com/6200442/221983492-f06fe74e-27bb-4e9e-ad77-3d829d87c7e4.png">
