### PR TITLE
BugFix: PCombobox null option support

### DIFF
--- a/src/components/Combobox/PCombobox.vue
+++ b/src/components/Combobox/PCombobox.vue
@@ -147,11 +147,11 @@
   function displayValue(value: SelectModelValue): string {
     const option = getSelectOption(value)
 
-    if (option?.value) {
+    if (option) {
       return option.label
     }
 
-    if (!value) {
+    if (value === null) {
       return ''
     }
 


### PR DESCRIPTION
# Description
PCombobox wouldn't show the selected value if the value was null and there was an option with a null value. This was due to some falsey checks that needed to be strict. 