### PR TITLE
Feature: p-overflow-menu-item to prop

### DIFF
--- a/demo/sections/components/OverflowMenu.vue
+++ b/demo/sections/components/OverflowMenu.vue
@@ -13,9 +13,9 @@
             <span class="text-prefect-500">3 INVITES</span>
           </template>
         </p-overflow-menu-item>
-        <p-overflow-menu-item label="Add Favorite" />
-        <p-overflow-menu-item label="Copy ID" to="https://www.google.com" />
-        <p-overflow-menu-item label="Settings" to="/p-button" />
+        <p-overflow-menu-item label="Google" to="https://www.google.com" />
+        <p-overflow-menu-item label="Icons" :to="{ name: 'icons' }" />
+        <p-overflow-menu-item label="Settings" />
       </p-overflow-menu>
     </template>
   </ComponentPage>

--- a/demo/sections/components/OverflowMenu.vue
+++ b/demo/sections/components/OverflowMenu.vue
@@ -14,8 +14,8 @@
           </template>
         </p-overflow-menu-item>
         <p-overflow-menu-item label="Add Favorite" />
-        <p-overflow-menu-item label="Copy ID" />
-        <p-overflow-menu-item label="Settings" />
+        <p-overflow-menu-item label="Copy ID" to="https://www.google.com" />
+        <p-overflow-menu-item label="Settings" to="/p-button" />
       </p-overflow-menu>
     </template>
   </ComponentPage>

--- a/src/components/OverflowMenuItem/POverflowMenuItem.vue
+++ b/src/components/OverflowMenuItem/POverflowMenuItem.vue
@@ -1,7 +1,8 @@
 <template>
-  <button
-    type="button"
+  <component
+    :is="component"
     class="p-menu-item"
+    v-bind="componentProps"
   >
     <PIcon v-if="icon" :icon="icon" class="p-menu-item__icon" />
 
@@ -12,17 +13,49 @@
     <div class="p-menu-item__after">
       <slot name="after" />
     </div>
-  </button>
+  </component>
 </template>
 
 <script lang="ts" setup>
+  import { computed } from 'vue'
+  import { RouteLocationRaw } from 'vue-router'
   import PIcon from '@/components/Icon/PIcon.vue'
   import { Icon } from '@/types/icon'
+  import { isRouteExternal } from '@/utilities/router'
 
-  defineProps<{
+  const props = defineProps<{
     label?: string,
     icon?: Icon,
+    to?: RouteLocationRaw,
   }>()
+
+  const component = computed(() => {
+    if (props.to) {
+      return isRouteExternal(props.to) ? 'a' : 'router-link'
+    }
+
+    return 'button'
+  })
+
+  const componentProps = computed(() => {
+    if (component.value === 'a') {
+      return {
+        role: 'button',
+        href: props.to,
+      }
+    }
+
+    if (component.value === 'button') {
+      return {
+        type: 'button',
+      }
+    }
+
+    return {
+      role: 'button',
+      to: props.to,
+    }
+  })
 </script>
 
 <style>


### PR DESCRIPTION
uses same logic from p-button to allow developer to pass route directly to component instead of nesting inside router-link component. Might be worth trying to encapsulate the shared logic between p-button and p-overflow-menu-item if we keep finding that logic repeated in future components.

```html
<p-overflow-menu-item label="Google" to="https://www.google.com" />
<p-overflow-menu-item label="Icons" :to="{ name: 'icons' }" />
```

closes #679