### PR TITLE
BugFix: Prevent grid blowout in PContent

### DIFF
--- a/src/components/Content/PContent.vue
+++ b/src/components/Content/PContent.vue
@@ -20,6 +20,7 @@
 .p-content { @apply
   grid
   gap-4
+  grid-cols-1
 }
 
 .p-content--secondary { @apply


### PR DESCRIPTION
# Description
PContent has no column settings which means grid blowout is pretty easy to accidentally do. Adding `minmax(0, 1fr)` allows content to shrink to fix inside the container. 

Before
![image](https://user-images.githubusercontent.com/6200442/224794301-ee26edbf-c126-4512-b848-b792179938e6.png)

After
![image](https://user-images.githubusercontent.com/6200442/224794364-885b57ba-4e08-4bb2-8ae7-3ecee58dc739.png)
