### PR TITLE
BugFix: keyboard interactions on p-toggle

### DIFF
--- a/demo/sections/components/Toggle.vue
+++ b/demo/sections/components/Toggle.vue
@@ -11,7 +11,7 @@
     <template #toggle>
       <p-label label="Toggle">
         <div class="flex flex-col gap-2">
-          <p-toggle v-model="exampleBoolean" :disabled="disabled" :state="exampleState" :append="exampleBoolean?.toString() ?? 'null'" />
+          <p-toggle v-model="exampleBoolean" :disabled="disabled" :state="exampleState" />
           <p-toggle
             v-model="exampleSecondBoolean"
             class="color-toggle"

--- a/src/components/Toggle/PToggle.vue
+++ b/src/components/Toggle/PToggle.vue
@@ -150,6 +150,9 @@
 .p-toggle__slider { @apply
   w-5
   h-5
+  flex
+  justify-center
+  items-center
   text-primary-300
   relative
   rounded-full

--- a/src/components/Toggle/PToggle.vue
+++ b/src/components/Toggle/PToggle.vue
@@ -6,7 +6,14 @@
       </slot>
     </button>
 
-    <label class="p-toggle__control" :class="classes.control">
+    <label
+      class="p-toggle__control"
+      tabindex="0"
+      role="switch"
+      :aria-checked="internalValue"
+      :class="classes.control"
+      @keypress.space="toggle"
+    >
       <input
         v-show="false"
         v-model="internalValue"


### PR DESCRIPTION
this PR actually fixes a few issues

1. the p-toggle itself was not focusable, so a toggle without buttons in prepend/append slot was not navigable by keyboard
2. even if it was focusable, space keypress would not toggle the value [as expected by APG](https://www.w3.org/WAI/ARIA/apg/patterns/switch/)
3. we were also missing "role" on the label. I don't believe we actually needed to add the aria-checked, since we're using a checkbox underneath, but I can't imagine it hurts to have redundancy here
4. if the toggle is pending, the loading icon was not properly centered

before:
https://user-images.githubusercontent.com/6098901/225179855-2bf8b44e-6e24-43a7-ae35-358a4d4ad082.mov
https://user-images.githubusercontent.com/6098901/225179872-94a98b9a-9e59-4770-8f36-9681eff4965e.mov

after:
https://user-images.githubusercontent.com/6098901/225179886-b482403a-8a85-4481-a99f-2fec9295f5b2.mov
https://user-images.githubusercontent.com/6098901/225179909-e3c1bdb9-f2a3-479c-bca9-9f4831f20b53.mov


