### PR TITLE
Feature: p-modal auto-close

### DIFF
--- a/demo/sections/components/Modals.vue
+++ b/demo/sections/components/Modals.vue
@@ -1,5 +1,5 @@
 <template>
-  <ComponentPage title="Modals" :demos="[{ title: 'Modals' }]">
+  <ComponentPage title="Modals" :demos="[{ title: 'Modals' }, { title: 'Auto-Close' }]">
     <template #description>
       This is where we add a short description of <p-code inline>
         p-modals
@@ -23,6 +23,24 @@
         </template>
       </p-modal>
     </template>
+
+    <template #auto-close>
+      <p-button @click="showAutoCloseModal = true">
+        Open Modal
+      </p-button>
+
+      <p-modal v-model:showModal="showAutoCloseModal" title="Auto-Close Modal" icon="CakeIcon" auto-close>
+        <p class="text-sm text-foreground">
+          Click on modal mask to automatically dismiss modal
+        </p> :modelValue=
+
+        <template #actions>
+          <p-button @click="showAutoCloseModal = false">
+            Submit
+          </p-button>
+        </template>
+      </p-modal>
+    </template>
   </ComponentPage>
 </template>
 
@@ -31,4 +49,5 @@
   import ComponentPage from '@/demo/components/ComponentPage.vue'
 
   const showModal = ref(false)
+  const showAutoCloseModal = ref(false)
 </script>

--- a/src/components/Modal/PModal.vue
+++ b/src/components/Modal/PModal.vue
@@ -68,7 +68,6 @@
     showModal: boolean,
     title?: string,
     icon?: Icon,
-    preventFocus?: boolean,
     autoClose?: boolean,
   }>()
 
@@ -124,7 +123,7 @@
   }
 
   watch(() => props.showModal, value => {
-    if (value && !props.preventFocus) {
+    if (value) {
       nextTick(focusOnFirstFocusable)
     }
 

--- a/src/components/Modal/PModal.vue
+++ b/src/components/Modal/PModal.vue
@@ -13,7 +13,7 @@
         @keydown="handleKeydown"
       >
         <div class="p-modal__container">
-          <div class="p-modal__background" aria-hidden="true" />
+          <div class="p-modal__background" aria-hidden="true" @click="handleMaskClick" />
           <div class="p-modal__card">
             <div class="p-modal__header" :class="classes.header">
               <div class="p-modal__tile-icon-group">
@@ -68,6 +68,8 @@
     showModal: boolean,
     title?: string,
     icon?: Icon,
+    preventFocus?: boolean,
+    autoClose?: boolean,
   }>()
 
   const emits = defineEmits<{
@@ -115,8 +117,14 @@
     firstFocusable?.focus()
   }
 
+  function handleMaskClick(): void {
+    if (props.autoClose) {
+      closeModal()
+    }
+  }
+
   watch(() => props.showModal, value => {
-    if (value) {
+    if (value && !props.preventFocus) {
       nextTick(focusOnFirstFocusable)
     }
 


### PR DESCRIPTION
added `auto-close` prop behavior (closes modal on mask click) similar to how p-pop-over auto-close prop works

also adds prop `prevent-focus`, which let's the developer prevent automatic focusing of first focusable element on modal opening.

https://user-images.githubusercontent.com/6098901/225753876-aad23e0f-4ab2-4989-b281-60832ac432b1.mov

