### PR TITLE
BugFix: sizing of p-calendar date rows

### DIFF
--- a/src/components/Calendar/PCalendar.vue
+++ b/src/components/Calendar/PCalendar.vue
@@ -68,6 +68,7 @@
 .p-calendar__dates { @apply
   grid
   grid-cols-7
+  grid-rows-6
   gap-y-2
   gap-x-3
   flex-grow

--- a/src/components/Calendar/PCalendar.vue
+++ b/src/components/Calendar/PCalendar.vue
@@ -68,10 +68,10 @@
 .p-calendar__dates { @apply
   grid
   grid-cols-7
-  grid-rows-6
   gap-y-2
   gap-x-3
-  flex-grow
+  flex-grow;
+  grid-auto-rows: minmax(0, 1fr)
 }
 
 .p-calendar__date { @apply


### PR DESCRIPTION
Not sure when it happened, but I found this weird sizing bug on safari

https://user-images.githubusercontent.com/6098901/225976162-73e25deb-93bb-49ad-b988-38fdad05ea65.mov

I didn't see any recent change that explain it, but the solution I came up with is explicit row sizing for the grid on p-calendar.
A side-effect of that decision (could be pro, could be con) is that the size of each row is the same regardless of if the month has 4, 5 or 6 weeks.

https://user-images.githubusercontent.com/6098901/225976425-3e8e97e0-5e5a-42a4-ae0b-b7be3f50edc8.mov

Here's a before/after for chrome, you can see the size of content changes depending on # of weeks in viewing month

https://user-images.githubusercontent.com/6098901/225976491-246f973b-68fe-4dc2-9a69-a988cd3fba25.mov




https://user-images.githubusercontent.com/6098901/225976675-3168b351-f37c-4adc-8ae9-b3012a89d603.mov



