### PR TITLE
Feature: p-native-datepicker new show-time prop

### DIFF
--- a/src/components/DateInput/PDateInput.vue
+++ b/src/components/DateInput/PDateInput.vue
@@ -21,7 +21,7 @@
           <PNativeDateInput
             v-model="internalModelValue"
             class="p-date-input__native"
-            v-bind="{ min, max, disabled }"
+            v-bind="{ min, max, disabled, showTime }"
           />
         </template>
       </slot>
@@ -150,7 +150,6 @@
 .p-date-input__date-picker { @apply
   bg-background
   my-1
-  rounded-md
   shadow-lg
   rounded
   dark:border-foreground-300

--- a/src/components/DatePicker/PTimePicker.vue
+++ b/src/components/DatePicker/PTimePicker.vue
@@ -28,11 +28,11 @@
 </template>
 
 <script lang="ts" setup>
-  import { endOfDay, format, set, setHours, setMinutes, startOfMinute, startOfDay } from 'date-fns'
+  import { startOfMinute } from 'date-fns'
   import { computed } from 'vue'
   import ScrollingPicker from '@/components/DatePicker/ScrollingPicker.vue'
-  import { SelectModelValue } from '@/types/selectOption'
-  import { isDateAfter, isDateBefore, isDateInRange, keepDateInRange } from '@/utilities/dates'
+  import { useTimeParts } from '@/compositions/useTimeParts'
+  import { keepDateInRange } from '@/utilities/dates'
 
   const props = defineProps<{
     modelValue: Date | null | undefined,
@@ -57,111 +57,14 @@
     },
   })
 
-  const selectedHours = computed({
-    get() {
-      return parseInt(format(selectedDate.value, 'h'))
-    },
-    set(hours: SelectModelValue) {
-      selectedDate.value = applyHours(selectedDate.value, hours as number)
-    },
-  })
-
-  const selectedMinutes = computed({
-    get() {
-      return parseInt(format(selectedDate.value, 'mm'))
-    },
-    set(value) {
-      selectedDate.value = applyMinutes(selectedDate.value, value as number)
-    },
-  })
-
-  const selectedMeridiem = computed({
-    get() {
-      return format(selectedDate.value, 'a')
-    },
-    set(meridiem: SelectModelValue) {
-      selectedDate.value = applyMeridiem(selectedDate.value, meridiem as 'AM' | 'PM')
-    },
-  })
-
-  function applyHours(date: Date, hours: number): Date {
-    hours = hours % 12
-    const meridiem = format(selectedDate.value, 'a')
-
-    if (meridiem === 'AM') {
-      return setHours(date, hours)
-    }
-
-    return setHours(date, hours + 12)
-  }
-
-  function applyMinutes(date: Date, minutes: number): Date {
-    return setMinutes(date, minutes)
-  }
-
-  function applyMeridiem(date: Date, meridiem: 'AM' | 'PM'): Date {
-    const currentMeridiem = format(date, 'a')
-    const currentHours = date.getHours()
-
-    if (meridiem === 'AM' && currentMeridiem !== 'AM') {
-      return setHours(date, currentHours - 12)
-    }
-
-    if (meridiem === 'PM' && currentMeridiem !== 'PM') {
-      return setHours(date, currentHours + 12)
-    }
-
-    return date
-  }
-
-  function isDateRangeOverlappingRange(interval: { start: Date, end: Date }): boolean {
-    return (!range.value.min || !isDateBefore(interval.end, range.value.min)) && (!range.value.max || !isDateAfter(interval.start, range.value.max))
-  }
-
-  const hourOptions = computed(() => [...new Array(12).keys()].map(hour => {
-    hour += 1
-    const dateValue = applyHours(selectedDate.value, hour)
-
-    return {
-      label: format(dateValue, 'h'),
-      value: hour,
-      disabled: !isDateInRange(dateValue, range.value, 'hour'),
-    }
-  }))
-
-  const minuteOptions = computed(() => [...new Array(60).keys()].map(minute => {
-    const dateValue = setMinutes(selectedDate.value, minute)
-
-    return {
-      label: format(dateValue, 'mm'),
-      value: minute,
-      disabled: !isDateInRange(dateValue, range.value),
-    }
-  }))
-
-  const meridiemOptions = computed(() => {
-    const beforeMeridiem = {
-      start: startOfDay(selectedDate.value),
-      end: set(selectedDate.value, { hours: 11, minutes: 59 }),
-    }
-    const afterMeridiem = {
-      start: set(selectedDate.value, { hours: 12, minutes: 0 }),
-      end: endOfDay(selectedDate.value),
-    }
-
-    return [
-      {
-        label: 'AM',
-        value: 'AM',
-        disabled: !isDateRangeOverlappingRange(beforeMeridiem),
-      },
-      {
-        label: 'PM',
-        value: 'PM',
-        disabled: !isDateRangeOverlappingRange(afterMeridiem),
-      },
-    ]
-  })
+  const {
+    selectedHours,
+    selectedMinutes,
+    selectedMeridiem,
+    hourOptions,
+    minuteOptions,
+    meridiemOptions,
+  } = useTimeParts(selectedDate, range)
 </script>
 
 <style>

--- a/src/components/NativeDateInput/PNativeDateInput.vue
+++ b/src/components/NativeDateInput/PNativeDateInput.vue
@@ -4,24 +4,45 @@
       <slot :name="name" v-bind="data" />
     </template>
     <template #control="{ attrs }">
-      <input
-        ref="inputElement"
-        v-model="stringValue"
-        type="date"
-        class="p-native-date-input__control"
-        :min="stringMin"
-        :max="stringMax"
-        v-bind="attrs"
-      >
-      <input
-        ref="inputElement"
-        v-model="stringValue"
-        type="date"
-        class="p-native-date-input__control p-native-date-input__control--placeholder"
-        :min="stringMin"
-        :max="stringMax"
-        v-bind="attrs"
-      >
+      <template v-if="dateMode">
+        <input
+          ref="inputElement"
+          v-model="stringValue"
+          type="date"
+          class="p-native-date-input__control"
+          :min="stringMin"
+          :max="stringMax"
+          v-bind="attrs"
+        >
+        <input
+          ref="inputElement"
+          v-model="stringValue"
+          type="date"
+          class="p-native-date-input__control p-native-date-input__control--placeholder"
+          :min="stringMin"
+          :max="stringMax"
+          v-bind="attrs"
+        >
+      </template>
+
+      <template v-else>
+        <div class="p-native-date-input__time-pickers">
+          <p-native-select v-model="selectedHours" class="p-native-date-input__picker" :options="hourOptions" />
+          <p-native-select v-model="selectedMinutes" class="p-native-date-input__picker" :options="minuteOptions" />
+          <p-native-select v-model="selectedMeridiem" class="p-native-date-input__picker" :options="meridiemOptions" />
+        </div>
+      </template>
+
+      <template v-if="showTime">
+        <p-button
+          class="p-native-date-input__mode-toggle"
+          size-sm
+          rounded
+          flat
+          icon="ClockIcon"
+          @click="dateMode = !dateMode"
+        />
+      </template>
     </template>
 
     <template #append>
@@ -33,21 +54,25 @@
 </template>
 
 <script lang="ts" setup>
-  import { format, parseISO } from 'date-fns'
+  import { format, parseISO, startOfMinute } from 'date-fns'
   import { computed, ref } from 'vue'
   import PBaseInput from '@/components/BaseInput/PBaseInput.vue'
   import PIcon from '@/components/Icon/PIcon.vue'
+  import { useTimeParts } from '@/compositions/useTimeParts'
+  import { keepDateInRange } from '@/utilities/dates'
 
   const props = defineProps<{
     modelValue: Date | null | undefined,
     min?: Date | null,
     max?: Date | null,
+    showTime?: boolean,
   }>()
 
-  const emits = defineEmits<{
+  const emit = defineEmits<{
     (event: 'update:modelValue', value: Date | null): void,
   }>()
 
+  const dateMode = ref(true)
   const internalValue = computed(() => props.modelValue ?? null)
   const inputElement = ref<HTMLInputElement>()
   const el = computed(() => inputElement.value)
@@ -59,12 +84,34 @@
       return internalValue.value ? format(internalValue.value, 'yyyy-MM-dd') : null
     },
     set(value) {
-      emits('update:modelValue', value ? parseISO(value) : null)
+      emit('update:modelValue', value ? parseISO(value) : null)
     },
   })
 
   const stringMin = computed(() => props.min ? format(props.min, 'yyyy-MM-dd') : undefined)
   const stringMax = computed(() => props.max ? format(props.max, 'yyyy-MM-dd') : undefined)
+
+  const selectedDate = computed({
+    get() {
+      return props.modelValue ?? startOfMinute(new Date())
+    },
+    set(value) {
+      const withoutSeconds = startOfMinute(value)
+
+      emit('update:modelValue', keepDateInRange(withoutSeconds, range.value))
+    },
+  })
+
+  const range = computed(() => ({ min: props.min, max: props.max }))
+
+  const {
+    selectedHours,
+    selectedMinutes,
+    selectedMeridiem,
+    hourOptions,
+    minuteOptions,
+    meridiemOptions,
+  } = useTimeParts(selectedDate, range)
 </script>
 
 <style>
@@ -117,5 +164,22 @@
 .p-native-date-input .p-native-date-input__control--placeholder::-webkit-calendar-picker-indicator {
   display: none;
   -webkit-appearance: none;
+}
+
+.p-native-date-input__mode-toggle { @apply
+  !p-0
+  mr-2
+}
+
+.p-native-date-input__time-pickers { @apply
+  flex
+  flex-grow
+  justify-around
+}
+
+.p-native-date-input__picker { @apply
+  w-min
+  border-0
+  !ring-0
 }
 </style>

--- a/src/compositions/useTimeParts.ts
+++ b/src/compositions/useTimeParts.ts
@@ -1,0 +1,134 @@
+import { endOfDay, format, set, setHours, setMinutes, startOfDay } from 'date-fns'
+import { computed, ComputedRef, ref, WritableComputedRef } from 'vue'
+import { SelectOption } from '@/types'
+import { MaybeRef } from '@/types/ref'
+import { DateRange, isDateAfter, isDateBefore, isDateInRange } from '@/utilities/dates'
+
+export type UseTimeParts = {
+  selectedHours: WritableComputedRef<number>,
+  selectedMinutes: WritableComputedRef<number>,
+  selectedMeridiem: WritableComputedRef<string>,
+  hourOptions: ComputedRef<SelectOption[]>,
+  minuteOptions: ComputedRef<SelectOption[]>,
+  meridiemOptions: ComputedRef<SelectOption[]>,
+}
+
+export function useTimeParts(value: MaybeRef<Date>, range: MaybeRef<DateRange> = { min: undefined, max: undefined }): UseTimeParts {
+  const valueRef = ref(value)
+  const rangeRef = ref(range)
+
+  const selectedHours = computed({
+    get() {
+      return parseInt(format(valueRef.value, 'h'))
+    },
+    set(hours) {
+      valueRef.value = applyHours(valueRef.value, hours as number)
+    },
+  })
+
+  const selectedMinutes = computed({
+    get() {
+      return parseInt(format(valueRef.value, 'mm'))
+    },
+    set(value) {
+      valueRef.value = applyMinutes(valueRef.value, value as number)
+    },
+  })
+
+  const selectedMeridiem = computed({
+    get() {
+      return format(valueRef.value, 'a')
+    },
+    set(meridiem) {
+      valueRef.value = applyMeridiem(valueRef.value, meridiem as 'AM' | 'PM')
+    },
+  })
+
+  function applyHours(date: Date, hours: number): Date {
+    hours = hours % 12
+    const meridiem = format(valueRef.value, 'a')
+
+    if (meridiem === 'AM') {
+      return setHours(date, hours)
+    }
+
+    return setHours(date, hours + 12)
+  }
+
+  function applyMinutes(date: Date, minutes: number): Date {
+    return setMinutes(date, minutes)
+  }
+
+  function applyMeridiem(date: Date, meridiem: 'AM' | 'PM'): Date {
+    const currentMeridiem = format(date, 'a')
+    const currentHours = date.getHours()
+
+    if (meridiem === 'AM' && currentMeridiem !== 'AM') {
+      return setHours(date, currentHours - 12)
+    }
+
+    if (meridiem === 'PM' && currentMeridiem !== 'PM') {
+      return setHours(date, currentHours + 12)
+    }
+
+    return date
+  }
+
+  function isDateRangeOverlappingRange(interval: { start: Date, end: Date }): boolean {
+    return (!rangeRef.value.min || !isDateBefore(interval.end, rangeRef.value.min)) && (!rangeRef.value.max || !isDateAfter(interval.start, rangeRef.value.max))
+  }
+
+  const hourOptions = computed(() => [...new Array(12).keys()].map(hour => {
+    hour += 1
+    const dateValue = applyHours(valueRef.value, hour)
+
+    return {
+      label: format(dateValue, 'h'),
+      value: hour,
+      disabled: !isDateInRange(dateValue, rangeRef.value, 'hour'),
+    }
+  }))
+
+  const minuteOptions = computed(() => [...new Array(60).keys()].map(minute => {
+    const dateValue = setMinutes(valueRef.value, minute)
+
+    return {
+      label: format(dateValue, 'mm'),
+      value: minute,
+      disabled: !isDateInRange(dateValue, rangeRef.value),
+    }
+  }))
+
+  const meridiemOptions = computed(() => {
+    const beforeMeridiem = {
+      start: startOfDay(valueRef.value),
+      end: set(valueRef.value, { hours: 11, minutes: 59 }),
+    }
+    const afterMeridiem = {
+      start: set(valueRef.value, { hours: 12, minutes: 0 }),
+      end: endOfDay(valueRef.value),
+    }
+
+    return [
+      {
+        label: 'AM',
+        value: 'AM',
+        disabled: !isDateRangeOverlappingRange(beforeMeridiem),
+      },
+      {
+        label: 'PM',
+        value: 'PM',
+        disabled: !isDateRangeOverlappingRange(afterMeridiem),
+      },
+    ]
+  })
+
+  return {
+    selectedHours,
+    selectedMinutes,
+    selectedMeridiem,
+    hourOptions,
+    minuteOptions,
+    meridiemOptions,
+  }
+}


### PR DESCRIPTION
as you probably know, p-date-input has a prop for `show-time`, which lets the user set both the date and the time.
as you probably also know, p-date-input relies on p-native-date-input if `media.hover`, which ignores `show-time`.


https://user-images.githubusercontent.com/6098901/225978874-d86ec99e-c210-4983-9d46-730a59dc2f5b.mov




https://user-images.githubusercontent.com/6098901/225979201-e7e3df13-5830-4bff-a159-16889ef2311b.MP4



my solution to add support for `show-time` prop on p-native-date-input, which puts an icon in the input that toggles between entering the "date" portion and entering the "time" portion.

https://user-images.githubusercontent.com/6098901/225978965-fa77245d-e99f-4f80-9c98-00a370005d62.mov


https://user-images.githubusercontent.com/6098901/225978988-b708bdfd-2a9b-4a33-80a0-a5676f6c7c5d.MP4



