### PR TITLE
BugFix: PDivider not very visible

### DIFF
--- a/src/components/Divider/PDivider.vue
+++ b/src/components/Divider/PDivider.vue
@@ -7,7 +7,7 @@
     border-none
     h-[1px]
     bg-background-400
-    dark:bg-background-500
+    dark:bg-foreground-200
     w-full
     my-3
   }

--- a/src/components/Divider/PDivider.vue
+++ b/src/components/Divider/PDivider.vue
@@ -6,8 +6,8 @@
   .p-divider { @apply
     border-none
     h-[1px]
-    bg-background-400
-    dark:bg-foreground-200
+    bg-foreground-50
+    dark:bg-foreground-100
     w-full
     my-3
   }


### PR DESCRIPTION
# Description
Matching the colors from PCard

Before
![image](https://user-images.githubusercontent.com/6200442/226743079-26093cf9-a12b-4410-943e-a44d3a66d5ec.png)

After
![image](https://user-images.githubusercontent.com/6200442/226743033-b390e1e9-d5b8-4198-86e9-7ca1393fb4e8.png)
