### PR TITLE
Enhancement: PCard flat prop + animation

### DIFF
--- a/demo/sections/components/Card.vue
+++ b/demo/sections/components/Card.vue
@@ -1,13 +1,15 @@
 <template>
   <ComponentPage title="Card" :demos="[{ title: 'Card' }]">
     <template #description>
-      This is where we add a short description of <p-code inline>
-        p-card
-      </p-code>. Describe the components intent, not hyper specific documentation that belongs on vitepress page.
+      A basic card, one of the most common UI components.
+
+      <div>
+        <p-checkbox v-model="flat" label="Flat" />
+      </div>
     </template>
 
     <template #card>
-      <p-card>
+      <p-card :flat="flat">
         <h1>This is a Card component</h1>
       </p-card>
     </template>
@@ -15,5 +17,8 @@
 </template>
 
 <script lang="ts" setup>
+  import { ref } from 'vue'
   import ComponentPage from '@/demo/components/ComponentPage.vue'
+
+  const flat = ref(false)
 </script>

--- a/src/components/Card/PCard.vue
+++ b/src/components/Card/PCard.vue
@@ -8,7 +8,7 @@
   import { computed } from 'vue'
 
   const props = defineProps<{
-    flat: boolean,
+    flat?: boolean,
   }>()
 
   const classes = computed(() => ({
@@ -28,16 +28,10 @@
   shadow-sm
   transition-all;
 
-  /*
-    Explicitly defining these after transition-all
-      to override the transition-property on the box-shadow
-      because transitioning shadows isn't super performant
-      and it doesn't add much value.
-  */
-  transition-property: border border-color border-radius background-color color padding;
+  transition-property: border border-color background-color;
 }
 
-.p-card .p-card--flat { @apply
+.p-card--flat { @apply
   border-transparent
   shadow-none
   bg-transparent

--- a/src/components/Card/PCard.vue
+++ b/src/components/Card/PCard.vue
@@ -1,8 +1,20 @@
 <template>
-  <div class="p-card">
+  <div class="p-card" :class="classes">
     <slot />
   </div>
 </template>
+
+<script lang="ts" setup>
+  import { computed } from 'vue'
+
+  const props = defineProps<{
+    flat: boolean,
+  }>()
+
+  const classes = computed(() => ({
+    'p-card--flat': props.flat,
+  }))
+</script>
 
 <style>
 .p-card { @apply
@@ -14,5 +26,12 @@
   p-6
   rounded-lg
   shadow-sm
+  transition-all;
+}
+
+.p-card .p-card--flat { @apply
+  border-none
+  shadow-none
+  bg-transparent
 }
 </style>

--- a/src/components/Card/PCard.vue
+++ b/src/components/Card/PCard.vue
@@ -27,6 +27,14 @@
   rounded-lg
   shadow-sm
   transition-all;
+
+  /*
+    Explicitly defining these after transition-all
+      to override the transition-property on the box-shadow
+      because transitioning shadows isn't super performant
+      and it doesn't add much value.
+  */
+  transition-property: border border-color border-radius background-color color padding;
 }
 
 .p-card .p-card--flat { @apply

--- a/src/components/Card/PCard.vue
+++ b/src/components/Card/PCard.vue
@@ -38,7 +38,7 @@
 }
 
 .p-card .p-card--flat { @apply
-  border-none
+  border-transparent
   shadow-none
   bg-transparent
 }


### PR DESCRIPTION
Pretty straightforward enhancement to the `PCard` component that adds a boolean `flat` property that removes the component's border, background, and box-shadow but keeps the padding. It also transitions all of these except box shadow.