### PR TITLE
BugFix: make sure bg can scroll after modal is closed

### DIFF
--- a/src/components/Modal/PModal.vue
+++ b/src/components/Modal/PModal.vue
@@ -122,10 +122,6 @@
     }
   }
 
-  function disableBackgroundScroll(): void {
-    document.body.classList.add('p-modal__stop-bg-scroll')
-  }
-
   function enableBackgroundScroll(): void {
     document.body.classList.remove('p-modal__stop-bg-scroll')
   }
@@ -137,11 +133,7 @@
       nextTick(focusOnFirstFocusable)
     }
 
-    if (value) {
-      disableBackgroundScroll()
-    } else {
-      enableBackgroundScroll()
-    }
+    document.body.classList.toggle('p-modal__stop-bg-scroll', value)
   }, { immediate: true })
 </script>
 

--- a/src/components/Modal/PModal.vue
+++ b/src/components/Modal/PModal.vue
@@ -57,7 +57,7 @@
 </script>
 
 <script setup lang="ts">
-  import { nextTick, computed, ref, useSlots, watch } from 'vue'
+  import { nextTick, computed, ref, useSlots, watch, onBeforeUnmount } from 'vue'
   import PButton from '@/components/Button/PButton.vue'
   import PIcon from '@/components/Icon/PIcon.vue'
   import { useFocusableElements } from '@/compositions/useFocusableElements'
@@ -122,15 +122,25 @@
     }
   }
 
+  function disableBackgroundScroll(): void {
+    document.body.classList.add('p-modal__stop-bg-scroll')
+  }
+
+  function enableBackgroundScroll(): void {
+    document.body.classList.remove('p-modal__stop-bg-scroll')
+  }
+
+  onBeforeUnmount(enableBackgroundScroll)
+
   watch(() => props.showModal, value => {
     if (value) {
       nextTick(focusOnFirstFocusable)
     }
 
     if (value) {
-      document.body.classList.add('p-modal__stop-bg-scroll')
+      disableBackgroundScroll()
     } else {
-      document.body.classList.remove('p-modal__stop-bg-scroll')
+      enableBackgroundScroll()
     }
   }, { immediate: true })
 </script>

--- a/src/components/Modal/PModal.vue
+++ b/src/components/Modal/PModal.vue
@@ -127,7 +127,11 @@
       nextTick(focusOnFirstFocusable)
     }
 
-    document.body.classList.toggle('p-modal__stop-bg-scroll', value)
+    if (value) {
+      document.body.classList.add('p-modal__stop-bg-scroll')
+    } else {
+      document.body.classList.remove('p-modal__stop-bg-scroll')
+    }
   }, { immediate: true })
 </script>
 


### PR DESCRIPTION
looks like original implementation mistook the 2nd argument as boolean for "should the class be there or not" when in reality the 2nd argument is a boolean for "force". 
https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/toggle

also ensure bg-scroll gets re-enabled if p-modal gets unmounted without resetting `showModal`