### PR TITLE
Chore: List item and list item input BEM classes

### DIFF
--- a/src/components/ListItem/PListItem.vue
+++ b/src/components/ListItem/PListItem.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="list-item">
+  <div class="p-list-item">
     <slot />
   </div>
 </template>
 
 <style>
-.list-item { @apply
+.p-list-item { @apply
   bg-background
   shadow
   rounded-lg

--- a/src/components/ListItemInput/PListItemInput.vue
+++ b/src/components/ListItemInput/PListItemInput.vue
@@ -6,7 +6,7 @@
       </label>
     </div>
 
-    <div class="p-list-item-input__content" v-on="{ click }">
+    <div class="p-list-item-input__content">
       <slot />
     </div>
   </PListItem>
@@ -27,7 +27,6 @@
 
   const emit = defineEmits<{
     (event: 'update:selected', value: Selected): void,
-    (event: 'click', value: unknown): void,
   }>()
 
   const model = computed({
@@ -67,12 +66,6 @@
   function mouseleave(): void {
     if (!props.disabled) {
       hover.value = false
-    }
-  }
-
-  function click(): void {
-    if (!props.disabled) {
-      emit('click', props.value)
     }
   }
 </script>

--- a/src/components/ListItemInput/PListItemInput.vue
+++ b/src/components/ListItemInput/PListItemInput.vue
@@ -1,6 +1,6 @@
 <template>
   <PListItem class="list-item-input" v-on="{ mouseenter, mouseleave }">
-    <div class="list-item-input__control" :class="classes.control">
+    <div class="list-item-input__control" :class="classes.control" @click.stop>
       <label class="list-item-input__checkbox">
         <PCheckbox v-model="model" v-bind="{ value, disabled }" />
       </label>

--- a/src/components/ListItemInput/PListItemInput.vue
+++ b/src/components/ListItemInput/PListItemInput.vue
@@ -1,12 +1,12 @@
 <template>
-  <PListItem class="list-item-input" v-on="{ mouseenter, mouseleave }">
-    <div class="list-item-input__control" :class="classes.control" @click.stop>
-      <label class="list-item-input__checkbox">
+  <PListItem class="p-list-item-input" v-on="{ mouseenter, mouseleave }">
+    <div class="p-list-item-input__control" :class="classes.control" @click.stop>
+      <label class="p-list-item-input__checkbox">
         <PCheckbox v-model="model" v-bind="{ value, disabled }" />
       </label>
     </div>
 
-    <div class="list-item-input__content">
+    <div class="p-list-item-input__content">
       <slot />
     </div>
   </PListItem>
@@ -53,7 +53,7 @@
 
   const classes = computed(() => ({
     control: {
-      'list-item-input__control--visible': show.value,
+      'p-list-item-input__control--visible': show.value,
     },
   }))
 
@@ -71,7 +71,7 @@
 </script>
 
 <style>
-.list-item-input { @apply
+.p-list-item-input { @apply
   bg-background
   shadow
   rounded-lg
@@ -80,7 +80,7 @@
   p-0
 }
 
-.list-item-input__content { @apply
+.p-list-item-input__content { @apply
   flex-grow
   py-3
   pl-3
@@ -88,7 +88,7 @@
   min-w-0
 }
 
-.list-item-input__control { @apply
+.p-list-item-input__control { @apply
   flex-grow-0
   flex-shrink-0
   flex
@@ -99,12 +99,12 @@
   transition-all
 }
 
-.list-item-input__control:focus-within,
-.list-item-input__control--visible { @apply
+.p-list-item-input__control:focus-within,
+.p-list-item-input__control--visible { @apply
   w-10
 }
 
-.list-item-input__checkbox { @apply
+.p-list-item-input__checkbox { @apply
   justify-center
   items-start
   sm:items-center

--- a/src/components/ListItemInput/PListItemInput.vue
+++ b/src/components/ListItemInput/PListItemInput.vue
@@ -1,12 +1,12 @@
 <template>
   <PListItem class="p-list-item-input" v-on="{ mouseenter, mouseleave }">
-    <div class="p-list-item-input__control" :class="classes.control" @click.stop>
+    <div class="p-list-item-input__control" :class="classes.control">
       <label class="p-list-item-input__checkbox">
         <PCheckbox v-model="model" v-bind="{ value, disabled }" />
       </label>
     </div>
 
-    <div class="p-list-item-input__content">
+    <div class="p-list-item-input__content" v-on="{ click }">
       <slot />
     </div>
   </PListItem>
@@ -27,6 +27,7 @@
 
   const emit = defineEmits<{
     (event: 'update:selected', value: Selected): void,
+    (event: 'click', value: unknown): void,
   }>()
 
   const model = computed({
@@ -66,6 +67,12 @@
   function mouseleave(): void {
     if (!props.disabled) {
       hover.value = false
+    }
+  }
+
+  function click(): void {
+    if (!props.disabled) {
+      emit('click', props.value)
     }
   }
 </script>


### PR DESCRIPTION
now developers can have a @click event on <p-list-item-input /> that will not get triggered by selection change

this PR also fixes some incorrect BEM classes on `p-list-item` and `p-list-item-input`