### PR TITLE
Chore: Fix extraneous non-props warning in PTabs

### DIFF
--- a/src/components/Tabs/PTabs.vue
+++ b/src/components/Tabs/PTabs.vue
@@ -8,7 +8,7 @@
       </PTabNavigation>
     </template>
     <template v-else>
-      <PTabSelect v-model:selected="selected" class="p-tabs--mobile" :tabs="tabs">
+      <PTabSelect v-model:selected="selected" :tabs="tabs">
         <template v-for="(index, name) in $slots" #[name]="data">
           <slot :name="name" v-bind="data" />
         </template>


### PR DESCRIPTION
# Description
The class that was added to PTabSelect was causing a warning because that component uses fragments. Seems like it shouldn't be a fragment component but rather than refactor I'm removing the unused class that was causing the warning. 

![image](https://user-images.githubusercontent.com/6200442/228337794-226c4220-f117-47bb-9ba0-ce0e6bb8c1c7.png)
