### PR TITLE
Enhancement: Add `items-start` to `.p-key-value`

### DIFF
--- a/src/components/KeyValue/PKeyValue.vue
+++ b/src/components/KeyValue/PKeyValue.vue
@@ -73,6 +73,7 @@
   flex-col
   gap-y-1
   leading-6
+  items-start
 }
 
 .p-key-value__label {
@@ -94,9 +95,6 @@
   @apply
   text-xs
   leading-4
-  flex
-  flex-col
-  gap-y-1
   font-normal
 }
 


### PR DESCRIPTION
# Description
`p-key-value` is `flex` and `flex-col`. Which means by default the flex children expand to fill the width. This means that the rect of the label and value are displayed like block elements. This can cause issues when the content of these slots has hover or click events because those events will be triggered in the empty space. 

Side quest: I also removed the duplicate styles from the `--alt` class that were already specified in the block class. 

Before
![image](https://user-images.githubusercontent.com/6200442/228905691-012afd7e-97b2-4510-b290-a74fe6a6bc53.png)

After
![image](https://user-images.githubusercontent.com/6200442/228905766-c41a140e-902b-4329-ab03-4a50281a7577.png)
