### PR TITLE
Enhancement: Expose target and content refs for PPopOver

### DIFF
--- a/src/components/PopOver/PPopOver.vue
+++ b/src/components/PopOver/PPopOver.vue
@@ -37,20 +37,20 @@
   }>()
 
   const visible = ref(false)
+  const attrs = useAttrs()
+  const container = ref<Element>()
+
+  const placements = computed(() => Array.isArray(props.placement) ? props.placement : [props.placement])
+  const { target, content, styles } = useMostVisiblePositionStyles(placements, { container })
 
   defineExpose({
     open,
     close,
     toggle,
     visible,
+    target,
+    content,
   })
-
-  const attrs = useAttrs()
-
-  const container = ref<Element>()
-
-  const placements = computed(() => Array.isArray(props.placement) ? props.placement : [props.placement])
-  const { target, content, styles } = useMostVisiblePositionStyles(placements, { container })
 
   onMounted(() => {
     if (props.autoClose) {


### PR DESCRIPTION
# Description
This makes it easier for a developer to implement logic around the content of a popover without creating new refs at implementation