### PR TITLE
Enhancement: Add margin to timeline date when stacked

### DIFF
--- a/src/components/Timeline/PTimelineItem.vue
+++ b/src/components/Timeline/PTimelineItem.vue
@@ -101,6 +101,10 @@
   min-w-0
 }
 
+.p-timeline-item__date:empty { @apply
+  hidden
+}
+
 .p-timeline-item__date {
   grid-area: date;
 }

--- a/src/components/Timeline/PTimelineItem.vue
+++ b/src/components/Timeline/PTimelineItem.vue
@@ -164,6 +164,12 @@
 }
 
 .p-timeline-item__date--stacked-left,
+.p-timeline-item__date--stacked-center,
+.p-timeline-item__date--stacked-right { @apply
+  mb-[var(--gap)]
+}
+
+.p-timeline-item__date--stacked-left,
 .p-timeline-item__content--stacked-left { @apply
   text-left
 }


### PR DESCRIPTION
# Description
The date and content had no gap when stacked. Adds some margin to the date to be consistent with the `--p-timeline-item-gap` custom property