### PR TITLE
Bugfix: Remove overscroll-contain on PCodeInput

### DIFF
--- a/src/components/CodeInput/PCodeInput.vue
+++ b/src/components/CodeInput/PCodeInput.vue
@@ -146,7 +146,6 @@
   justify-start
   min-h-[inherit]
   overflow-auto
-  overscroll-contain
   p-0
   relative
   rounded-lg


### PR DESCRIPTION
Contained overscroll is only really nice for small inputs; large inputs capture too much passive scrolling and lead to a poor UX if they don't pass the event up the chain.