### PR TITLE
BugFix: background on p-tooltip

### DIFF
--- a/src/components/Tooltip/PTooltip.vue
+++ b/src/components/Tooltip/PTooltip.vue
@@ -99,6 +99,7 @@
   text-sm
   rounded-sm
   border-[1px]
-  border-slate-600
+  border-background-400
+  dark:border-foreground-200
 }
 </style>


### PR DESCRIPTION
simply using the non-theme aware color

before: (only noticeable on light-mode)
<img width="232" alt="Screenshot 2023-04-13 at 9 02 40 AM" src="https://user-images.githubusercontent.com/6098901/231783928-bcefdca7-1f81-4a7a-9352-9de524bb08c5.png">

after:
<img width="250" alt="Screenshot 2023-04-13 at 9 02 52 AM" src="https://user-images.githubusercontent.com/6098901/231784025-48dac626-ef06-4b90-9214-0c4c8592dcf8.png">
<img width="238" alt="Screenshot 2023-04-13 at 9 02 59 AM" src="https://user-images.githubusercontent.com/6098901/231784028-b478c5ab-c09b-406c-bb5a-95edc78088ee.png">

