### PR TITLE
BugFix: PTabs key bound to tab object

### DIFF
--- a/src/components/Tabs/PTabs.vue
+++ b/src/components/Tabs/PTabs.vue
@@ -14,7 +14,7 @@
         </template>
       </PTabSelect>
     </template>
-    <template v-for="tab in tabs" :key="tab">
+    <template v-for="tab in tabs" :key="tab.label">
       <template v-if="selected === tab.label">
         <section
           :id="`${kebabCase(tab.label)}-content`"


### PR DESCRIPTION
# Description
When rendering tabs the entire tab object is being used as the `key`. This means tabs are not reused if the tabs array is updated. Switching the key to be the tab label to enable vue to accurately track tabs. 