### PR TITLE
reduce the size of pTab

### DIFF
--- a/src/components/Tab/PTab.vue
+++ b/src/components/Tab/PTab.vue
@@ -20,7 +20,7 @@
 
 <style>
 .p-tab { @apply
-  px-10
+  px-5
   py-4
   text-center
   font-medium


### PR DESCRIPTION
The tabs on the Flow Run Page are falling off the viewport.

Currently:
<img width="865" alt="image" src="https://user-images.githubusercontent.com/6776415/233160926-117b9cc7-7d05-4ca5-acf3-e0942dfc94ee.png">


This shrinks them down so they look like this:

https://user-images.githubusercontent.com/6776415/233161085-82acc9d8-522c-47a0-92f7-af616ae6e185.mov

