### PR TITLE
Enhancement: `PCodeInput` placeholder and line numbers

### DIFF
--- a/demo/sections/components/CodeInput.vue
+++ b/demo/sections/components/CodeInput.vue
@@ -151,5 +151,6 @@ And sighs that waft to heav'n
   max-w-full
   min-h-[200px]
   min-w-[200px]
+  max-h-96
 }
 </style>

--- a/demo/sections/components/CodeInput.vue
+++ b/demo/sections/components/CodeInput.vue
@@ -22,10 +22,21 @@
       <div>
         <p-checkbox v-model="showLineNumbers" label="Show line numbers" />
       </div>
+
+      <DemoState v-model:state="exampleState" v-model:disabled="disabled" />
     </template>
 
     <template #placeholder>
-      <PCodeInput v-model="placeholderInput" :min-lines="25" :placeholder="JSON.stringify([1, 2, 3, 4], undefined, 2)" class="code-input__input" :show-line-numbers="showLineNumbers" />
+      <p-label label="State demo">
+        <PCodeInput
+          v-model="placeholderInput"
+          :state="exampleState"
+          :min-lines="25"
+          :placeholder="JSON.stringify([1, 2, 3, 4], undefined, 2)"
+          class="code-input__input"
+          :show-line-numbers="showLineNumbers"
+        />
+      </p-label>
     </template>
 
     <template #unstyled>
@@ -52,8 +63,13 @@
 // in a <\/script> tag (try removing the one in this comment lol)
   import { PCode } from '@/components'
   import PCodeInput from '@/components/CodeInput/PCodeInput.vue'
+  import { State } from '@/types'
   import { ref } from 'vue'
   import ComponentPage from '@/demo/components/ComponentPage.vue'
+  import DemoState from '@/demo/components/DemoState.vue'
+
+  const exampleState = ref<State>()
+  const disabled = ref(false)
 
   const showLineNumbers = ref(true)
 

--- a/demo/sections/components/CodeInput.vue
+++ b/demo/sections/components/CodeInput.vue
@@ -149,7 +149,7 @@ And sighs that waft to heav'n
 .code-input__input { @apply
   resize
   max-w-full
-  min-h-[200px]
+  min-h-[48px]
   min-w-[200px]
   max-h-96
 }

--- a/demo/sections/components/CodeInput.vue
+++ b/demo/sections/components/CodeInput.vue
@@ -27,7 +27,7 @@
     </template>
 
     <template #placeholder>
-      <p-label label="State demo">
+      <p-label label="Stateful demo">
         <PCodeInput
           v-model="placeholderInput"
           :state="exampleState"
@@ -35,6 +35,7 @@
           :placeholder="JSON.stringify([1, 2, 3, 4], undefined, 2)"
           class="code-input__input"
           :show-line-numbers="showLineNumbers"
+          :disabled="disabled"
         />
       </p-label>
     </template>

--- a/demo/sections/components/CodeInput.vue
+++ b/demo/sections/components/CodeInput.vue
@@ -133,8 +133,8 @@ And sighs that waft to heav'n
   resize
   max-w-full
   h-64
-  /* min-h-[200px]
-  min-w-[200px] */
+  min-h-[200px]
+  min-w-[200px]
 }
 
 .code-input__input-textarea { @apply

--- a/demo/sections/components/CodeInput.vue
+++ b/demo/sections/components/CodeInput.vue
@@ -25,7 +25,7 @@
     </template>
 
     <template #placeholder>
-      <PCodeInput v-model="placeholderInput" :placeholder="JSON.stringify([1, 2, 3, 4], undefined, 2)" class="code-input__input" :show-line-numbers="showLineNumbers" />
+      <PCodeInput v-model="placeholderInput" :min-lines="25" :placeholder="JSON.stringify([1, 2, 3, 4], undefined, 2)" class="code-input__input" :show-line-numbers="showLineNumbers" />
     </template>
 
     <template #unstyled>

--- a/demo/sections/components/CodeInput.vue
+++ b/demo/sections/components/CodeInput.vue
@@ -2,6 +2,7 @@
   <ComponentPage
     title="CodeInput"
     :demos="[
+      { title: 'Placeholder' },
       { title: 'Unstyled' },
       { title: 'Markdown' },
       { title: 'Python' },
@@ -21,6 +22,10 @@
       <div>
         <p-checkbox v-model="showLineNumbers" label="Show line numbers" />
       </div>
+    </template>
+
+    <template #placeholder>
+      <PCodeInput v-model="placeholderInput" :placeholder="JSON.stringify([1, 2, 3, 4], undefined, 2)" class="code-input__input" :show-line-numbers="showLineNumbers" />
     </template>
 
     <template #unstyled>
@@ -51,6 +56,8 @@
   import ComponentPage from '@/demo/components/ComponentPage.vue'
 
   const showLineNumbers = ref(true)
+
+  const placeholderInput = ref()
 
   const vueInput = ref(`<template>
   <div class="p-card">
@@ -126,8 +133,8 @@ And sighs that waft to heav'n
   resize
   max-w-full
   h-64
-  min-h-[200px]
-  min-w-[200px]
+  /* min-h-[200px]
+  min-w-[200px] */
 }
 
 .code-input__input-textarea { @apply

--- a/demo/sections/components/CodeInput.vue
+++ b/demo/sections/components/CodeInput.vue
@@ -2,7 +2,7 @@
   <ComponentPage
     title="CodeInput"
     :demos="[
-      { title: 'Placeholder' },
+      { title: 'Stateful' },
       { title: 'Unstyled' },
       { title: 'Markdown' },
       { title: 'Python' },
@@ -26,13 +26,13 @@
       <DemoState v-model:state="exampleState" v-model:disabled="disabled" />
     </template>
 
-    <template #placeholder>
-      <p-label label="Stateful demo">
+    <template #stateful>
+      <p-label label="Code input label">
         <PCodeInput
           v-model="placeholderInput"
           :state="exampleState"
           :min-lines="25"
-          :placeholder="JSON.stringify([1, 2, 3, 4], undefined, 2)"
+          :placeholder="markdownInput"
           class="code-input__input"
           :show-line-numbers="showLineNumbers"
           :disabled="disabled"

--- a/demo/sections/components/CodeInput.vue
+++ b/demo/sections/components/CodeInput.vue
@@ -41,7 +41,7 @@
     </template>
 
     <template #long-lines>
-      <PCodeHighlight :text="long" lang="md" :show-line-numbers="showLineNumbers" />
+      <PCodeInput v-model="longInput" lang="md" :show-line-numbers="showLineNumbers" />
     </template>
   </ComponentPage>
 </template>
@@ -124,7 +124,7 @@ And sighs that waft to heav'n
  *[Alexander Pope](https://www.poetryfoundation.org/poems/44892/eloisa-to-abelard)*
 `)
 
-  const long = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+  const longInput = ref('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.')
 </script>
 
 <style>
@@ -132,16 +132,7 @@ And sighs that waft to heav'n
 .code-input__input { @apply
   resize
   max-w-full
-  h-64
   min-h-[200px]
   min-w-[200px]
-}
-
-.code-input__input-textarea { @apply
-  bg-background
-  text-foreground
-  block
-  my-2
-  w-full
 }
 </style>

--- a/src/components/CodeInput/PCodeInput.vue
+++ b/src/components/CodeInput/PCodeInput.vue
@@ -143,7 +143,8 @@
 
 <style>
 .p-code-input {
-  --gap: var(--p-code-input-gap, 0.5rem);
+  --gap-x: var(--p-code-input-gap-x, 0.5rem);
+  --gap-y: var(--p-code-input-gap-y, 1rem);
 }
 
 .p-code-input,
@@ -182,8 +183,8 @@
   dark:border-foreground-200
   grow-0
   overflow-hidden
-  px-[var(--gap)]
-  py-4
+  px-[var(--gap-x)]
+  py-[var(--gap-y)]
   relative
   rounded-r-none
   self-stretch
@@ -204,7 +205,7 @@
   min-h-[inherit]
   overflow-auto
   p-0
-  pt-4
+  pt-[var(--gap-y)]
   relative
   rounded-lg
   self-stretch
@@ -220,7 +221,7 @@
   min-w-full
   overflow-hidden
   p-0
-  px-[var(--gap)]
+  px-[var(--gap-x)]
   resize-none
   text-transparent
   whitespace-pre
@@ -243,8 +244,8 @@
   overflow-hidden
   p-0
   pointer-events-none
-  px-[var(--gap)]
-  pt-4
+  px-[var(--gap-x)]
+  pt-[var(--gap-y)]
   select-none
   text-foreground
   top-0

--- a/src/components/CodeInput/PCodeInput.vue
+++ b/src/components/CodeInput/PCodeInput.vue
@@ -53,7 +53,7 @@
   import { SupportedLanguage } from '@/types/codeHighlight'
 
   const props = defineProps<{
-    modelValue?: string | null | undefined,
+    modelValue?: string | null,
     lang?: SupportedLanguage,
     showLineNumbers?: boolean,
     placeholder?: string,

--- a/src/components/CodeInput/PCodeInput.vue
+++ b/src/components/CodeInput/PCodeInput.vue
@@ -31,12 +31,13 @@
             :lang="lang"
             :text="internalValue"
             class="p-code-input__view"
+            :style="styles.view"
             v-bind="ctrlAttrs"
           />
         </template>
 
         <template v-else>
-          <PCode class="p-code-input__view" v-bind="ctrlAttrs">
+          <PCode class="p-code-input__view" :style="styles.view" v-bind="ctrlAttrs">
             {{ internalValue }}
           </PCode>
         </template>
@@ -109,9 +110,10 @@
   }))
 
   const updateTextAreaWidth = (): void => {
-    console.log('updateTextAreaWidth')
     if (textarea.value && source.value) {
-      textAreaWidth.value = Math.max(textarea.value.scrollWidth, source.value.scrollWidth)
+      const { scrollWidth: sourceScrollWidth, clientWidth: sourceClientWidth } = source.value
+      const { scrollWidth: textareaScrollWidth, clientWidth: textareaClientWidth } = textarea.value
+      textAreaWidth.value = Math.max(textareaScrollWidth, sourceScrollWidth, sourceClientWidth, textareaClientWidth)
     }
   }
 
@@ -125,6 +127,10 @@
   const styles = computed(() => {
     return {
       textarea: {
+        height: `${lineHeight.value * lines.value}px`,
+        width: `${textAreaWidth.value}px`,
+      },
+      view: {
         height: `${lineHeight.value * lines.value}px`,
         width: `${textAreaWidth.value}px`,
       },
@@ -146,10 +152,16 @@
 .p-code-input,
 .p-code-input__view,
 .p-code-input__control,
-.p-code-input__textarea {
+.p-code-input__textarea,
+.p-code-input__line-numbers-wrapper {
   font-size: inherit;
   font-family: inherit;
   line-height: inherit;
+}
+
+.p-code-input__control  {
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
 }
 
 .p-code-input__textarea,
@@ -168,13 +180,17 @@
 }
 
 .p-code-input__line-numbers-wrapper { @apply
+  border-background-400
+  border-r
+  dark:border-foreground-200
   grow-0
+  overflow-hidden
   h-full
   max-h-full
-  overflow-hidden
   px-[var(--gap)]
   py-4
   relative
+  rounded-r-none
   self-start
   shrink-0
   w-min
@@ -192,18 +208,11 @@
   min-h-[inherit]
   overflow-auto
   p-0
-  py-4
+  pt-4
   relative
   rounded-lg
   self-stretch
   z-[1]
-}
-
-.p-code-input__control--show-line-numbers { @apply
-  border-background-400
-  border-l
-  dark:border-foreground-200
-  rounded-l-none
 }
 
 .p-code-input__textarea { @apply
@@ -235,7 +244,7 @@
   p-0
   pointer-events-none
   px-[var(--gap)]
-  py-4
+  pt-4
   select-none
   text-foreground
   top-0

--- a/src/components/CodeInput/PCodeInput.vue
+++ b/src/components/CodeInput/PCodeInput.vue
@@ -194,6 +194,11 @@
   z-0
 }
 
+.p-code-input__textarea::selection { @apply
+  bg-foreground-200
+  bg-opacity-50
+}
+
 .p-code-input__textarea-view-container { @apply
   min-h-full
   min-w-full

--- a/src/components/CodeInput/PCodeInput.vue
+++ b/src/components/CodeInput/PCodeInput.vue
@@ -19,7 +19,7 @@
             spellcheck="false"
             class="p-code-input__textarea"
             :placeholder="placeholder"
-            :rows="rows"
+            :rows="lines"
             :class="classes.textArea"
             v-bind="ctrlAttrs"
           />
@@ -67,19 +67,19 @@
   const textarea = ref()
   const { source, target } = useScrollLinking()
 
+  const lineSplitRegex = /\r|\r\n|\n/
   const valueLines = computed(() => {
     if (internalValue.value !== '') {
-      return internalValue.value.split(/\r|\r\n|\n/)
+      return internalValue.value.split(lineSplitRegex)
     }
 
     if (props.placeholder) {
-      return props.placeholder.split(/\r|\r\n|\n/)
+      return props.placeholder.split(lineSplitRegex)
     }
 
     return []
   })
   const lines = computed(() => Math.max(valueLines.value.length, props.minLines ?? 1))
-  const rows = computed(() => valueLines.value.length)
 
   const internalValue = computed({
     get() {

--- a/src/components/CodeInput/PCodeInput.vue
+++ b/src/components/CodeInput/PCodeInput.vue
@@ -182,8 +182,6 @@
   dark:border-foreground-200
   grow-0
   overflow-hidden
-  h-full
-  max-h-full
   px-[var(--gap)]
   py-4
   relative

--- a/src/components/CodeInput/PCodeInput.vue
+++ b/src/components/CodeInput/PCodeInput.vue
@@ -23,7 +23,6 @@
           :style="styles.textarea"
           v-bind="ctrlAttrs"
         />
-        <!-- @input="updateViewWidth" -->
 
         <template v-if="lang">
           <PCodeHighlight
@@ -46,8 +45,8 @@
 </template>
 
 <script lang="ts" setup>
-  import { useResizeObserver, useComputedStyle } from '@prefecthq/vue-compositions'
-  import { computed, onMounted, ref } from 'vue'
+  import { useComputedStyle } from '@prefecthq/vue-compositions'
+  import { computed, ref } from 'vue'
   import { PCode, PCodeHighlight, PLineNumbers } from '@/components'
   import { useScrollLinking } from '@/compositions'
   import { SupportedLanguage } from '@/types/codeHighlight'
@@ -68,7 +67,6 @@
   const textareaStyle = useComputedStyle(textarea)
 
   const { source, target } = useScrollLinking()
-  const viewWidth = ref(0)
 
   const lineSplitRegex = /\r|\r\n|\n/
   const valueLines = computed(() => {
@@ -125,14 +123,6 @@
       textarea.value.focus()
     }
   }
-
-  // const { observe } = useResizeObserver(updateViewWidth)
-
-  // onMounted(() => {
-  //   observe(textarea)
-  //   observe(source)
-  //   // updateViewWidth()
-  // })
 </script>
 
 <style>

--- a/src/components/CodeInput/PCodeInput.vue
+++ b/src/components/CodeInput/PCodeInput.vue
@@ -139,6 +139,10 @@
 </script>
 
 <style>
+.p-code-input {
+  --gap: var(--p-code-input-gap, 0.5rem);
+}
+
 .p-code-input,
 .p-code-input__view,
 .p-code-input__control,
@@ -168,7 +172,7 @@
   h-full
   max-h-full
   overflow-hidden
-  px-2
+  px-[var(--gap)]
   py-4
   relative
   self-start
@@ -211,6 +215,7 @@
   min-w-full
   overflow-hidden
   p-0
+  px-[var(--gap)]
   resize-none
   text-transparent
   whitespace-pre
@@ -229,6 +234,7 @@
   overflow-hidden
   p-0
   pointer-events-none
+  px-[var(--gap)]
   py-4
   select-none
   text-foreground

--- a/src/components/CodeInput/PCodeInput.vue
+++ b/src/components/CodeInput/PCodeInput.vue
@@ -53,7 +53,7 @@
   import { SupportedLanguage } from '@/types/codeHighlight'
 
   const props = defineProps<{
-    modelValue?: string | null,
+    modelValue: string | null | undefined,
     lang?: SupportedLanguage,
     showLineNumbers?: boolean,
     placeholder?: string,

--- a/src/components/CodeInput/PCodeInput.vue
+++ b/src/components/CodeInput/PCodeInput.vue
@@ -217,6 +217,7 @@
   bg-transparent
   overflow-hidden
   min-h-full
+  select-none
   p-0
   text-foreground
 }

--- a/src/components/CodeInput/PCodeInput.vue
+++ b/src/components/CodeInput/PCodeInput.vue
@@ -18,6 +18,7 @@
             v-model="internalValue"
             spellcheck="false"
             class="p-code-input__textarea"
+            :placeholder="placeholder"
             :rows="rows"
             :class="classes.textArea"
             v-bind="ctrlAttrs"
@@ -52,9 +53,11 @@
   import { SupportedLanguage } from '@/types/codeHighlight'
 
   const props = defineProps<{
-    modelValue: string | null | undefined,
+    modelValue?: string | null | undefined,
     lang?: SupportedLanguage,
     showLineNumbers?: boolean,
+    placeholder?: string,
+    minLines?: number,
   }>()
 
   const emit = defineEmits<{
@@ -64,8 +67,18 @@
   const textarea = ref()
   const { source, target } = useScrollLinking()
 
-  const valueLines = computed(() => internalValue.value.split(/\r|\r\n|\n/))
-  const lines = computed(() => Math.max(valueLines.value.length, 1))
+  const valueLines = computed(() => {
+    if (internalValue.value !== '') {
+      return internalValue.value.split(/\r|\r\n|\n/)
+    }
+
+    if (props.placeholder) {
+      return props.placeholder.split(/\r|\r\n|\n/)
+    }
+
+    return []
+  })
+  const lines = computed(() => Math.max(valueLines.value.length, props.minLines ?? 1))
   const rows = computed(() => valueLines.value.length)
 
   const internalValue = computed({
@@ -149,6 +162,9 @@
   p-0
   relative
   rounded-lg
+  pl-4
+  pt-4
+  pr-4
   z-[1]
 }
 
@@ -166,10 +182,9 @@
   box-content
   caret-foreground-500
   grow
-  h-min
   left-0
   m-0
-  min-h-[1.5rem]
+  min-h-full
   min-w-[1.5rem]
   overflow-hidden
   p-0
@@ -183,10 +198,9 @@
 }
 
 .p-code-input__textarea-view-container { @apply
+  min-h-full
+  min-w-full
   relative
-  ml-4
-  mt-4
-  pr-4
 }
 
 .p-code-input__view-container { @apply

--- a/src/components/CodeInput/PCodeInput.vue
+++ b/src/components/CodeInput/PCodeInput.vue
@@ -22,8 +22,8 @@
           :class="classes.textArea"
           :style="styles.textarea"
           v-bind="ctrlAttrs"
-          @input="updateViewWidth"
         />
+        <!-- @input="updateViewWidth" -->
 
         <template v-if="lang">
           <PCodeHighlight
@@ -113,20 +113,12 @@
     return {
       textarea: {
         height: `${lineHeight.value * lines.value}px`,
-        width: `${viewWidth.value}px`,
       },
       view: {
         height: `${lineHeight.value * lines.value}px`,
-        width: `${viewWidth.value}px`,
       },
     }
   })
-
-  const updateViewWidth = (): void => {
-    if (textarea.value && source.value) {
-      viewWidth.value = Math.max(textarea.value.scrollWidth, source.value.scrollWidth)
-    }
-  }
 
   const handleInputControlClick = (): void => {
     if (textarea.value) {
@@ -134,13 +126,13 @@
     }
   }
 
-  const { observe } = useResizeObserver(updateViewWidth)
+  // const { observe } = useResizeObserver(updateViewWidth)
 
-  onMounted(() => {
-    observe(textarea)
-    observe(source)
-    updateViewWidth()
-  })
+  // onMounted(() => {
+  //   observe(textarea)
+  //   observe(source)
+  //   // updateViewWidth()
+  // })
 </script>
 
 <style>
@@ -243,6 +235,7 @@
   bg-transparent
   left-0
   min-h-full
+  min-w-full
   overflow-hidden
   p-0
   pointer-events-none

--- a/src/components/CodeInput/PCodeInput.vue
+++ b/src/components/CodeInput/PCodeInput.vue
@@ -227,6 +227,10 @@
   whitespace-pre
 }
 
+.p-code-input__textarea:disabled { @apply
+  cursor-not-allowed
+}
+
 .p-code-input__textarea::selection { @apply
   bg-foreground-200
   bg-opacity-50

--- a/src/components/CodeInput/PCodeInput.vue
+++ b/src/components/CodeInput/PCodeInput.vue
@@ -46,7 +46,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { useResizeObserver } from '@prefecthq/vue-compositions'
+  import { useResizeObserver, useComputedStyle } from '@prefecthq/vue-compositions'
   import { computed, onMounted, ref } from 'vue'
   import { PCode, PCodeHighlight, PLineNumbers } from '@/components'
   import { useScrollLinking } from '@/compositions'
@@ -65,6 +65,8 @@
   }>()
 
   const textarea = ref()
+  const textareaStyle = useComputedStyle(textarea)
+
   const { source, target } = useScrollLinking()
   const viewWidth = ref(0)
 
@@ -82,8 +84,8 @@
   })
   const lines = computed(() => Math.max(valueLines.value.length, props.minLines ?? 1))
   const lineHeight = computed(() => {
-    if (textarea.value) {
-      return parseFloat(getComputedStyle(textarea.value).lineHeight)
+    if (textareaStyle.value) {
+      return parseFloat(textareaStyle.value.lineHeight)
     }
 
     return 0

--- a/src/components/CodeInput/PCodeInput.vue
+++ b/src/components/CodeInput/PCodeInput.vue
@@ -111,9 +111,7 @@
 
   const updateTextAreaWidth = (): void => {
     if (textarea.value && source.value) {
-      const { scrollWidth: sourceScrollWidth, clientWidth: sourceClientWidth } = source.value
-      const { scrollWidth: textareaScrollWidth, clientWidth: textareaClientWidth } = textarea.value
-      textAreaWidth.value = Math.max(textareaScrollWidth, sourceScrollWidth, sourceClientWidth, textareaClientWidth)
+      textAreaWidth.value = Math.max(textarea.value.scrollWidth, source.value.scrollWidth)
     }
   }
 

--- a/src/components/CodeInput/PCodeInput.vue
+++ b/src/components/CodeInput/PCodeInput.vue
@@ -128,7 +128,7 @@
   bg-background-500
   font-mono
   min-h-[100px]
-  overflow-auto
+  overflow-hidden
   p-0
   relative
 }
@@ -159,12 +159,9 @@
   justify-start
   min-h-[inherit]
   overflow-auto
-  p-0
   relative
   rounded-lg
-  pl-4
-  pt-4
-  pr-4
+  p-4
   z-[1]
 }
 
@@ -185,7 +182,7 @@
   left-0
   m-0
   min-h-full
-  min-w-[1.5rem]
+  min-w-full
   overflow-hidden
   p-0
   resize-none
@@ -207,6 +204,7 @@
   overflow-hidden
   pointer-events-none
   min-h-full
+  min-w-full
   z-0
 }
 

--- a/src/components/CodeInput/PCodeInput.vue
+++ b/src/components/CodeInput/PCodeInput.vue
@@ -119,6 +119,7 @@
   onMounted(() => {
     observe(textarea)
     observe(source)
+    updateTextAreaWidth()
   })
 
   const styles = computed(() => {
@@ -200,6 +201,7 @@
   cursor-text
   grow
   h-full
+  max-h-[inherit]
   min-h-[inherit]
   overflow-auto
   p-0

--- a/src/components/CodeInput/PCodeInput.vue
+++ b/src/components/CodeInput/PCodeInput.vue
@@ -22,8 +22,7 @@
           :class="classes.textArea"
           :style="styles.textarea"
           v-bind="ctrlAttrs"
-          @keyup="updateTextAreaWidth"
-          @paste="updateTextAreaWidth"
+          @input="updateTextAreaWidth"
         />
 
         <template v-if="lang">
@@ -189,7 +188,7 @@
   py-4
   relative
   rounded-r-none
-  self-start
+  self-stretch
   shrink-0
   w-min
 }

--- a/src/components/CodeInput/PCodeInput.vue
+++ b/src/components/CodeInput/PCodeInput.vue
@@ -22,7 +22,7 @@
           :class="classes.textArea"
           :style="styles.textarea"
           v-bind="ctrlAttrs"
-          @input="updateTextAreaWidth"
+          @input="updateViewWidth"
         />
 
         <template v-if="lang">
@@ -66,6 +66,7 @@
 
   const textarea = ref()
   const { source, target } = useScrollLinking()
+  const viewWidth = ref(0)
 
   const lineSplitRegex = /\r|\r\n|\n/
   const valueLines = computed(() => {
@@ -88,8 +89,6 @@
     return 0
   })
 
-  const textAreaWidth = ref(0)
-
   const internalValue = computed({
     get() {
       return props.modelValue ?? ''
@@ -108,38 +107,38 @@
     },
   }))
 
-  const updateTextAreaWidth = (): void => {
-    if (textarea.value && source.value) {
-      textAreaWidth.value = Math.max(textarea.value.scrollWidth, source.value.scrollWidth)
-    }
-  }
-
-  const { observe } = useResizeObserver(updateTextAreaWidth)
-
-  onMounted(() => {
-    observe(textarea)
-    observe(source)
-    updateTextAreaWidth()
-  })
-
   const styles = computed(() => {
     return {
       textarea: {
         height: `${lineHeight.value * lines.value}px`,
-        width: `${textAreaWidth.value}px`,
+        width: `${viewWidth.value}px`,
       },
       view: {
         height: `${lineHeight.value * lines.value}px`,
-        width: `${textAreaWidth.value}px`,
+        width: `${viewWidth.value}px`,
       },
     }
   })
+
+  const updateViewWidth = (): void => {
+    if (textarea.value && source.value) {
+      viewWidth.value = Math.max(textarea.value.scrollWidth, source.value.scrollWidth)
+    }
+  }
 
   const handleInputControlClick = (): void => {
     if (textarea.value) {
       textarea.value.focus()
     }
   }
+
+  const { observe } = useResizeObserver(updateViewWidth)
+
+  onMounted(() => {
+    observe(textarea)
+    observe(source)
+    updateViewWidth()
+  })
 </script>
 
 <style>


### PR DESCRIPTION
These changes enhance the functionality of `PCodeInput` by:

- introducing the ability to specify a minimum number of lines to display. 
- fixing a bug where the placeholder text was limited to a small area of the input 
- updating the line number calculation to take placeholder text into account

I removed several wrapper elements and streamlined some of the CSS. The input now uses a combination of resize observers and input handlers instead of relying on CSS for dynamic sizing. As a result, the textarea underlay and code view overlay will now fill an appropriate amount of space (previously they shrunk to fit their contents).

These changes (hopefully) provide a better user experience when interacting with the input with text that doesn't span the entire width in LTR mode as the cursor will now move to the correct line.