### PR TITLE
Bugfix: Use esm path to import icons

### DIFF
--- a/src/components/Icon/PIcon.vue
+++ b/src/components/Icon/PIcon.vue
@@ -4,8 +4,8 @@
 
 
 <script lang="ts" setup>
-  import * as outlinedHeroIcons from '@heroicons/vue/24/outline'
-  import * as solidHeroIcons from '@heroicons/vue/24/solid'
+  import * as outlinedHeroIcons from '@heroicons/vue/24/outline/esm/index'
+  import * as solidHeroIcons from '@heroicons/vue/24/solid/esm/index'
   import { computed } from 'vue'
   import * as prefectIcons from '@/components/Icon/icons'
   import { Icon, PrefectIcon } from '@/types/icon'


### PR DESCRIPTION
#742 bumped our heroicons version to latest, which contains a bug in how modules are resolved within the package. This means that downstream consumers of our package are getting a commonjs bundle instead of an esm-compatible one. A fix has been merged to the upstream but I'm not sure of their release cadence so we can use this as a shim in the meantime.