### PR TITLE
Bugfix: `PButton` flat and inset styles

### DIFF
--- a/src/components/Button/PButton.vue
+++ b/src/components/Button/PButton.vue
@@ -191,8 +191,8 @@
 
 .p-button--flat { @apply
   bg-transparent
+  shadow-none
 }
-
 .p-button--flat:not(.p-button--disabled) { @apply
   hover:bg-background-400
   dark:hover:bg-background-500

--- a/src/components/Button/PButton.vue
+++ b/src/components/Button/PButton.vue
@@ -186,11 +186,11 @@
 }
 .p-button--inset:not(.p-button--disabled) { @apply
   hover:bg-background-400
-  dark:hover:bg-background-500
+  dark:hover:bg-background-600
 }
 
 .p-button--flat { @apply
-  bg-background
+  bg-transparent
 }
 
 .p-button--flat:not(.p-button--disabled) { @apply


### PR DESCRIPTION
This PR fixes an issue where inset buttons had hover styles that matched the background, which made them feel unresponsive. It also makes the flat button actually flat by removing the background and shadow