### PR TITLE
Feature: Truncated list component

### DIFF
--- a/demo/sections/components/ListTruncate.vue
+++ b/demo/sections/components/ListTruncate.vue
@@ -1,0 +1,52 @@
+<template>
+  <ComponentPage
+    title="List Truncate"
+    :demos="demos"
+  >
+    <template #basic>
+      <PListTruncate :items="items">
+        <template #default="{ item }">
+          <div>{{ item.title }}</div>
+        </template>
+      </PListTruncate>
+    </template>
+  </ComponentPage>
+</template>
+
+<script lang="ts" setup>
+  import PListTruncate from '@/components/ListTruncate/PListTruncate.vue'
+  import { ref } from 'vue'
+  import ComponentPage from '@/demo/components/ComponentPage.vue'
+
+  const demos = [
+    { title: 'Basic' },
+    { title: 'Custom button text' },
+    { title: 'Custom increment' },
+    { title: 'Custom decrement' },
+  ]
+
+  const books = [
+    "The Philosopher's Pizza",
+    'A Tale of Two Teapots',
+    'The Great Gastropod',
+    'Pride and Pyrotechnics',
+    'Mystery of the Missing Muffin',
+    'Lord of the Light Bulbs',
+    'Cabbages and Kings: A Culinary Adventure',
+    'Socks and Sorcery',
+    'The Llama at the End of the Universe',
+    'To Grill a Mockingbird',
+    'The Wombat in the Wardrobe',
+    'The Broccoli Chronicles',
+    'Journey to the Center of the Sofa',
+    '20,000 Leeks Under the Sea',
+    'Nineteen Eighty-Fork',
+    'Brave New Whirled Peas',
+    'Gone with the Waffles',
+    'The Secret Life of Potted Plants',
+    'Moonwalking with Penguins: An Arctic Odyssey',
+    'Life, the Universe, and Cupcakes',
+  ]
+
+  const items = ref(Array.from({ length: 20 }, (_, i) => ({ id: i, title: books[i] })))
+</script>

--- a/demo/sections/components/ListTruncate.vue
+++ b/demo/sections/components/ListTruncate.vue
@@ -11,8 +11,8 @@
       </PListTruncate>
     </template>
 
-    <template #custom-button-text>
-      <PListTruncate :items="items" button-text="Load more books">
+    <template #custom-button-label>
+      <PListTruncate :items="items" button-label="Load more books">
         <template #default="{ item }">
           <div>{{ item.title }}</div>
         </template>
@@ -79,7 +79,7 @@
 
   const demos = [
     { title: 'Basic' },
-    { title: 'Custom button text' },
+    { title: 'Custom button label' },
     { title: 'Custom increment' },
     { title: 'Show fewer' },
     { title: 'Async' },

--- a/demo/sections/components/ListTruncate.vue
+++ b/demo/sections/components/ListTruncate.vue
@@ -10,6 +10,44 @@
         </template>
       </PListTruncate>
     </template>
+
+    <template #custom-button-text>
+      <PListTruncate :items="items" button-text="Load more books">
+        <template #default="{ item }">
+          <div>{{ item.title }}</div>
+        </template>
+      </PListTruncate>
+    </template>
+
+    <template #custom-increment>
+      <PListTruncate :items="items" :increment="1">
+        <template #default="{ item }">
+          <div>{{ item.title }}</div>
+        </template>
+      </PListTruncate>
+    </template>
+
+    <template #show-fewer>
+      <PListTruncate :items="items" :decrement="5">
+        <template #default="{ item }">
+          <div>{{ item.title }}</div>
+        </template>
+
+        <template #bottom="{ showLess, canShowLess, canShowMore, showMore }">
+          <template v-if="canShowLess">
+            <p-button class="p-list-truncate__button" size="sm" inset @click="showLess">
+              Show fewer
+            </p-button>
+          </template>
+
+          <template v-if="canShowMore">
+            <p-button class="p-list-truncate__button" size="sm" inset @click="showMore">
+              Show more
+            </p-button>
+          </template>
+        </template>
+      </PListTruncate>
+    </template>
   </ComponentPage>
 </template>
 
@@ -22,7 +60,7 @@
     { title: 'Basic' },
     { title: 'Custom button text' },
     { title: 'Custom increment' },
-    { title: 'Custom decrement' },
+    { title: 'Show fewer' },
   ]
 
   const books = [

--- a/demo/sections/components/ListTruncate.vue
+++ b/demo/sections/components/ListTruncate.vue
@@ -20,7 +20,7 @@
     </template>
 
     <template #custom-increment>
-      <PListTruncate :items="items" :increment="1">
+      <PListTruncate :items="items" :shown="1" :increment="1">
         <template #default="{ item }">
           <div>{{ item.title }}</div>
         </template>

--- a/demo/sections/components/ListTruncate.vue
+++ b/demo/sections/components/ListTruncate.vue
@@ -48,6 +48,27 @@
         </template>
       </PListTruncate>
     </template>
+
+    <template #async>
+      <PListTruncate :items="asyncItems" :shown="Infinity">
+        <template #default="{ item }">
+          <div>{{ item.title }}</div>
+        </template>
+
+        <template #bottom>
+          <p-button
+            v-if="asyncItems.length < items.length"
+            class="p-list-truncate__button"
+            size="sm"
+            :loading="loading"
+            inset
+            @click="loadMore"
+          >
+            Load more
+          </p-button>
+        </template>
+      </PListTruncate>
+    </template>
   </ComponentPage>
 </template>
 
@@ -61,6 +82,7 @@
     { title: 'Custom button text' },
     { title: 'Custom increment' },
     { title: 'Show fewer' },
+    { title: 'Async' },
   ]
 
   const books = [
@@ -87,4 +109,17 @@
   ]
 
   const items = ref(Array.from({ length: 20 }, (_, i) => ({ id: i, title: books[i] })))
+
+  const asyncItems = ref(Array.from({ length: 5 }, (_, i) => ({ id: i, title: books[i] })))
+
+  const loading = ref(false)
+
+  const loadMore = async (): Promise<void> => {
+    loading.value = true
+    await new Promise(resolve => setTimeout(resolve, 2000))
+
+    const startingLength = asyncItems.value.length
+    asyncItems.value = Array.from({ length: startingLength + 5 }, (_, i) => ({ id: i, title: books[i] }))
+    loading.value = false
+  }
 </script>

--- a/demo/sections/components/index.ts
+++ b/demo/sections/components/index.ts
@@ -26,6 +26,7 @@ export const components: Section = {
   label: () => import('./Label.vue'),
   links: () => import('./Links.vue'),
   listItems: () => import('./ListItems.vue'),
+  listTruncate: () => import('./ListTruncate.vue'),
   markdownRenderer: () => import('./MarkdownRenderer.vue'),
   message: () => import('./Message.vue'),
   modals: () => import('./Modals.vue'),

--- a/src/components/ListTruncate/PListTruncate.vue
+++ b/src/components/ListTruncate/PListTruncate.vue
@@ -8,7 +8,7 @@
       <slot name="bottom" v-bind="{ shown, showMore, showLess, canShowMore, canShowLess }">
         <template v-if="canShowMore">
           <p-button class="p-list-truncate__button" size="sm" inset @click="showMore">
-            {{ buttonText ?? 'Show more' }}
+            {{ buttonLabel ?? 'Show more' }}
           </p-button>
         </template>
       </slot>
@@ -24,7 +24,7 @@
     shown?: number,
     increment?: number,
     decrement?: number,
-    buttonText?: string,
+    buttonLabel?: string,
   }>()
 
   const DEFAULT_INCREMENT = 5

--- a/src/components/ListTruncate/PListTruncate.vue
+++ b/src/components/ListTruncate/PListTruncate.vue
@@ -1,0 +1,58 @@
+<template>
+  <p-virtual-scroller :items="shownItems" class="p-list-truncate">
+    <template #default="{ item, index }">
+      <slot v-bind="{ item, index, shown, showMore, showLess, canShowMore, canShowLess }" />
+    </template>
+
+    <template #bottom>
+      <slot name="bottom" v-bind="{ shown, showMore, showLess, canShowMore, canShowLess }">
+        <template v-if="canShowMore">
+          <p-button class="p-list-truncate__button" size="sm" inset @click="showMore">
+            {{ buttonText ?? 'Show more' }}
+          </p-button>
+        </template>
+      </slot>
+    </template>
+  </p-virtual-scroller>
+</template>
+
+<script lang="ts" setup generic="T extends Record<string, any>">
+  import { computed, ref } from 'vue'
+
+  const props = defineProps<{
+    items: T[],
+    shown?: number,
+    increment?: number,
+    decrement?: number,
+    buttonText?: string,
+  }>()
+
+  const DEFAULT_INCREMENT = 5
+
+  const shown = ref(props.shown ?? DEFAULT_INCREMENT)
+
+  const canShowMore = computed(() => props.items.length > shown.value)
+  const canShowLess = computed(() => shown.value > DEFAULT_INCREMENT)
+
+  const shownItems = computed(() => props.items.slice(0, shown.value))
+
+  const showMore = (): void => {
+    shown.value += props.increment ?? DEFAULT_INCREMENT
+  }
+
+  const showLess = (): void => {
+    if (props.decrement) {
+      shown.value -= props.decrement
+      return
+    }
+    shown.value = DEFAULT_INCREMENT
+  }
+</script>
+
+<style>
+.p-list-truncate__button { @apply
+  mt-2
+  text-foreground-200
+  w-full
+}
+</style>

--- a/src/components/ListTruncate/index.ts
+++ b/src/components/ListTruncate/index.ts
@@ -1,0 +1,8 @@
+import { App } from 'vue'
+import PListTruncate from '@/components/ListTruncate/PListTruncate.vue'
+
+const install = (app: App): void => {
+  app.component('PListTruncate', PListTruncate)
+}
+
+export { PListTruncate, install }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -38,6 +38,7 @@ import { PLineNumbers, install as installPLineNumbers } from '@/components/LineN
 import { PLink, install as installPLink } from '@/components/Link'
 import { PListItem, install as installPListItem } from '@/components/ListItem'
 import { PListItemInput, install as installPListItemInput } from '@/components/ListItemInput'
+import { PListTruncate, install as installPListTruncate } from '@/components/ListTruncate'
 import { PLoadingIcon, install as installPLoadingIcon } from '@/components/LoadingIcon'
 import { PMarkdownRenderer, install as installPMarkdownRenderer } from '@/components/MarkdownRenderer'
 import { PMessage, install as installPMessage } from '@/components/Message'
@@ -121,6 +122,7 @@ export {
   PLink,
   PListItem,
   PListItemInput,
+  PListTruncate,
   PLoadingIcon,
   PMarkdownRenderer,
   PMessage,
@@ -215,6 +217,7 @@ export const installs = [
   installPLink,
   installPListItem,
   installPListItemInput,
+  installPListTruncate,
   installPLoadingIcon,
   installPMarkdownRenderer,
   installPMessage,
@@ -299,6 +302,7 @@ declare module '@vue/runtime-core' {
     PLink: typeof PLink,
     PListItem: typeof PListItem,
     PListItemInput: typeof PListItemInput,
+    PListTruncate: typeof PListTruncate,
     PLoadingIcon: typeof PLoadingIcon,
     PMarkdownRenderer: typeof PMarkdownRenderer,
     PMessage: typeof PMessage,


### PR DESCRIPTION
This PR introduces a new utility component, `PTruncatedList`, that allows incrementally showing/hiding an item list. It wraps `PVirtualScroller` and so takes all properties of that component as well as the following:

- `shown` (optional, default `5`) - the number of items shown initially
- `increment` (optional, default `5`) - the number of items added when more items are requested
- `decrement` (optional, default `n - increment`) - the number of items to remove when fewer are requested
- `buttonLabel` (optional, defaults to `Show more`) - a shorthand way of modifying the default button

This component is designed to be used with a pretty simple list but I included a demo to show a more complex asynchronous example.  