### PR TITLE
Bugfix: Drawer close on `esc`

### DIFF
--- a/src/components/Drawer/PDrawer.vue
+++ b/src/components/Drawer/PDrawer.vue
@@ -61,7 +61,7 @@
   const drawerScope = useDrawer(open)
   function closeOnEscape(event: KeyboardEvent): void {
     if (isKeyEvent(keys.escape, event)) {
-      close()
+      drawerScope.close()
     }
   }
   useGlobalEventListener('keyup', closeOnEscape)


### PR DESCRIPTION
TIL `close` is available on the global scope (that's why this didn't throw any type or build errors)

Resolves: #795 

