### PR TITLE
Enhancement: `PTooltip` styling and width fix

### DIFF
--- a/src/components/Tooltip/PTooltip.vue
+++ b/src/components/Tooltip/PTooltip.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { computed, onMounted, onUnmounted, ref } from 'vue'
+  import { computed, onUnmounted, ref } from 'vue'
   import PPopOver from '@/components/PopOver/PPopOver.vue'
   import { PositionMethod } from '@/types/position'
   import { isNotNullish, isHtmlElement, randomId } from '@/utilities'

--- a/src/components/Tooltip/PTooltip.vue
+++ b/src/components/Tooltip/PTooltip.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { computed, onUnmounted, ref } from 'vue'
+  import { computed, onMounted, onUnmounted, ref } from 'vue'
   import PPopOver from '@/components/PopOver/PPopOver.vue'
   import { PositionMethod } from '@/types/position'
   import { isNotNullish, isHtmlElement, randomId } from '@/utilities'
@@ -81,6 +81,10 @@
       close()
     }
   }
+
+  onMounted(() => {
+    open()
+  })
 </script>
 
 <style>
@@ -90,6 +94,7 @@
 
 .p-tooltip__tooltip { @apply
   p-2
+  max-w-xs
 }
 
 .p-tooltip__content { @apply
@@ -97,9 +102,9 @@
   px-2
   py-1
   text-sm
-  rounded-sm
-  border-[1px]
-  border-background-400
-  dark:border-foreground-200
+  rounded
+  shadow-sm
+  bg-opacity-50
+  backdrop-blur-[1px]
 }
 </style>

--- a/src/components/Tooltip/PTooltip.vue
+++ b/src/components/Tooltip/PTooltip.vue
@@ -81,10 +81,6 @@
       close()
     }
   }
-
-  onMounted(() => {
-    open()
-  })
 </script>
 
 <style>
@@ -98,13 +94,16 @@
 }
 
 .p-tooltip__content { @apply
-  bg-background
+  backdrop-blur-[1px]
+  bg-slate-300
+  dark:bg-slate-950
+  bg-opacity-30
+  dark:bg-opacity-50
   px-2
   py-1
-  text-sm
   rounded
-  shadow-sm
-  bg-opacity-50
-  backdrop-blur-[1px]
+  shadow
+  dark:shadow-md
+  text-xs
 }
 </style>

--- a/src/components/Tooltip/PTooltip.vue
+++ b/src/components/Tooltip/PTooltip.vue
@@ -97,14 +97,13 @@
   backdrop-blur-[1px]
   bg-slate-300
   dark:bg-slate-950
-  bg-opacity-30
-  dark:bg-opacity-50
+  bg-opacity-50
+  dark:bg-opacity-70
   text-foreground
   px-2
   py-1
   rounded
   shadow
   dark:shadow-md
-  text-xs
 }
 </style>

--- a/src/components/Tooltip/PTooltip.vue
+++ b/src/components/Tooltip/PTooltip.vue
@@ -99,6 +99,7 @@
   dark:bg-slate-950
   bg-opacity-30
   dark:bg-opacity-50
+  text-foreground
   px-2
   py-1
   rounded


### PR DESCRIPTION
My goal with the new styles was to make the tooltips look like less cards and foreground elements we use frequently in this library (opaque backgrounds with thin, rounded borders) and a little more "ephemeral". To that end I've added distinct box shadows, a slight blur on the background, and ∫umped the font size down 1 step. 

Width fix before:
![Screenshot 2023-05-31 at 3 39 44 PM](https://github.com/PrefectHQ/prefect-design/assets/27291717/d55155b0-8e4c-4de1-8c00-b9b4b545102a)


After:
![Screenshot 2023-05-31 at 3 49 46 PM](https://github.com/PrefectHQ/prefect-design/assets/27291717/b8fc8ee6-99e3-42ac-a84b-e19c094aaa94)


Styling changes before:
![Screenshot 2023-05-31 at 4 57 36 PM](https://github.com/PrefectHQ/prefect-design/assets/27291717/6139310c-e41a-499d-9e5f-c71498f35638)
![Screenshot 2023-05-31 at 4 57 28 PM](https://github.com/PrefectHQ/prefect-design/assets/27291717/83789c5b-9b43-4d7d-8b87-9f33f2dbc333)

After:
![Screenshot 2023-05-31 at 4 57 54 PM](https://github.com/PrefectHQ/prefect-design/assets/27291717/8d82804c-a96d-4d10-9ef7-e2b940d5a7cd)
![Screenshot 2023-05-31 at 4 57 44 PM](https://github.com/PrefectHQ/prefect-design/assets/27291717/305361da-7311-49ff-bdcf-fc48c1045b70)
