### PR TITLE
update card styles

### DIFF
--- a/src/components/Card/PCard.vue
+++ b/src/components/Card/PCard.vue
@@ -20,11 +20,8 @@
 .p-card { @apply
   bg-background
   text-foreground
-  border
-  border-background-400
-  dark:border-foreground-200
-  p-6
-  rounded-lg
+  p-4
+  rounded-xl
   shadow-sm
   transition-all;
 
@@ -32,8 +29,6 @@
 }
 
 .p-card--flat { @apply
-  border-transparent
-  dark:border-transparent
   shadow-none
   bg-transparent
 }

--- a/src/components/Code/PCode.vue
+++ b/src/components/Code/PCode.vue
@@ -22,9 +22,9 @@
 
 <style>
 .p-code-container { @apply
-  bg-slate-700
+  bg-slate-800
   text-slate-50
-  rounded
+  rounded-xl
   px-1
   py-0
   inline-block

--- a/src/components/CodeHighlight/PCodeHighlight.vue
+++ b/src/components/CodeHighlight/PCodeHighlight.vue
@@ -56,8 +56,9 @@
 
   @apply
   flex
-  bg-background-500
-  rounded-md
+  bg-background
+  shadow
+  rounded-lg
   font-mono
   py-0
   px-1

--- a/src/components/EmptyState/PEmptyState.vue
+++ b/src/components/EmptyState/PEmptyState.vue
@@ -30,9 +30,8 @@
 
 <style>
 .p-empty-state { @apply
-  border
   bg-background
-  rounded-lg
+  rounded-xl
   shadow-sm
 }
 

--- a/src/components/Table/PTable.vue
+++ b/src/components/Table/PTable.vue
@@ -183,26 +183,22 @@
 .p-table { @apply
   overflow-hidden
   overflow-x-auto
-  shadow
-  ring-1
-  ring-black
-  ring-opacity-5
-  rounded
-  md:rounded-lg
-  dark:ring-background-600
+  shadow-sm
+  rounded-xl
 }
 
 .p-table__table { @apply
   min-w-full
   divide-y
-  divide-background-400
-  dark:divide-background-900
+  divide-background-500
+  dark:divide-background-700
 }
 
 .p-table__checkbox-cell { @apply
   flex
   justify-center
   items-center
-  px-1
+  pl-2
+  pr-0
 }
 </style>

--- a/src/components/Table/PTableBody.vue
+++ b/src/components/Table/PTableBody.vue
@@ -45,7 +45,7 @@
 .p-table-body { @apply
   divide-y
   bg-background
-  divide-background-400
-  dark:divide-background-900
+  divide-background-500
+  dark:divide-background-700
 }
 </style>


### PR DESCRIPTION
Update card styles in preparation for the dashboard design initiative. Also aims to bring a few card variants in line, in the interest of consistency.

I have a list of styles to hit up in `prefect-ui-library` as well:
```
.workspace-dashboard-card
.organization-dashboard-card
.work-pools-list
.logs__divider
```