### PR TITLE
fix modal styles

### DIFF
--- a/src/components/Modal/PModal.vue
+++ b/src/components/Modal/PModal.vue
@@ -157,7 +157,7 @@
 .p-modal__background { @apply
   fixed
   inset-0
-  bg-background-600
+  bg-background-100
   bg-opacity-75
   transition-opacity
 }
@@ -166,7 +166,7 @@
   relative
   flex
   flex-col
-  bg-background-500
+  bg-background
   rounded-lg
   shadow-xl
   transition-all


### PR DESCRIPTION

Old light mode:
<img width="1512" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6776415/41d63a16-af67-4104-9342-a0d16c80d1b3">

New light mode:
<img width="1512" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6776415/a6d75a09-537a-43e7-9de5-22caa2ca6450">

Old dark mode:
<img width="1512" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6776415/981de7cf-4529-4d32-b6ca-6ab9075db19d">

New dark mode:
<img width="1512" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6776415/5e86f858-3d5c-4be6-b6a6-44c5078c2d71">
