### PR TITLE
fix active nav item color in light mode

### DIFF
--- a/src/components/ContextNavItem/PContextNavItem.vue
+++ b/src/components/ContextNavItem/PContextNavItem.vue
@@ -48,6 +48,6 @@
 }
 
 .p-context-nav-item--active { @apply
-  text-primary
+  text-prefect-400
 }
 </style>


### PR DESCRIPTION
Fixes the color of active nav items to be static rather than changing with the theme. Dark mode looked fine, but light mode was pretty muddy, so both light and dark now use the same value as was previously used on just dark mode.

Old:
<img width="320" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6776415/9d6978fa-460e-41dc-b545-596346c43bf3">

New:
<img width="320" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6776415/94265066-cd19-47c8-a372-f515f2c1b6ee">
