### PR TITLE
Bugfix: Add handling for escape tokens

### DIFF
--- a/src/components/MarkdownRenderer/parser.ts
+++ b/src/components/MarkdownRenderer/parser.ts
@@ -21,7 +21,8 @@ import {
   isSpace,
   isBreak,
   isHorizontalRule,
-  isTextToken
+  isTextToken,
+  isEscape
 } from '@/types/markdownRenderer'
 import { ColumnClassesMethod } from '@/types/tables'
 import { randomId } from '@/utilities'
@@ -48,6 +49,10 @@ const getVNode = (token: Token, options: ParserOptions): VNode | VNode[] => {
 
   const props = { class: [`${baseClass}__token`] }
   const { type } = token
+
+  if (isEscape(token)) {
+    return t(unescapeHtml(token.text))
+  }
 
   if (isTextToken(token)) {
     // This is because text tokens can have embedded elements

--- a/src/types/markdownRenderer.ts
+++ b/src/types/markdownRenderer.ts
@@ -104,3 +104,7 @@ export function isDeleted(token: unknown): token is marked.Tokens.Del {
 export function isTextToken(token: unknown): token is marked.Tokens.Text | marked.Tokens.Em | marked.Tokens.Strong | marked.Tokens.Del {
   return isText(token) || isParagraph(token) || isStrong(token) || isEmphasis(token) || isDeleted(token)
 }
+
+export function isEscape(token: unknown): token is marked.Tokens.Escape {
+  return isToken(token) && token.type === 'escape'
+}


### PR DESCRIPTION
Escape tokens were falling through before and ending up as empty block elements.

This will fix an issue where any escaped slash after the first is invisible. 

Related: https://github.com/PrefectHQ/prefect/issues/9816 