### PR TITLE
Enhancement: `PLayout*` conditional slots

### DIFF
--- a/src/layouts/PLayoutDefault/PLayoutDefault.vue
+++ b/src/layouts/PLayoutDefault/PLayoutDefault.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="p-layout-default">
-    <div class="p-layout-default__header">
-      <slot name="header" class="p-layout-default__header" />
+    <div v-if="slots.header" class="p-layout-default__header">
+      <slot name="header" />
     </div>
     <div class="p-layout-default__content">
       <slot />
@@ -9,11 +9,14 @@
   </div>
 </template>
 
+<script lang="ts" setup>
+  import { useSlots } from 'vue'
+
+  const slots = useSlots()
+</script>
+
 <style>
-.p-layout-default {
-  @apply
-  p-4
-  lg:p-8
+.p-layout-default { @apply
   grid
   grid-rows-[max-content_max-content]
   gap-4
@@ -21,8 +24,7 @@
   w-full
 }
 
-.p-layout-default__content {
-  @apply
+.p-layout-default__content { @apply
   grid
   grid-cols-[minmax(0,1fr)]
   gap-4

--- a/src/layouts/PLayoutDefault/PLayoutDefault.vue
+++ b/src/layouts/PLayoutDefault/PLayoutDefault.vue
@@ -3,7 +3,7 @@
     <div v-if="slots.header" class="p-layout-default__header">
       <slot name="header" />
     </div>
-    <div class="p-layout-default__content">
+    <div v-if="slots.default" class="p-layout-default__content">
       <slot />
     </div>
   </div>

--- a/src/layouts/PLayoutWell/PLayoutWell.vue
+++ b/src/layouts/PLayoutWell/PLayoutWell.vue
@@ -1,22 +1,26 @@
 <template>
   <div class="p-layout-well">
-    <div class="p-layout-well__header">
+    <div v-if="slots.header" class="p-layout-well__header">
       <slot name="header" />
     </div>
-    <div class="p-layout-well__content">
+
+    <div v-if="slots.default" class="p-layout-well__content">
       <slot />
     </div>
-    <div class="p-layout-well__well">
+    <div v-if="slots.well" class="p-layout-well__well">
       <slot name="well" />
     </div>
   </div>
 </template>
 
+<script lang="ts" setup>
+  import { useSlots } from 'vue'
+
+  const slots = useSlots()
+</script>
+
 <style>
-.p-layout-well {
-  @apply
-  p-4
-  lg:p-8
+.p-layout-well { @apply
   grid
   grid-cols-[1fr_1fr_250px]
   grid-rows-[max-content_max-content]
@@ -25,13 +29,11 @@
   w-full
 }
 
-.p-layout-well__header {
-  @apply
+.p-layout-well__header { @apply
   col-span-3
 }
 
-.p-layout-well__content {
-  @apply
+.p-layout-well__content { @apply
   xl:col-span-2
   col-span-3
   grid
@@ -39,8 +41,7 @@
   grid-cols-[minmax(0,1fr)]
 }
 
-.p-layout-well__well {
-  @apply
+.p-layout-well__well { @apply
   w-full
   hidden
   xl:block


### PR DESCRIPTION
**This is a breaking change**

This PR removes the default padding on the `PLayoutDefault` and `PLayoutWell` components. It also hides the wrappers for slots that aren't present to prevent adding spacing where it shouldn't exist. 

I'm a little tentative to introduce these changes but without more flexibility here we don't have much control when using these layouts so I'm open to closing this in favor of a different solution