### PR TITLE
Enhancement: Add support for generic `heading` and `content` slots in PTabs

### DIFF
--- a/demo/sections/components/Tab.vue
+++ b/demo/sections/components/Tab.vue
@@ -10,7 +10,7 @@
       <PTabs v-model:selected="selectedTab" :tabs="tabs">
         <template #tab-one-heading="{ tab }">
           <p-icon icon="Prefect" class="w-4 h-4 mr-2" />
-          <span>{{ tab }}</span>
+          <span>{{ tab?.label }}</span>
         </template>
 
         <template #tab-one>
@@ -30,6 +30,14 @@
             Content Three
           </div>
         </template>
+
+        <template #heading="{ tab }">
+          {{ tab?.label }} Heading
+        </template>
+
+        <template #content="{ tab }">
+          This is the content for {{ tab.label }}
+        </template>
       </PTabs>
 
       <p-button size="sm" class="mt-2" @click="changeToTab(tabs[2])">
@@ -44,7 +52,7 @@
   import { ref } from 'vue'
   import ComponentPage from '@/demo/components/ComponentPage.vue'
 
-  const tabs = ['Tab One', 'Tab Two', 'Tab Three']
+  const tabs = ['Tab One', 'Tab Two', 'Tab Three', 'Tab Four']
 
   const selectedTab = ref()
   const changeToTab = (tab: string): void => {

--- a/src/components/Tabs/PTabNavigation.vue
+++ b/src/components/Tabs/PTabNavigation.vue
@@ -13,7 +13,9 @@
           :name="`${kebabCase(tab.label)}-heading`"
           v-bind="{ tab, index }"
         >
-          {{ tab.label }}
+          <slot name="heading" v-bind="{ tab, index }">
+            {{ tab.label }}
+          </slot>
         </slot>
       </PTab>
     </template>

--- a/src/components/Tabs/PTabSelect.vue
+++ b/src/components/Tabs/PTabSelect.vue
@@ -12,14 +12,18 @@
         :name="`${kebabCase(option.label)}-heading`"
         v-bind="{ tab: option.label, index }"
       >
-        {{ option.label }}
+        <slot name="heading" v-bind="{ tab: option.label, index }">
+          {{ option.label }}
+        </slot>
       </slot>
     </template>
     <template #default="{ option, label }">
       <slot
         :name="`${kebabCase(label)}-heading`"
         v-bind="{ tab: option, index: options.findIndex(tab => tab.label === label) }"
-      />
+      >
+        <slot name="heading" v-bind="{ tab: option, index: options.findIndex(tab => tab.label === label) }" />
+      </slot>
     </template>
   </PSelect>
 </template>

--- a/src/components/Tabs/PTabs.vue
+++ b/src/components/Tabs/PTabs.vue
@@ -22,7 +22,9 @@
           role="tabpanel"
           :aria-labelledby="`${kebabCase(tab.label)}`"
         >
-          <slot :name="kebabCase(tab.label)" v-bind="{ tab, index }" />
+          <slot :name="kebabCase(tab.label)" v-bind="{ tab, index }">
+            <slot name="content" v-bind="{ tab, index }" />
+          </slot>
         </section>
       </template>
     </template>


### PR DESCRIPTION
# Description
Adding generic heading and content slots allows using a single component for all the tab headings/content. Which is useful if your tab prop is a union type that can be passed to another component. 