### PR TITLE
remove checkbox animation from PListItemInput

### DIFF
--- a/src/components/ListItemInput/PListItemInput.vue
+++ b/src/components/ListItemInput/PListItemInput.vue
@@ -1,6 +1,6 @@
 <template>
-  <PListItem class="p-list-item-input" v-on="{ mouseenter, mouseleave }">
-    <div class="p-list-item-input__control" :class="classes.control">
+  <PListItem class="p-list-item-input">
+    <div class="p-list-item-input__control">
       <label class="p-list-item-input__checkbox">
         <PCheckbox v-model="model" v-bind="{ value, disabled }" />
       </label>
@@ -13,7 +13,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { computed, ref } from 'vue'
+  import { computed } from 'vue'
   import PCheckbox from '@/components/Checkbox/PCheckbox.vue'
   import PListItem from '@/components/ListItem/PListItem.vue'
 
@@ -37,37 +37,6 @@
       emit('update:selected', value)
     },
   })
-
-  const hover = ref(false)
-  const show = computed(() => {
-    if (hover.value) {
-      return true
-    }
-
-    if (typeof model.value === 'object') {
-      return model.value.includes(props.value)
-    }
-
-    return model
-  })
-
-  const classes = computed(() => ({
-    control: {
-      'p-list-item-input__control--visible': show.value,
-    },
-  }))
-
-  function mouseenter(): void {
-    if (!props.disabled) {
-      hover.value = true
-    }
-  }
-
-  function mouseleave(): void {
-    if (!props.disabled) {
-      hover.value = false
-    }
-  }
 </script>
 
 <style>
@@ -80,42 +49,18 @@
   p-0
 }
 
-.p-list-item-input__content { @apply
-  flex-grow
-  py-3
-  pl-3
-  pr-4
-  min-w-0
-}
-
 .p-list-item-input__control { @apply
   flex-grow-0
   flex-shrink-0
-  flex
-  w-10
-  sm:w-2
   justify-self-stretch
-  overflow-hidden
-  transition-all
+  py-3
+  px-2
 }
 
-.p-list-item-input__control:focus-within,
-.p-list-item-input__control--visible { @apply
-  w-10
-}
-
-.p-list-item-input__checkbox { @apply
-  justify-center
-  items-start
-  sm:items-center
-  flex
-  flex-shrink-0
-  justify-self-stretch
-  bg-background-400
-  dark:bg-background-600
-  w-10
-  pt-3
-  sm:pt-0
-  cursor-pointer
+.p-list-item-input__content { @apply
+  flex-grow
+  py-3
+  pr-4
+  min-w-0
 }
 </style>


### PR DESCRIPTION
Instead of animating the checkboxes and drawing a lot of undue attention to them, have them statically sit in the corner.

<img width="791" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6776415/43c1dbb4-2560-4869-a094-b78fc232ac46">
