### PR TITLE
Enhancement: PCode inline border radii

### DIFF
--- a/demo/sections/components/Code.vue
+++ b/demo/sections/components/Code.vue
@@ -13,7 +13,9 @@
     </template>
 
     <template #inline>
-      This is an <p-code inline>
+      This <p-code inline>
+        is
+      </p-code> an <p-code inline>
         inline
       </p-code> code block.
     </template>

--- a/src/components/Code/PCode.vue
+++ b/src/components/Code/PCode.vue
@@ -24,7 +24,7 @@
 .p-code-container { @apply
   bg-slate-800
   text-slate-50
-  rounded-xl
+  rounded
   px-1
   py-0
   inline-block
@@ -34,5 +34,6 @@
   px-2
   py-2
   block
+  rounded-xl
 }
 </style>


### PR DESCRIPTION
The current border radius on the `p-code` component leads to inline code snippets having overly-round corners, particularly when the snippet is short. 

Before:
![Screenshot 2023-06-14 at 2 24 29 PM](https://github.com/PrefectHQ/prefect-design/assets/27291717/fe394162-eaca-4f54-ad01-8917fb435304)
![Screenshot 2023-06-14 at 2 24 35 PM](https://github.com/PrefectHQ/prefect-design/assets/27291717/c17d6a44-ae40-456b-a4fa-0377b9592087)

After:
![Screenshot 2023-06-14 at 2 24 45 PM](https://github.com/PrefectHQ/prefect-design/assets/27291717/6e13a51d-b6a4-4299-bad4-7175fa049735)
![Screenshot 2023-06-14 at 2 24 49 PM](https://github.com/PrefectHQ/prefect-design/assets/27291717/da8ae86b-03b7-4ea5-86af-6002d412adfc)
