### PR TITLE
RFC: PSelectOption add the ability to target or omit specific values

### DIFF
--- a/demo/sections/components/Select.vue
+++ b/demo/sections/components/Select.vue
@@ -67,6 +67,18 @@
     {
       label: 'Three', value: '3',
     },
+    {
+      label: 'Four', value: '4',
+    },
+    {
+      label: 'Five', value: '5',
+    },
+    {
+      label: 'Six', value: '6',
+    },
+    {
+      label: 'Seven', value: '7',
+    },
   ]
 
   const exampleOptionsGrouped = [

--- a/src/components/Select/PSelectOptions.vue
+++ b/src/components/Select/PSelectOptions.vue
@@ -17,6 +17,7 @@
               v-model="internalValue"
               v-model:highlightedValue="highlightedValue"
               :option="option"
+              :options="optionsOnly"
               :multiple="multiple"
             >
               <template #default="scope">
@@ -47,7 +48,7 @@
   import PSelectOption from '@/components/SelectOption/PSelectOption.vue'
   import PSelectOptionGroup from '@/components/SelectOptionGroup/PSelectOptionGroup.vue'
   import PVirtualScroller from '@/components/VirtualScroller/PVirtualScroller.vue'
-  import { isSelectOptionGroup, SelectModelValue, SelectOptionGroupNormalized, SelectOptionNormalized } from '@/types/selectOption'
+  import { isSelectOptionGroup, isSelectOptionNormalized, SelectModelValue, SelectOptionGroupNormalized, SelectOptionNormalized } from '@/types/selectOption'
 
   const props = defineProps<{
     modelValue: string | number | boolean | null | SelectModelValue[] | undefined,
@@ -110,6 +111,7 @@
   }
 
   const flattened = computed(() => props.options.flatMap(option => flattenGroupsAndOptions(option)))
+  const optionsOnly = computed(() => props.options.filter(isSelectOptionNormalized))
 </script>
 
 <style>

--- a/src/components/SelectOption/PSelectOption.vue
+++ b/src/components/SelectOption/PSelectOption.vue
@@ -2,7 +2,7 @@
   <div
     class="p-select-option"
     role="option"
-    :class="classes"
+    :class="classes.root"
     @click="handleClick"
     @mouseenter="handleMouseEnter"
   >
@@ -18,6 +18,24 @@
         {{ option.label }}
       </slot>
     </span>
+    <template v-if="!option.disabled">
+      <div class="p-select-option__actions" :class="classes.actions">
+        <p-button
+          title="Select only this value"
+          flat
+          size="xs"
+          icon="Target"
+          @click.stop="selectOnly"
+        />
+        <p-button
+          title="Select all except this value"
+          flat
+          size="xs"
+          icon="NoSymbolIcon"
+          @click.stop="selectOthers"
+        />
+      </div>
+    </template>
   </div>
 </template>
 
@@ -30,6 +48,7 @@
     modelValue: string | number | boolean | null | SelectModelValue[],
     highlightedValue: string | number | boolean | null | symbol,
     option: SelectOptionNormalized,
+    options: SelectOptionNormalized[],
     multiple?: boolean,
   }>()
 
@@ -55,6 +74,7 @@
 
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const multiple = computed(() => props.multiple || Array.isArray(modelValue.value))
+  const highlighted = computed(() => props.highlightedValue === option.value.value)
 
   const selected = computed(() => {
     if (Array.isArray(modelValue.value)) {
@@ -74,9 +94,14 @@
   })
 
   const classes = computed(() => ({
-    'p-select-option--selected': selected.value,
-    'p-select-option--highlighted': highlightedValue.value === option.value.value,
-    'p-select-option--disabled': option.value.disabled,
+    root: {
+      'p-select-option--selected': selected.value,
+      'p-select-option--highlighted': highlighted.value,
+      'p-select-option--disabled': option.value.disabled,
+    },
+    actions: {
+      'p-select-option__actions--visible': highlighted.value,
+    },
   }))
 
   function handleClick(): void {
@@ -86,6 +111,14 @@
     }
 
     setValue()
+  }
+
+  function selectOnly(): void {
+    modelValue.value = [option.value.value]
+  }
+
+  function selectOthers(): void {
+    modelValue.value = props.options.filter(option => option.value !== props.option.value && !option.disabled).map(option => option.value)
   }
 
   function handleMouseEnter(): void {
@@ -169,5 +202,15 @@
 
 .p-select-option--disabled .p-checkbox { @apply
   opacity-100
+}
+
+.p-select-option__actions { @apply
+  opacity-0
+  ml-auto
+  flex
+}
+
+.p-select-option__actions--visible { @apply
+ opacity-100
 }
 </style>


### PR DESCRIPTION
# Description
Adds two actions to PSelectOption. One for selecting only the highlighted value (removes any other values) and one for selecting all values except the highlighted value. 

This loom goes into a little more detail about how this works and also explains how most of this is just a launching point. 
https://www.loom.com/embed/8f8c6648b7f54e2bbb5ee99c147f9bd9

<img width="1306" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6200442/d267df2f-485d-4c1f-81fc-07286de03c39">
<img width="730" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6200442/716165fb-8ea2-4ff0-af2b-fad08775dbb8">
