### PR TITLE
Enhancement: Better date formatting of selected date and time in p-date-input

### DIFF
--- a/src/components/DateInput/PDateButton.vue
+++ b/src/components/DateInput/PDateButton.vue
@@ -33,16 +33,26 @@
 
   const props = defineProps<{
     date: Date | null | undefined,
+    showTime?: boolean,
   }>()
 
   const buttonElement = ref<HTMLButtonElement>()
   const el = computed(() => buttonElement.value)
-  const displayValue = computed(() => {
-    if (props.date) {
-      return format(props.date, 'MM/dd/yyyy')
+
+  const dateTimeFormat = computed(() => {
+    if (props.showTime) {
+      return 'MMM do, yyyy \'at\' h:mm a'
     }
 
-    return 'mm/dd/yyyy'
+    return 'MMM do, yyyy'
+  })
+
+  const displayValue = computed(() => {
+    if (props.date) {
+      return format(props.date, dateTimeFormat.value)
+    }
+
+    return 'Select a date'
   })
 
   defineExpose({ el })

--- a/src/components/DateInput/PDateButton.vue
+++ b/src/components/DateInput/PDateButton.vue
@@ -52,7 +52,7 @@
       return format(props.date, dateTimeFormat.value)
     }
 
-    return 'Select a date'
+    return props.showTime ? 'Select a date and time' : 'Select a date'
   })
 
   defineExpose({ el })

--- a/src/components/DateInput/PDateInput.vue
+++ b/src/components/DateInput/PDateInput.vue
@@ -13,7 +13,7 @@
           <PDateButton
             :date="internalModelValue"
             :class="classes.control"
-            :disabled="disabled"
+            v-bind="{ showTime, disabled }"
             @click="openPicker"
           />
         </template>


### PR DESCRIPTION
# Description
Specifically set out to solve the issue where the selected time was not shown unless you opened the input. Made some overall changes to how we format and display the text/date/time. Feedback welcome

No value before
<img width="600" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6200442/2af00bf2-950e-4ed9-b0db-ec20066b19d6">

No value after
<img width="601" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6200442/0ddb5f8d-c281-430d-bdba-e8da0c16ec14">

No value and `showTime` before
<img width="600" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6200442/2af00bf2-950e-4ed9-b0db-ec20066b19d6">

No value and `showTime` after
<img width="599" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6200442/43a0e2ed-c864-45a1-b881-681c817ecf36">

Date selected before
<img width="605" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6200442/f0edf66e-6928-4603-96a9-bf3672d4e478">

Date selected after
<img width="606" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6200442/4b0547ec-fdf4-4d60-81fa-a11e5bf22886">

Date and time selected before
<img width="605" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6200442/0e6380bf-2e61-4df8-99db-d162fd2a051c">

Date and time selected after
<img width="603" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6200442/0e84aa81-343a-4ff2-bc3e-f82827fbbce6">
