### PR TITLE
BugFix: PDateRange use correct times

### DIFF
--- a/src/components/DateInput/PDateButton.vue
+++ b/src/components/DateInput/PDateButton.vue
@@ -52,7 +52,7 @@
       return format(props.date, dateTimeFormat.value)
     }
 
-    return props.showTime ? 'Select a date and time' : 'Select a date'
+    return props.showTime ? 'Select date and time' : 'Select date'
   })
 
   defineExpose({ el })


### PR DESCRIPTION
# Description
Fixes an issue where selecting the same start and end date would result in a date difference of 0 minutes. Should also fix issues where ranges of dates wouldn't include some data when using those dates directly for filters and queries. 

Closes https://github.com/PrefectHQ/prefect/issues/7917

This change forces the start date to always be 00:00:00 and the end date to be 59:59:59 by using date-fns startOfDate and endOfDay utilities.

Side quest: Also updated the formatting when displaying the dates to match PDateInput