### PR TITLE
BugFix: PTextarea can be resized where user cannot see the text. 

### DIFF
--- a/src/components/Textarea/PTextarea.vue
+++ b/src/components/Textarea/PTextarea.vue
@@ -47,5 +47,6 @@
   rounded-md
   border-0
   focus:ring-0
+  min-h-[2.5rem]
 }
 </style>


### PR DESCRIPTION
## Bug

PTextarea can be resized where user cannot see the text.

## Fix

Set min-height to e 2.5rem. This is calculated by lineHight of 1.5rem + padding-top of .5rem and padding-bottom of .5rem.