### PR TITLE
BugFix: Long tooltip content makes wide and skinny tooltips

### DIFF
--- a/src/components/Tooltip/PTooltip.vue
+++ b/src/components/Tooltip/PTooltip.vue
@@ -105,5 +105,6 @@
   rounded
   shadow
   dark:shadow-md
+  max-w-xs
 }
 </style>


### PR DESCRIPTION
## Bug

Long tooltip content makes wide and skinny tooltips

## Solution

Added a max-width of max-w-xs to the tooltip

## Screenshots

Screenshot of tooltip on desktop

![Screenshot 2023-07-15 at 6 44 02 PM](https://github.com/PrefectHQ/prefect-design/assets/10262857/d73e6488-78b1-4405-a83a-44cd1897d20a)

Screenshot of tooltip on mobile

![Screenshot 2023-07-15 at 6 44 22 PM](https://github.com/PrefectHQ/prefect-design/assets/10262857/d673ec83-68e8-46ab-aac7-e78a33347a16)

