### PR TITLE
style markdown renderer and tables

### DIFF
--- a/demo/sections/components/Table.vue
+++ b/demo/sections/components/Table.vue
@@ -3,6 +3,7 @@
     title="Tables"
     :demos="[
       { title: 'Basic' },
+      { title: 'In a card' },
       { title: 'With Multiselect' },
       { title: 'Using Columns' },
       { title: 'Custom Slots' },
@@ -17,6 +18,12 @@
 
     <template #basic>
       <p-table :data="data" />
+    </template>
+
+    <template #in-a-card>
+      <p-card>
+        <p-table :data="data" />
+      </p-card>
     </template>
 
     <template #with-multiselect>

--- a/demo/sections/components/Table.vue
+++ b/demo/sections/components/Table.vue
@@ -22,7 +22,15 @@
 
     <template #in-a-card>
       <p-card>
-        <p-table :data="data" />
+        <p-table :data="data">
+          <template #footer>
+            <PTableRow>
+              <PTableData class="text-center" colspan="5">
+                Footer
+              </PTableData>
+            </PTableRow>
+          </template>
+        </p-table>
       </p-card>
     </template>
 

--- a/demo/sections/components/Table.vue
+++ b/demo/sections/components/Table.vue
@@ -190,17 +190,21 @@
 <style>
 .custom-row-class { @apply
   bg-rose-400
+  dark:bg-rose-900
 }
 
 .custom-row-class--index { @apply
   bg-teal-200
+  dark:bg-teal-900
 }
 
 .custom-column-class { @apply
   bg-emerald-200
+  dark:bg-emerald-900
 }
 
 .custom-column-class--index { @apply
   bg-amber-200
+  dark:bg-amber-900
 }
 </style>

--- a/src/components/ListItem/PListItem.vue
+++ b/src/components/ListItem/PListItem.vue
@@ -6,7 +6,7 @@
 
 <style>
 .p-list-item { @apply
-  rounded-lg
+  rounded-md
   flex
   py-3
   px-4

--- a/src/components/ListItemInput/PListItemInput.vue
+++ b/src/components/ListItemInput/PListItemInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <PListItem class="p-list-item-input">
+  <PListItem class="p-list-item-input p-background">
     <div class="p-list-item-input__control">
       <label class="p-list-item-input__checkbox">
         <PCheckbox v-model="model" v-bind="{ value, disabled }" />
@@ -41,9 +41,7 @@
 
 <style>
 .p-list-item-input { @apply
-  bg-background
-  shadow
-  rounded-lg
+  rounded-md
   overflow-hidden
   flex
   p-0

--- a/src/components/MarkdownRenderer/PMarkdownRenderer.vue
+++ b/src/components/MarkdownRenderer/PMarkdownRenderer.vue
@@ -48,13 +48,12 @@
 }
 
 .markdown-renderer__html a[href] { @apply
-  text-primary-500
-  hover:text-primary-600
+  text-link
 }
 
 .markdown-renderer__image { @apply
   max-w-full
-  rounded
+  rounded-md
   shadow-sm
 }
 
@@ -133,7 +132,7 @@
 .markdown-renderer__blockquote { @apply
   italic
   border-l-4
-  border-background-600
+  border-divider
   pl-4
   ml-2
 }

--- a/src/components/Table/PTable.vue
+++ b/src/components/Table/PTable.vue
@@ -184,14 +184,13 @@
 .p-table { @apply
   overflow-hidden
   overflow-x-auto
-  shadow-sm
+  rounded-md
 }
 
 .p-table__table { @apply
   min-w-full
   divide-y
-  divide-background-500
-  dark:divide-background-700
+  divide-divider
 }
 
 .p-table__checkbox-cell { @apply

--- a/src/components/Table/PTableBody.vue
+++ b/src/components/Table/PTableBody.vue
@@ -1,5 +1,5 @@
 <template>
-  <tbody class="p-table-body">
+  <tbody class="p-table-body p-background">
     <slot>
       <template v-for="(row, index) in data" :key="index">
         <PTableRow>
@@ -44,7 +44,6 @@
 <style>
 .p-table-body { @apply
   divide-y
-  divide-background-500
-  dark:divide-background-700
+  divide-divider
 }
 </style>

--- a/src/components/Table/PTableData.vue
+++ b/src/components/Table/PTableData.vue
@@ -10,6 +10,5 @@
   px-3
   py-4
   text-sm
-  text-foreground-300
 }
 </style>

--- a/src/components/Table/PTableFoot.vue
+++ b/src/components/Table/PTableFoot.vue
@@ -1,5 +1,5 @@
 <template>
-  <tfoot class="p-table-foot">
+  <tfoot class="p-table-foot p-background">
     <slot />
   </tfoot>
 </template>

--- a/src/components/Table/PTableHead.vue
+++ b/src/components/Table/PTableHead.vue
@@ -1,5 +1,5 @@
 <template>
-  <thead class="p-table-head">
+  <thead class="p-table-head p-background">
     <slot>
       <PTableRow>
         <slot name="row" />

--- a/src/components/Table/PTableHeader.vue
+++ b/src/components/Table/PTableHeader.vue
@@ -10,7 +10,6 @@
   py-3.5
   text-sm
   font-semibold
-  text-foreground-900
   whitespace-nowrap
   text-left
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -545,12 +545,6 @@ body {
   color: var(--p-color-text-default)
 }
 
-* {
-  --duration: 50ms;
-  --timing: ease;
-  transition: background-color var(--duration) var(--timing), color var(--duration) var(--timing);
-}
-
 *::selection {
   background-color: var(--p-color-text-selection);
 }


### PR DESCRIPTION
As I updated styles for the markdown renderer, I notices tables got some special styles for a sticky header. I had previously removed the bg from tables with the intent to make them sit in cards and let the card handle bg-colors, but seeing this and auditing how we use tables a bit, I added the bg's back to the table on the header and body independently so they work with the sticky header.