### PR TITLE
PTerminal adding output for command line.

### DIFF
--- a/demo/sections/components/Terminal.vue
+++ b/demo/sections/components/Terminal.vue
@@ -7,7 +7,7 @@
     </template>
 
     <template #terminal>
-      <p-terminal command="perfect config set PREFECT_API_URL" />
+      <p-terminal command="prefect config set PREFECT_API_URL" output="Set 'PREFECT_API_URL' to 'test'." />
     </template>
   </ComponentPage>
 </template>

--- a/src/components/Terminal/PTerminal.vue
+++ b/src/components/Terminal/PTerminal.vue
@@ -10,8 +10,13 @@
     <div class="p-terminal__code">
       <template v-for="(line, index) in commands" :key="index">
         <p class="p-terminal__code-line">
-          {{ line }}
+          $ {{ line }}
           <span class="p-terminal__cursor" />
+        </p>
+      </template>
+      <template v-for="(line, index) in outputs" :key="index">
+        <p class="p-terminal__code-line">
+          {{ line }}
         </p>
       </template>
     </div>
@@ -27,13 +32,21 @@
 
   const props = defineProps<{
     command: string | string[],
+    output: string | string[],
   }>()
 
   const commands = computed(() => asArray(props.command))
+  const outputs = computed(() => asArray(props.output))
 
   async function copy(): Promise<void> {
     const copyText = commands.value.join(' && ')
     await navigator.clipboard.writeText(copyText)
+
+    showToast('Copied!', 'success')
+  }
+
+  async function copyLine(index: string): Promise<void> {
+    await navigator.clipboard.writeText(commands.value[index])
 
     showToast('Copied!', 'success')
   }

--- a/src/components/Terminal/PTerminal.vue
+++ b/src/components/Terminal/PTerminal.vue
@@ -32,7 +32,7 @@
 
   const props = defineProps<{
     command: string | string[],
-    output: string | string[],
+    output?: string | string[] | null | undefined,
   }>()
 
   const commands = computed(() => asArray(props.command))

--- a/src/components/Terminal/PTerminal.vue
+++ b/src/components/Terminal/PTerminal.vue
@@ -44,12 +44,6 @@
 
     showToast('Copied!', 'success')
   }
-
-  async function copyLine(index: string): Promise<void> {
-    await navigator.clipboard.writeText(commands.value[index])
-
-    showToast('Copied!', 'success')
-  }
 </script>
 
 <style>


### PR DESCRIPTION
This adds an "output" prop to the PTerminal component to display command line outputs underneath the "commands" property. 

It also adds a $ to each command in p terminal to. The copy functionality does not include the $ in this case.  