### PR TITLE
Feature: PDialog component

### DIFF
--- a/demo/sections/components/Dialog.vue
+++ b/demo/sections/components/Dialog.vue
@@ -1,0 +1,26 @@
+<template>
+  <ComponentPage title="Dialog" :demos="[{ title: 'Dialog' }]">
+    <template #dialog>
+      <p-dialog v-model:open="open" auto-close modal>
+        <template #default="{ close }">
+          <p-card>
+            hello world <p-button size="sm" @click="close">
+              close
+            </p-button>
+          </p-card>
+        </template>
+      </p-dialog>
+
+      <p-button @click="open = true">
+        Open
+      </p-button>
+    </template>
+  </ComponentPage>
+</template>
+
+<script lang="ts" setup>
+  import { ref } from 'vue'
+  import ComponentPage from '@/demo/components/ComponentPage.vue'
+
+  const open = ref(false)
+</script>

--- a/demo/sections/components/index.ts
+++ b/demo/sections/components/index.ts
@@ -15,6 +15,7 @@ export const components: Section = {
   combobox: () => import('./Combobox.vue'),
   dateInput: () => import('./DateInput.vue'),
   dateRangeInput: () => import('./DateRangeInput.vue'),
+  dialog: () => import('./Dialog.vue'),
   divider: () => import('./Divider.vue'),
   drawer: () => import('./Drawer.vue'),
   emptyState: () => import('./EmptyState.vue'),

--- a/src/components/Dialog/PDialog.vue
+++ b/src/components/Dialog/PDialog.vue
@@ -1,0 +1,81 @@
+<template>
+  <dialog ref="dialog" class="p-dialog" @click="onClick">
+    <div class="p-dialog__content">
+      <template v-if="open">
+        <slot v-bind="{ close }" />
+      </template>
+    </div>
+  </dialog>
+</template>
+
+<script lang="ts" setup>
+  import { onMounted, onUnmounted, ref, watch } from 'vue'
+
+  const props = defineProps<{
+    open: boolean,
+    modal?: boolean,
+    autoClose?: boolean,
+  }>()
+
+  const emit = defineEmits<{
+    (event: 'update:open', value: boolean): void,
+  }>()
+
+  const dialog = ref<HTMLDialogElement>()
+
+  function show(): void {
+    if (!dialog.value) {
+      return
+    }
+
+    if (props.modal) {
+      dialog.value.showModal()
+      return
+    }
+
+    dialog.value.show()
+  }
+
+  function close(): void {
+    if (!dialog.value) {
+      return
+    }
+
+    dialog.value.close()
+  }
+
+  function syncOpenValue(): void {
+    if (!dialog.value) {
+      return
+    }
+
+    emit('update:open', dialog.value.open)
+  }
+
+  function onClick(event: MouseEvent): void {
+    if (!props.autoClose) {
+      return
+    }
+
+    if (event.target === dialog.value) {
+      close()
+    }
+  }
+
+  watch(() => props.open, open => {
+    if (open) {
+      show()
+      return
+    }
+
+    close()
+  })
+
+  onMounted(() => {
+    dialog.value?.addEventListener('close', syncOpenValue)
+  })
+
+  onUnmounted(() => {
+    dialog.value?.removeEventListener('close', syncOpenValue)
+  })
+</script>

--- a/src/components/Dialog/index.ts
+++ b/src/components/Dialog/index.ts
@@ -1,0 +1,8 @@
+import { App } from 'vue'
+import PDialog from '@/components/Dialog/PDialog.vue'
+
+const install = (app: App): void => {
+  app.component('PDialog', PDialog)
+}
+
+export { PDialog, install }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,6 +20,7 @@ import { PContextSidebar, install as installPContextSidebar } from '@/components
 import { PDateInput, install as installPDateInput } from '@/components/DateInput'
 import { PDatePicker, install as installPDatePicker } from '@/components/DatePicker'
 import { PDateRangeInput, install as installPDateRangeInput } from '@/components/DateRangeInput'
+import { PDialog, install as installPDialog } from '@/components/Dialog'
 import { PDivider, install as installPDivider } from '@/components/Divider'
 import { PDrawer, install as installPDrawer } from '@/components/Drawer'
 import { PEmptyResults, install as installPEmptyResults } from '@/components/EmptyResults'
@@ -105,6 +106,7 @@ export {
   PDateInput,
   PDatePicker,
   PDateRangeInput,
+  PDialog,
   PDivider,
   PDrawer,
   PEmptyResults,
@@ -201,6 +203,7 @@ export const installs = [
   installPDateInput,
   installPDatePicker,
   installPDateRangeInput,
+  installPDialog,
   installPDivider,
   installPDrawer,
   installPEmptyResults,
@@ -287,6 +290,7 @@ declare module '@vue/runtime-core' {
     PDateInput: typeof PDateInput,
     PDatePicker: typeof PDatePicker,
     PDateRangeInput: typeof PDateRangeInput,
+    PDialog: typeof PDialog,
     PDivider: typeof PDivider,
     PDrawer: typeof PDrawer,
     PEmptyResults: typeof PEmptyResults,


### PR DESCRIPTION
# Description
Adds a new `PDialog` component which is a reactive wrapper around the [dialog](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog) element. It has a single default slot which binds a close method. This component does not add any opinionated styling and is designed to be styled at implementation. 

## Props
- open - `boolean` (required)
- autoClose - `boolean`
- modal - `boolean`