### PR TITLE
Bugfix: Nav item active class inconsistencies

### DIFF
--- a/src/components/ContextAccordionItem/PContextAccordionItem.vue
+++ b/src/components/ContextAccordionItem/PContextAccordionItem.vue
@@ -114,7 +114,7 @@
 
 .p-context-accordion-item__header--highlighted { @apply
   hover:bg-selectable-hover
-  active:bg-selected
+  bg-selected
 }
 
 .p-context-accordion-item__icon { @apply

--- a/src/components/ContextNavItem/PContextNavItem.vue
+++ b/src/components/ContextNavItem/PContextNavItem.vue
@@ -1,7 +1,7 @@
 <template>
   <component
     :is="component"
-    active-class="p-context-nav-item--active"
+    exact-active-class="p-context-nav-item--active"
     class="p-context-nav-item"
     v-bind="componentProps"
   >

--- a/src/components/OverflowMenuItem/POverflowMenuItem.vue
+++ b/src/components/OverflowMenuItem/POverflowMenuItem.vue
@@ -2,6 +2,7 @@
   <component
     :is="component"
     class="p-overflow-menu-item"
+    exact-active-class="p-overflow-menu-item--active"
     v-bind="componentProps"
   >
     <PIcon v-if="icon" :icon="icon" class="p-overflow-menu-item__icon" />
@@ -79,5 +80,10 @@
 .p-overflow-menu-item__after { @apply
   ml-auto
   pl-10
+}
+
+.p-overflow-menu-item--active { @apply
+  bg-selected
+  hover:bg-selected
 }
 </style>


### PR DESCRIPTION
This PR: 
- fixes an issue where context accordion items weren't highlighting properly when a child route was matched and the accordion was closed
- fixes an issue where context nav items were highlighted when matched inexactly (this doesn't preclude downstream consumers from passing `active-class` but probably better matches our intent here)
- adds an active class to overflow menu items