### PR TITLE
Bugfix: Don't flex default slot

### DIFF
--- a/src/components/ListItem/PListItem.vue
+++ b/src/components/ListItem/PListItem.vue
@@ -7,7 +7,6 @@
 <style>
 .p-list-item { @apply
   rounded-default
-  flex
   py-3
   px-4
 }


### PR DESCRIPTION
There's not really a reason to flex the slot, downstream consumers should be responsible for that