### PR TITLE
BugFix: Allow PSelect options to be readonly

### DIFF
--- a/demo/sections/components/Select.vue
+++ b/demo/sections/components/Select.vue
@@ -1,5 +1,13 @@
 <template>
-  <ComponentPage title="Select" :demos="[{ title: 'Single Select' }, { title: 'Multi-Select' }, { title: 'Grouped' }]">
+  <ComponentPage
+    title="Select"
+    :demos="[
+      { title: 'Single Select' },
+      { title: 'Multi-Select' },
+      { title: 'Grouped' },
+      { title: 'Readonly options' },
+    ]"
+  >
     <template #description>
       <DemoState v-model:state="exampleState" v-model:disabled="disabled" />
     </template>
@@ -31,6 +39,16 @@
     <template #grouped>
       <div class="select__demo">
         <p-select v-model="exampleGroupedSelect" :disabled="disabled" :options="exampleOptionsGrouped" :state="exampleState" />
+
+        <p-code inline>
+          value: {{ JSON.stringify(exampleGroupedSelect) }}
+        </p-code>
+      </div>
+    </template>
+
+    <template #readonly>
+      <div class="select__demo">
+        <p-select v-model="readonlySelected" :disabled="disabled" :options="readonlyOptions" :state="exampleState" />
 
         <p-code inline>
           value: {{ JSON.stringify(exampleGroupedSelect) }}
@@ -89,6 +107,9 @@
     { label: '', value: null },
     ...exampleOptions,
   ]
+
+  const readonlySelected = ref()
+  const readonlyOptions = ['one', 'two', 'three'] as const
 </script>
 
 <style>

--- a/src/components/Select/PSelect.vue
+++ b/src/components/Select/PSelect.vue
@@ -104,6 +104,7 @@
   import PTagWrapper from '@/components/TagWrapper/PTagWrapper.vue'
   import { useAttrsStylesAndClasses } from '@/compositions/attributes'
   import { useHighlightedValue } from '@/compositions/useHighlightedValue'
+  import { MaybeReadonly } from '@/types'
   import { isAlphaNumeric, keys } from '@/types/keyEvent'
   import { SelectModelValue, flattenSelectOptions, normalizeSelectOption, SelectOptionGroup, SelectOptionNormalized, SelectOption, isSelectOptionNormalized } from '@/types/selectOption'
   import { TagValue } from '@/types/tag'
@@ -114,7 +115,7 @@
   const props = defineProps<{
     modelValue: string | number | boolean | null | SelectModelValue[] | undefined,
     disabled?: boolean,
-    options: (SelectOption | SelectOptionGroup)[],
+    options: MaybeReadonly<(SelectOption | SelectOptionGroup)[]>,
     emptyMessage?: string,
     multiple?: boolean,
   }>()

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -1,3 +1,5 @@
 // https://stackoverflow.com/questions/73732549/narrow-number-argument-of-function-to-be-literal-type?noredirect=1#comment130199140_73732549
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type NoInfer<T> = T & {}
+
+export type MaybeReadonly<T> = T | Readonly<T>


### PR DESCRIPTION
# Description
Currently if you try and pass a readonly array of options into PSelect it will error. Adding `MaybeReadonly` to this repository and using it for the `options` prop to make using this component easier. 