### PR TITLE
Enhancement: Add manual prop to PCombobox to skip internal filtering

### DIFF
--- a/src/components/Combobox/PCombobox.vue
+++ b/src/components/Combobox/PCombobox.vue
@@ -68,6 +68,7 @@
     emptyMessage?: string,
     placeholder?: string,
     search?: string,
+    manual?: boolean,
   }>(), {
     emptyMessage: undefined,
     placeholder: 'Search',
@@ -129,7 +130,7 @@
   })
 
   const filteredSelectOptions = computed(() => {
-    if (!search.value) {
+    if (!search.value || props.manual) {
       return selectOptionsWithUnknown.value
     }
 


### PR DESCRIPTION
# Description
The `search` prop was already an optional v-model but there was no way to tell the combobox to not perform the filter. Adding a `manual` prop to skip all internal filtering and let the implementation dictate the filtering for the options. 

This allows filtering to be async (done via an api)