### PR TITLE
Bugfix: `PSelect` empty message

### DIFF
--- a/src/components/Select/PSelect.vue
+++ b/src/components/Select/PSelect.vue
@@ -157,7 +157,7 @@
       return modelValue.value.length === 0
     }
 
-    return getSelectOption(modelValue.value) === undefined
+    return modelValue.value === null
   })
 
   const selectOptions = computed(() => {


### PR DESCRIPTION
`PSelect` was making an implicit assumption that the model value for the component would exist in the list of options and thereby render the `empty-message` slot if a value was set but not present. This is problematic in circumstances where options are fetched on-demand from an async source or when paginating the options list.