### PR TITLE
Fix stepper disabled

### DIFF
--- a/demo/sections/components/Stepper.vue
+++ b/demo/sections/components/Stepper.vue
@@ -4,6 +4,7 @@
     :demos="[
       { title: 'Min and Max Props' },
       { title: 'Step Size' },
+      { title: 'Disabled' },
     ]"
   >
     <template #min-and-max-props>
@@ -53,6 +54,15 @@
         >
           Reset Value
         </p-button>
+      </div>
+    </template>
+
+    <template #disabled>
+      <div class="stepper__demo">
+        <p-stepper
+          :model-value="0"
+          disabled
+        />
       </div>
     </template>
   </ComponentPage>

--- a/src/components/Stepper/PStepper.vue
+++ b/src/components/Stepper/PStepper.vue
@@ -1,12 +1,12 @@
 <template>
-  <p-number-input v-model="internalValue" class="p-stepper">
+  <p-number-input v-model="internalValue" class="p-stepper" :disabled="disabled">
     <template #prepend>
       <p-button
         class="p-stepper__step p-stepper__step--down"
         flat
         small
         icon="MinusIcon"
-        :disabled="!canDecrease"
+        :disabled="disabled || !canDecrease"
         @click="internalValue -= step"
       />
     </template>
@@ -16,7 +16,7 @@
         flat
         small
         icon="PlusIcon"
-        :disabled="!canIncrease"
+        :disabled="disabled || !canIncrease"
         @click="internalValue += step"
       />
     </template>
@@ -29,6 +29,7 @@
 
   const props = withDefaults(defineProps<{
     modelValue: number | null | undefined,
+    disabled?: boolean,
     min?: number | null,
     max?: number | null,
     step?: number,


### PR DESCRIPTION
p-stepper does not currently accept `disabled` prop. It sort of works by passing that prop through to the underlying p-number-input component but the buttons used in prepend and append are stick clickable and still appear to modify the value. 

this change makes `disabled` an expected prop, uses to disable stepper buttons and still passes through to underlying p-number-input