### PR TITLE
update slot props on PTabSelect to be consistent with PTabNavigation

### DIFF
--- a/src/components/Tabs/PTabSelect.vue
+++ b/src/components/Tabs/PTabSelect.vue
@@ -10,9 +10,9 @@
     <template #option="{ option, index }">
       <slot
         :name="`${kebabCase(option.label)}-heading`"
-        v-bind="{ tab: option.label, index }"
+        v-bind="{ tab: option, index }"
       >
-        <slot name="heading" v-bind="{ tab: option.label, index }">
+        <slot name="heading" v-bind="{ tab: option, index }">
           {{ option.label }}
         </slot>
       </slot>


### PR DESCRIPTION
this change could theoretically introduce a breaking change if any thing was using PTabSelect and expected `tab` to be string. Theoretically any slot that accounted for this would have a case for `tab` being `{ label: string }`, which will always be the case now and shouldn't cause any issues.

closes #988