### PR TITLE
Remove p-overflow-menu-item's after slot styling if no slot content is provided.

### DIFF
--- a/src/components/OverflowMenuItem/POverflowMenuItem.vue
+++ b/src/components/OverflowMenuItem/POverflowMenuItem.vue
@@ -11,7 +11,7 @@
       <span>{{ label }}</span>
     </slot>
 
-    <div class="p-overflow-menu-item__after">
+    <div v-if="$slots.after" class="p-overflow-menu-item__after">
       <slot name="after" />
     </div>
   </component>


### PR DESCRIPTION
## Description
The deployment menu in Prefect has this implicit extra spacing
<img width="158" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/22418768/d88d6117-3a8a-4a83-a695-ca5a77f7ad16">

## What's changed 📸
| With `<template #after />` | **Before** | **After** |
| :----: | ---- | ---- |
| ✅ | <img width="311" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/22418768/48b816f6-898e-480d-b7ec-96fcff1cf534"> | <img width="289" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/22418768/ec327c8e-4829-40cf-9a25-ed404a30e01b"> |
| ❌ | <img width="302" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/22418768/5bbdd37e-9602-4a68-a840-40d4f270c46f"> | <img width="297" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/22418768/bdb5d0b2-03e1-4b42-b2ef-d0a10252ee2c"> |

