### PR TITLE
fix large screen padding in well layout

### DIFF
--- a/src/layouts/PLayoutWell/PLayoutWell.vue
+++ b/src/layouts/PLayoutWell/PLayoutWell.vue
@@ -16,7 +16,6 @@
 .p-layout-well {
   @apply
   p-4
-  lg:p-8
   grid
   grid-cols-[1fr_1fr_250px]
   grid-rows-[max-content_max-content]


### PR DESCRIPTION
Remove the bump in padding on large screens for PLayoutWell so that it matches PLayoutDefault and things line up nicely on the pages.