### PR TITLE
Enhancement: Improved sanitization

### DIFF
--- a/src/components/MarkdownRenderer/parser.ts
+++ b/src/components/MarkdownRenderer/parser.ts
@@ -137,7 +137,7 @@ const getVNode = (token: Token, options: ParserOptions): VNode | VNode[] => {
     const { href, title } = token
     const classList = [`${baseClass}__link`]
     const composedHref = normalizeHref(href)
-    return h(PLink, { to: composedHref, title, class: classList }, { default: () => token.text })
+    return h(PLink, { to: composedHref, title, class: classList, rel: 'noopener' }, { default: () => token.text })
   }
 
   return h(baseElement, props, children)

--- a/src/components/SanitizeHtml/PSanitizeHtml.vue
+++ b/src/components/SanitizeHtml/PSanitizeHtml.vue
@@ -13,13 +13,15 @@
     html: string,
   }>()
 
-  const forbiddenAttrs = ['style']
+  const forbiddenAttrs = ['style', 'action', 'method', 'onclick', 'onmouseover', 'onload', 'data']
+  const forbiddenTags = ['script', 'iframe', 'form']
   const useProfiles = { svg: true, html: true }
 
   const sanitize = (text: string): string => {
     return dompurify.sanitize(
       text,
       {
+        FORBID_TAGS: forbiddenTags,
         FORBID_ATTR: forbiddenAttrs,
         USE_PROFILES: useProfiles,
       },

--- a/src/components/SanitizeHtml/PSanitizeHtml.vue
+++ b/src/components/SanitizeHtml/PSanitizeHtml.vue
@@ -14,7 +14,7 @@
   }>()
 
   const forbiddenAttrs = ['style', 'action', 'method', 'onclick', 'onmouseover', 'onload', 'data']
-  const forbiddenTags = ['script', 'iframe', 'form']
+  const forbiddenTags = ['script', 'style', 'iframe', 'form']
   const useProfiles = { svg: true, html: true }
 
   const sanitize = (text: string): string => {

--- a/src/components/SanitizeHtml/PSanitizeHtml.vue
+++ b/src/components/SanitizeHtml/PSanitizeHtml.vue
@@ -13,7 +13,7 @@
     html: string,
   }>()
 
-  const forbiddenAttrs = ['style', 'action', 'method', 'onclick', 'onmouseover', 'onload', 'data']
+  const forbiddenAttrs = ['style', 'action', 'method', 'onclick', 'onmouseover', 'onload', 'data', 'onmousedown', 'onmouseup']
   const forbiddenTags = ['script', 'style', 'iframe', 'form']
   const useProfiles = { svg: true, html: true }
 


### PR DESCRIPTION
This PR updates the markdown renderer and sanitize html components to better improve their security posture.

`PSanitizeHtml` no longer allows `form` elements and explicitly forbids `script`, `style`, and `iframe` elements instead of relying on the default behavior of DOMPurify.

It also explicitly strips the following HTML attributes: 
- `action`
- `method`
- `onclick`
- `onmouseover`
- `onload`
- `data`

`PMarkdownRenderer`'s parser now also adds `rel="noopener"` to all markdown-created links (ones generated by `[link](https://some-link)`) as an added layer of protection against tab/window hijacking

