### PR TITLE
Enhancement: Allow passing sanitization config to `PSanitizeHtml` component

### DIFF
--- a/src/components/SanitizeHtml/PSanitizeHtml.vue
+++ b/src/components/SanitizeHtml/PSanitizeHtml.vue
@@ -10,17 +10,18 @@
   import { PUnwrap } from '@/components/Unwrap'
 
   const props = defineProps<{
-    html: string,
+    html: string | HTMLElement | DocumentFragment,
+    config?: dompurify.Config,
   }>()
 
   const forbiddenAttrs = ['style', 'action', 'method', 'onclick', 'onmouseover', 'onload', 'data', 'onmousedown', 'onmouseup']
   const forbiddenTags = ['script', 'style', 'iframe', 'form']
   const useProfiles = { svg: true, html: true }
 
-  const sanitize = (text: string): string => {
+  const sanitize = (text: string | HTMLElement | DocumentFragment): string | HTMLElement | DocumentFragment => {
     return dompurify.sanitize(
       text,
-      {
+      props.config ?? {
         FORBID_TAGS: forbiddenTags,
         FORBID_ATTR: forbiddenAttrs,
         USE_PROFILES: useProfiles,

--- a/src/components/Unwrap/PUnwrap.vue
+++ b/src/components/Unwrap/PUnwrap.vue
@@ -6,7 +6,7 @@
   import { DirectiveBinding, ref } from 'vue'
 
   defineProps<{
-    html: string,
+    html: string | HTMLElement | DocumentFragment,
   }>()
 
   const parentElement = ref()


### PR DESCRIPTION
This will provide downstream consumers a way to override the component defaults as necessary without needing to re-implement the component.

Note: I've also updated allowed types for both `PSanitizeHtml` and `PUnwrap` due to the change in overload coming from the config. 