### PR TITLE
add sort placement in table layout header

### DIFF
--- a/demo/sections/layouts/LayoutTable.vue
+++ b/demo/sections/layouts/LayoutTable.vue
@@ -12,16 +12,17 @@
           </template>
 
           <template #header-start>
-            <div class="bg-indigo-500 layout-table-section__box">
-              header-start
-            </div>
+            header-start
           </template>
 
           <template #header-end>
-            <div class="bg-violet-500 layout-table-section__box">
-              header-end
-            </div>
+            header-end
           </template>
+
+          <template #header-sort>
+            header-sort
+          </template>
+
 
           <div class="bg-blue-200 dark:bg-blue-800 layout-table-section__box layout-table__main">
             main
@@ -60,15 +61,15 @@
           </template>
 
           <template #header-start>
-            <div class="bg-indigo-500 layout-table-section__box">
-              header-start
-            </div>
+            header-start
           </template>
 
           <template #header-end>
-            <div class="bg-violet-500 layout-table-section__box">
-              header-end
-            </div>
+            header-end
+          </template>
+
+          <template #header-sort>
+            header-sort
           </template>
 
 

--- a/src/layouts/PLayoutTable/PLayoutTable.vue
+++ b/src/layouts/PLayoutTable/PLayoutTable.vue
@@ -8,6 +8,12 @@
 
         <div class="p-layout-table__section p-layout-table__section--end">
           <slot name="header-end" />
+
+          <template v-if="slots['header-sort']">
+            <div class="p-layout-table__header-sort">
+              <slot name="header-sort" />
+            </div>
+          </template>
         </div>
       </slot>
     </div>
@@ -30,7 +36,7 @@
 
 <script lang="ts" setup>
   import { UsePositionStickyObserverOptions, usePositionStickyObserver } from '@prefecthq/vue-compositions'
-  import { computed, ref, toRefs } from 'vue'
+  import { computed, ref, toRefs, useSlots } from 'vue'
   import { Getter } from '@/types'
 
   const props = defineProps<{
@@ -40,6 +46,8 @@
     // class to apply when the header is stuck to a different scroll container.
     boundingElement?: HTMLElement,
   }>()
+
+  const slots = useSlots()
 
   const stickyHeader = ref<HTMLElement>()
 
@@ -69,6 +77,12 @@
   mb-2
   p-2
   gap-2
+}
+
+.p-layout-table__header-sort { @apply
+  border-l
+  border-l-divider
+  pl-2
 }
 
 .p-layout-table__header--sticky { @apply


### PR DESCRIPTION
Creates a dedicated space in the table header for sort options, so it can be separated with a divider from other filter options:

<img width="1255" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6776415/36d4a538-8b86-41c3-9c1e-86611b1bbf36">
