### PR TITLE
Chore: Remove @types/tailwindcss

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "@types/dompurify": "^3.0.1",
         "@types/marked": "^4.0.8",
         "@types/node": "^20.1.6",
-        "@types/tailwindcss": "^3.0.10",
         "@vitejs/plugin-vue": "4.4.0",
         "auto-changelog": "^2.4.0",
         "autoprefixer": "^10.4.6",
@@ -1035,16 +1034,6 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
       "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
-    },
-    "node_modules/@types/tailwindcss": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/tailwindcss/-/tailwindcss-3.1.0.tgz",
-      "integrity": "sha512-JxPzrm609hzvF4nmOI3StLjbBEP3WWQxDDJESqR1nh94h7gyyy3XSl0hn5RBMJ9mPudlLjtaXs5YEBtLw7CnPA==",
-      "deprecated": "This is a stub types definition. tailwindcss provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "tailwindcss": "*"
-      }
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.2",
@@ -6373,15 +6362,6 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
       "integrity": "sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==",
       "dev": true
-    },
-    "@types/tailwindcss": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/tailwindcss/-/tailwindcss-3.1.0.tgz",
-      "integrity": "sha512-JxPzrm609hzvF4nmOI3StLjbBEP3WWQxDDJESqR1nh94h7gyyy3XSl0hn5RBMJ9mPudlLjtaXs5YEBtLw7CnPA==",
-      "dev": true,
-      "requires": {
-        "tailwindcss": "*"
-      }
     },
     "@types/trusted-types": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "@types/dompurify": "^3.0.1",
     "@types/marked": "^4.0.8",
     "@types/node": "^20.1.6",
-    "@types/tailwindcss": "^3.0.10",
     "@vitejs/plugin-vue": "4.4.0",
     "auto-changelog": "^2.4.0",
     "autoprefixer": "^10.4.6",


### PR DESCRIPTION
# Description
Noticed this npm warning while installing packages
```
WARN deprecated @types/tailwindcss@3.1.0: This is a stub types definition. tailwindcss provides its own type definitions, so you do not need this installed.
```

Confirmed by https://www.npmjs.com/package/@types/tailwindcss

So uninstalling the package. 