### PR TITLE
Native date and time input components

### DIFF
--- a/demo/sections/components/NativeTimeInput.vue
+++ b/demo/sections/components/NativeTimeInput.vue
@@ -1,0 +1,33 @@
+<template>
+  <ComponentPage title="Native Time Input" :demos="[{ title: 'Native Time Input' }]">
+    <template #description>
+      <DemoState v-model:state="exampleState" v-model:disabled="disabled" />
+    </template>
+
+    <template #native-time-input>
+      <p-label :message="JSON.stringify(exampleDate)" :state="exampleState">
+        <p-native-time-input
+          v-model="exampleDate"
+          :min="minDate"
+          :max="maxDate"
+          :disabled="disabled"
+          :state="exampleState"
+        />
+      </p-label>
+    </template>
+  </ComponentPage>
+</template>
+
+<script lang="ts" setup>
+  import { State } from '@/types'
+  import { ref } from 'vue'
+  import ComponentPage from '@/demo/components/ComponentPage.vue'
+  import DemoState from '@/demo/components/DemoState.vue'
+
+  const exampleState = ref<State>()
+  const disabled = ref(false)
+
+  const exampleDate = ref<Date | null>()
+  const minDate = ref<Date | null>(null)
+  const maxDate = ref<Date | null>(null)
+</script>

--- a/demo/sections/components/index.ts
+++ b/demo/sections/components/index.ts
@@ -36,6 +36,7 @@ export const components: Section = {
   modals: () => import('./Modals.vue'),
   nativeDateInput: () => import('./NativeDateInput.vue'),
   nativeSelect: () => import('./NativeSelect.vue'),
+  nativeTimeInput: () => import('./NativeTimeInput.vue'),
   numberInput: () => import('./NumberInput.vue'),
   overflowMenu: () => import('./OverflowMenu.vue'),
   pager: () => import('./Pager.vue'),

--- a/src/components/NativeDateInput/PNativeDateInput.vue
+++ b/src/components/NativeDateInput/PNativeDateInput.vue
@@ -16,7 +16,7 @@
       >
     </template>
 
-    <template #append>
+    <template v-if="!disablePicker" #append>
       <PButton icon="CalendarIcon" small flat class="p-native-date-input__picker" @click="showPicker" />
     </template>
   </PBaseInput>
@@ -31,6 +31,7 @@
     modelValue: Date | null | undefined,
     min?: Date | null,
     max?: Date | null,
+    disablePicker?: boolean,
   }>()
 
   const emit = defineEmits<{

--- a/src/components/NativeDateInput/PNativeDateInput.vue
+++ b/src/components/NativeDateInput/PNativeDateInput.vue
@@ -3,84 +3,47 @@
     <template v-for="(index, name) in $slots" #[name]="data">
       <slot :name="name" v-bind="data" />
     </template>
+
     <template #control="{ attrs }">
-      <template v-if="dateMode">
-        <input
-          ref="inputElement"
-          v-model="stringValue"
-          type="date"
-          class="p-native-date-input__control"
-          :min="stringMin"
-          :max="stringMax"
-          v-bind="attrs"
-        >
-        <input
-          ref="inputElement"
-          v-model="stringValue"
-          type="date"
-          class="p-native-date-input__control p-native-date-input__control--placeholder"
-          :min="stringMin"
-          :max="stringMax"
-          v-bind="attrs"
-        >
-      </template>
-
-      <template v-else>
-        <div class="p-native-date-input__time-pickers">
-          <p-native-select v-model="selectedHours" class="p-native-date-input__picker" :options="hourOptions" />
-          <p-native-select v-model="selectedMinutes" class="p-native-date-input__picker" :options="minuteOptions" />
-          <p-native-select v-model="selectedMeridiem" class="p-native-date-input__picker" :options="meridiemOptions" />
-        </div>
-      </template>
-
-      <template v-if="showTime">
-        <p-button
-          class="p-native-date-input__mode-toggle"
-          small
-          flat
-          icon="ClockIcon"
-          @click="dateMode = !dateMode"
-        />
-      </template>
+      <input
+        ref="inputElement"
+        v-model="stringValue"
+        type="date"
+        class="p-native-date-input__control"
+        :min="stringMin"
+        :max="stringMax"
+        v-bind="attrs"
+      >
     </template>
 
     <template #append>
-      <div class="p-native-date-input__icon">
-        <PIcon icon="CalendarIcon" />
-      </div>
+      <PButton icon="CalendarIcon" small flat class="p-native-date-input__picker" @click="showPicker" />
     </template>
   </PBaseInput>
 </template>
 
 <script lang="ts" setup>
-  import { format, parseISO, startOfMinute } from 'date-fns'
-  import { computed, ref } from 'vue'
+  import { format, parseISO } from 'date-fns'
+  import { computed, readonly, ref } from 'vue'
   import PBaseInput from '@/components/BaseInput/PBaseInput.vue'
-  import PIcon from '@/components/Icon/PIcon.vue'
-  import { useTimeParts } from '@/compositions/useTimeParts'
-  import { keepDateInRange } from '@/utilities/dates'
 
   const props = defineProps<{
     modelValue: Date | null | undefined,
     min?: Date | null,
     max?: Date | null,
-    showTime?: boolean,
   }>()
 
   const emit = defineEmits<{
     (event: 'update:modelValue', value: Date | null): void,
   }>()
 
-  const dateMode = ref(true)
-  const internalValue = computed(() => props.modelValue ?? null)
   const inputElement = ref<HTMLInputElement>()
-  const el = computed(() => inputElement.value)
 
-  defineExpose({ inputElement, el })
+  defineExpose({ el: readonly(inputElement) })
 
   const stringValue = computed({
     get() {
-      return internalValue.value ? format(internalValue.value, 'yyyy-MM-dd') : null
+      return props.modelValue ? format(props.modelValue, 'yyyy-MM-dd') : null
     },
     set(value) {
       emit('update:modelValue', value ? parseISO(value) : null)
@@ -90,90 +53,31 @@
   const stringMin = computed(() => props.min ? format(props.min, 'yyyy-MM-dd') : undefined)
   const stringMax = computed(() => props.max ? format(props.max, 'yyyy-MM-dd') : undefined)
 
-  const selectedDate = computed({
-    get() {
-      return props.modelValue ?? startOfMinute(new Date())
-    },
-    set(value) {
-      const withoutSeconds = startOfMinute(value)
-
-      emit('update:modelValue', keepDateInRange(withoutSeconds, range.value))
-    },
-  })
-
-  const range = computed(() => ({ min: props.min, max: props.max }))
-
-  const {
-    selectedHours,
-    selectedMinutes,
-    selectedMeridiem,
-    hourOptions,
-    minuteOptions,
-    meridiemOptions,
-  } = useTimeParts(selectedDate, range)
+  function showPicker(): void {
+    inputElement.value?.showPicker()
+  }
 </script>
 
 <style>
-.p-native-date-input { @apply
-  relative
-  appearance-none
-  bg-none
-}
-
-.p-native-date-input__icon { @apply
-  pr-3
-  flex
-  items-center
-  z-10
-  pointer-events-none
-}
-
 .p-native-date-input__control { @apply
   bg-transparent
-  absolute
-  top-0
-  bottom-0
-  left-0
-  right-0
+  block
   w-full
   rounded-default
   border-0
   focus:ring-0
 }
 
-.p-native-date-input__control:disabled { @apply
-  cursor-not-allowed
-}
-
-.p-native-date-input__control--placeholder { @apply
-  relative
-  invisible
-  w-full
-}
-
-.p-native-date-input .p-native-date-input__control::-webkit-calendar-picker-indicator { @apply
-  cursor-pointer
-  bg-none
-}
-
-.p-native-date-input .p-native-date-input__control--placeholder::-webkit-calendar-picker-indicator {
+.p-native-date-input__control::-webkit-calendar-picker-indicator {
   display: none;
   -webkit-appearance: none;
 }
 
-.p-native-date-input__mode-toggle { @apply
-  mr-2
-}
-
-.p-native-date-input__time-pickers { @apply
-  flex
-  flex-grow
-  justify-around
+.p-native-date-input__control:disabled { @apply
+  cursor-not-allowed
 }
 
 .p-native-date-input__picker { @apply
-  w-min
-  border-0
-  !ring-0
+  mr-2
 }
 </style>

--- a/src/components/NativeDateInput/PNativeDateInput.vue
+++ b/src/components/NativeDateInput/PNativeDateInput.vue
@@ -46,7 +46,19 @@
       return props.modelValue ? format(props.modelValue, 'yyyy-MM-dd') : null
     },
     set(value) {
-      emit('update:modelValue', value ? parseISO(value) : null)
+      if (!value) {
+        emit('update:modelValue', null)
+        return
+      }
+
+      const parsed = parseISO(value)
+
+      if (props.modelValue) {
+        parsed.setHours(props.modelValue.getHours())
+        parsed.setMinutes(props.modelValue.getMinutes())
+      }
+
+      emit('update:modelValue', parsed)
     },
   })
 

--- a/src/components/NativeTimeInput/PNativeTimeInput.vue
+++ b/src/components/NativeTimeInput/PNativeTimeInput.vue
@@ -1,0 +1,91 @@
+<template>
+  <PBaseInput class="p-native-time-input">
+    <template v-for="(index, name) in $slots" #[name]="data">
+      <slot :name="name" v-bind="data" />
+    </template>
+
+    <template #control="{ attrs }">
+      <input
+        ref="inputElement"
+        v-model="stringValue"
+        type="time"
+        class="p-native-time-input__control"
+        :min="stringMin"
+        :max="stringMax"
+        v-bind="attrs"
+      >
+    </template>
+
+    <template #append>
+      <PButton icon="ClockIcon" small flat class="p-native-time-input__picker" @click="showPicker" />
+    </template>
+  </PBaseInput>
+</template>
+
+<script lang="ts" setup>
+  import { format, parse } from 'date-fns'
+  import { computed, readonly, ref } from 'vue'
+  import PBaseInput from '@/components/BaseInput/PBaseInput.vue'
+
+  const props = defineProps<{
+    modelValue: Date | null | undefined,
+    min?: Date | null,
+    max?: Date | null,
+  }>()
+
+  const emit = defineEmits<{
+    (event: 'update:modelValue', value: Date | null): void,
+  }>()
+
+  const inputElement = ref<HTMLInputElement>()
+
+  defineExpose({ el: readonly(inputElement) })
+
+  const stringValue = computed({
+    get() {
+      return props.modelValue ? format(props.modelValue, 'HH:mm') : null
+    },
+    set(value) {
+      if (!value) {
+        emit('update:modelValue', null)
+        return
+      }
+
+      const reference = props.modelValue ?? new Date()
+      const parsed = parse(value, 'H:mm', reference)
+
+      emit('update:modelValue', parsed)
+    },
+  })
+
+  const stringMin = computed(() => props.min ? format(props.min, 'yyyy-MM-dd') : undefined)
+  const stringMax = computed(() => props.max ? format(props.max, 'yyyy-MM-dd') : undefined)
+
+  function showPicker(): void {
+    inputElement.value?.showPicker()
+  }
+</script>
+
+<style>
+.p-native-time-input__control { @apply
+  bg-transparent
+  block
+  w-full
+  rounded-default
+  border-0
+  focus:ring-0
+}
+
+.p-native-time-input__control::-webkit-calendar-picker-indicator {
+  display: none;
+  -webkit-appearance: none;
+}
+
+.p-native-time-input__control:disabled { @apply
+  cursor-not-allowed
+}
+
+.p-native-time-input__picker { @apply
+  mr-2
+}
+</style>

--- a/src/components/NativeTimeInput/PNativeTimeInput.vue
+++ b/src/components/NativeTimeInput/PNativeTimeInput.vue
@@ -16,7 +16,7 @@
       >
     </template>
 
-    <template #append>
+    <template v-if="!disablePicker" #append>
       <PButton icon="ClockIcon" small flat class="p-native-time-input__picker" @click="showPicker" />
     </template>
   </PBaseInput>
@@ -31,6 +31,7 @@
     modelValue: Date | null | undefined,
     min?: Date | null,
     max?: Date | null,
+    disablePicker?: boolean,
   }>()
 
   const emit = defineEmits<{

--- a/src/components/NativeTimeInput/index.ts
+++ b/src/components/NativeTimeInput/index.ts
@@ -1,0 +1,8 @@
+import { App } from 'vue'
+import PNativeTimeInput from '@/components/NativeTimeInput/PNativeTimeInput.vue'
+
+const install = (app: App): void => {
+  app.component('PNativeTimeInput', PNativeTimeInput)
+}
+
+export { PNativeTimeInput, install }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -49,6 +49,7 @@ import { PMessage, install as installPMessage } from '@/components/Message'
 import { PModal, install as installPModal } from '@/components/Modal'
 import { PNativeDateInput, install as installPNativeDateInput } from '@/components/NativeDateInput'
 import { PNativeSelect, install as installPNativeSelect } from '@/components/NativeSelect'
+import { PNativeTimeInput, install as installPNativeTimeInput } from '@/components/NativeTimeInput'
 import { PNavigationBar, install as installPNavigationBar } from '@/components/NavigationBar'
 import { PNumberInput, install as installPNumberInput } from '@/components/NumberInput'
 import { POverflowMenu, install as installPOverflowMenu } from '@/components/OverflowMenu'
@@ -137,6 +138,7 @@ export {
   PModal,
   PNativeDateInput,
   PNativeSelect,
+  PNativeTimeInput,
   PNavigationBar,
   PNumberInput,
   POverflowMenu,
@@ -236,6 +238,7 @@ export const installs = [
   installPModal,
   installPNativeDateInput,
   installPNativeSelect,
+  installPNativeTimeInput,
   installPNavigationBar,
   installPNumberInput,
   installPOverflowMenu,
@@ -325,6 +328,7 @@ declare module '@vue/runtime-core' {
     PModal: typeof PModal,
     PNativeDateInput: typeof PNativeDateInput,
     PNativeSelect: typeof PNativeSelect,
+    PNativeTimeInput: typeof PNativeDateInput,
     PNavigationBar: typeof PNavigationBar,
     PNumberInput: typeof PNumberInput,
     POverflowMenu: typeof POverflowMenu,


### PR DESCRIPTION
# Description
Updates the existing native date input component and adds a new native time input component.

## Date
Works exactly the same as before with the exception of removing the ability to also enter time. Which now has a dedicated input for. Also fixes an issue where if a date that already had time was v-model'd the time would be reset. This way the same date can be bound to both the date and the time inputs
<img width="778" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6200442/c0fea474-efb9-4796-b859-fd6bdd8be8fd">

Time
Almost identical to the native date input in functionality. Also preserves the date of the v-model when updating the time. 
<img width="794" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6200442/3b812f05-817b-489f-931e-930345b9dbe3">
