### PR TITLE
Make sentiment colors work with tw opacity modifiers

### DIFF
--- a/public/tailwindPlugin.js
+++ b/public/tailwindPlugin.js
@@ -14,9 +14,9 @@ const colors = {
   'focus-ring': 'var(--p-color-focus-ring)',
   'focus-ring-offset': 'var(--p-color-focus-ring-offset)',
   live: 'var(--p-color-live)',
-  'sentiment-positive': 'var(--p-color-sentiment-positive)',
-  'sentiment-neutral': 'var(--p-color-sentiment-neutral)',
-  'sentiment-negative': 'var(--p-color-sentiment-negative)',
+  'sentiment-positive': 'hsl(var(--p-color-sentiment-positive-hsl-values) / <alpha-value>)',
+  'sentiment-neutral': 'hsl(var(--p-color-sentiment-neutral-hsl-values) / <alpha-value>)',
+  'sentiment-negative': 'hsl(var(--p-color-sentiment-negative-hsl-values) / <alpha-value>)',
 }
 
 const spacing = {

--- a/public/tailwindPlugin.js
+++ b/public/tailwindPlugin.js
@@ -16,6 +16,7 @@ const colors = {
   live: 'var(--p-color-live)',
   'sentiment-positive': 'hsl(var(--p-color-sentiment-positive-hsl-values) / <alpha-value>)',
   'sentiment-neutral': 'hsl(var(--p-color-sentiment-neutral-hsl-values) / <alpha-value>)',
+  'sentiment-warning': 'hsl(var(--p-color-sentiment-warning-hsl-values) / <alpha-value>)',
   'sentiment-negative': 'hsl(var(--p-color-sentiment-negative-hsl-values) / <alpha-value>)',
 }
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -57,7 +57,11 @@
     --p-color-sentiment-neutral-lightness: 46%;
     --p-color-sentiment-neutral-hsl-values: var(--p-color-sentiment-neutral-hue) var(--p-color-sentiment-neutral-saturation) var(--p-color-sentiment-neutral-lightness);
     --p-color-sentiment-neutral: hsl(var(--p-color-sentiment-neutral-hsl-values));
-    --p-color-sentiment-warning: #F5A50A;
+    --p-color-sentiment-warning-hue: 40deg;
+    --p-color-sentiment-warning-saturation: 92%;
+    --p-color-sentiment-warning-lightness: 50%;
+    --p-color-sentiment-warning-hsl-values: var(--p-color-sentiment-warning-hue) var(--p-color-sentiment-warning-saturation) var(--p-color-sentiment-warning-lightness);
+    --p-color-sentiment-warning: hsl(var(--p-color-sentiment-warning-hsl-values));
     --p-color-sentiment-negative-hue: 4deg;
     --p-color-sentiment-negative-saturation: 74%;
     --p-color-sentiment-negative-lightness: 49%;
@@ -221,7 +225,11 @@
     --p-color-sentiment-neutral-lightness: 46%;
     --p-color-sentiment-neutral-hsl-values: var(--p-color-sentiment-neutral-hue) var(--p-color-sentiment-neutral-saturation) var(--p-color-sentiment-neutral-lightness);
     --p-color-sentiment-neutral: hsl(var(--p-color-sentiment-neutral-hsl-values));
-    --p-color-sentiment-warning: #F5A50A;
+    --p-color-sentiment-warning-hue: 40deg;
+    --p-color-sentiment-warning-saturation: 92%;
+    --p-color-sentiment-warning-lightness: 50%;
+    --p-color-sentiment-warning-hsl-values: var(--p-color-sentiment-warning-hue) var(--p-color-sentiment-warning-saturation) var(--p-color-sentiment-warning-lightness);
+    --p-color-sentiment-warning: hsl(var(--p-color-sentiment-warning-hsl-values));
     --p-color-sentiment-negative-hue: 4deg;
     --p-color-sentiment-negative-saturation: 74%;
     --p-color-sentiment-negative-lightness: 49%;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -47,10 +47,22 @@
 
     --p-color-live: #6272FF;
 
-    --p-color-sentiment-positive: #22C55E;
-    --p-color-sentiment-neutral: #70707B;
+    --p-color-sentiment-positive-hue: 142deg;
+    --p-color-sentiment-positive-saturation: 71%;
+    --p-color-sentiment-positive-lightness: 45%;
+    --p-color-sentiment-positive-hsl-values: var(--p-color-sentiment-positive-hue) var(--p-color-sentiment-positive-saturation) var(--p-color-sentiment-positive-lightness);
+    --p-color-sentiment-positive: hsl(var(--p-color-sentiment-positive-hsl-values));
+    --p-color-sentiment-neutral-hue: 240deg;
+    --p-color-sentiment-neutral-saturation: 5%;
+    --p-color-sentiment-neutral-lightness: 46%;
+    --p-color-sentiment-neutral-hsl-values: var(--p-color-sentiment-neutral-hue) var(--p-color-sentiment-neutral-saturation) var(--p-color-sentiment-neutral-lightness);
+    --p-color-sentiment-neutral: hsl(var(--p-color-sentiment-neutral-hsl-values));
     --p-color-sentiment-warning: #F5A50A;
-    --p-color-sentiment-negative: #D92D21;
+    --p-color-sentiment-negative-hue: 4deg;
+    --p-color-sentiment-negative-saturation: 74%;
+    --p-color-sentiment-negative-lightness: 49%;
+    --p-color-sentiment-negative-hsl-values: var(--p-color-sentiment-negative-hue) var(--p-color-sentiment-negative-saturation) var(--p-color-sentiment-negative-lightness);
+    --p-color-sentiment-negative: hsl(var(--p-color-sentiment-negative-hsl-values));
 
     /* Text */
     --p-color-text-default: #FFFFFF;
@@ -199,10 +211,22 @@
 
     --p-color-live: #4B5CFF;
 
-    --p-color-sentiment-positive: #22C55E;
-    --p-color-sentiment-neutral: #70707B;
+    --p-color-sentiment-positive-hue: 142deg;
+    --p-color-sentiment-positive-saturation: 71%;
+    --p-color-sentiment-positive-lightness: 45%;
+    --p-color-sentiment-positive-hsl-values: var(--p-color-sentiment-positive-hue) var(--p-color-sentiment-positive-saturation) var(--p-color-sentiment-positive-lightness);
+    --p-color-sentiment-positive: hsl(var(--p-color-sentiment-positive-hsl-values));
+    --p-color-sentiment-neutral-hue: 240deg;
+    --p-color-sentiment-neutral-saturation: 5%;
+    --p-color-sentiment-neutral-lightness: 46%;
+    --p-color-sentiment-neutral-hsl-values: var(--p-color-sentiment-neutral-hue) var(--p-color-sentiment-neutral-saturation) var(--p-color-sentiment-neutral-lightness);
+    --p-color-sentiment-neutral: hsl(var(--p-color-sentiment-neutral-hsl-values));
     --p-color-sentiment-warning: #F5A50A;
-    --p-color-sentiment-negative: #D92D21;
+    --p-color-sentiment-negative-hue: 4deg;
+    --p-color-sentiment-negative-saturation: 74%;
+    --p-color-sentiment-negative-lightness: 49%;
+    --p-color-sentiment-negative-hsl-values: var(--p-color-sentiment-negative-hue) var(--p-color-sentiment-negative-saturation) var(--p-color-sentiment-negative-lightness);
+    --p-color-sentiment-negative: hsl(var(--p-color-sentiment-negative-hsl-values));
 
     /* Text */
     --p-color-text-default: #171717;


### PR DESCRIPTION
At the moment, our custom sentiment colors don't work with tailwind's [opacity modifiers](https://tailwindcss.com/docs/text-color#changing-the-opacity). So it's difficult to take our design token as-is and apply an alpha channel to it without having to break out of the design system and losing the ability to "just update the color in one place". This PR addresses this issue.

### How/why does it work? (see [the docs](https://tailwindcss.com/docs/customizing-colors#using-css-variables))
The current system defines colors using CSS variables which have hex color values. Hex doesn't support the alpha channel color modifier syntax (`{value} / {opacity}`) which Tailwind will use for its opacity modifiers so we need to switch over to either RGB or HSL. 
1. Swap from hex to RGB/HSL
2. Tailwind needs the "raw" values (or for RGB, color channels) to then use within an `rgb`/`hsl` function so we provide a "template" to tailwind instead of the literal color value which will take the alpha channel into account. 

> [!Note]
> While I was in here, I also added `sentiment-warning` in as a color for tailwind

### The end result
<img width="908" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/22418768/67248f9b-5845-4130-a9d9-e0857be52a3f">

> [!Note]
> The green circles above were made using tailwind's `ring` utilities. More specifically, something like `w-1 h-1 rounded-full bg-sentiment-positive ring-4 ring-sentiment-positive ring-opacity-25`. Notice the outer ring color uses the same exact color but with an opacity modifier applied to it. Without the changes in this PR, the `ring-opacity-25` doesn't work and neither would something like `ring-sentiment-positive/25`
