### PR TITLE
Remove vertical space when p-layout-default header slot unused.

### DIFF
--- a/src/layouts/PLayoutDefault/PLayoutDefault.vue
+++ b/src/layouts/PLayoutDefault/PLayoutDefault.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="p-layout-default">
-    <div class="p-layout-default__header">
+    <div v-if="$slots.header" class="p-layout-default__header">
       <slot name="header" class="p-layout-default__header" />
     </div>
     <div class="p-layout-default__content">


### PR DESCRIPTION
```html
<p-layout-default>
  <p>some content</p>
</p-layout-default>
```

Produces an extra 16px of top spacing because it expects header content. This PR skips rendering the slot if there's no content provided so that there's no child element to produce the 16px grid gap.

Should maybe consider deprecating the header slot entirely as it doesn't provide a ton. 