### PR TITLE
Expose PTextarea's `<textarea>` element.

### DIFF
--- a/src/components/Textarea/PTextarea.vue
+++ b/src/components/Textarea/PTextarea.vue
@@ -4,13 +4,13 @@
       <slot :name="name" v-bind="data" />
     </template>
     <template #control="{ attrs }">
-      <textarea v-model="value" class="p-textarea__control" v-bind="attrs" />
+      <textarea ref="el" v-model="value" class="p-textarea__control" v-bind="attrs" />
     </template>
   </PBaseInput>
 </template>
 
 <script lang="ts" setup>
-  import { computed } from 'vue'
+  import { computed, ref } from 'vue'
   import PBaseInput from '@/components/BaseInput/PBaseInput.vue'
 
   const props = defineProps<{
@@ -20,6 +20,10 @@
   const emits = defineEmits<{
     (event: 'update:modelValue', value: string | null): void,
   }>()
+
+  const el = ref<HTMLTextAreaElement>()
+
+  defineExpose({ el })
 
   const value = computed({
     get() {


### PR DESCRIPTION
## Problem
When a template ref is passed into a `<p-textarea>` component, it gets caught at `PBaseInput` so it's otherwise _difficult_ to get a reference to the underlying `<textarea>` element.

```vue
<template>
  <p-textarea :v-model="..." ref="elRef" />
</template>

<script setup lang="ts">
  ...
  const elRef = ref<InstanceType<typeof PTextarea>>()
  
  onMounted(() => {
    elRef.value.focus()  // nope. it's a component template ref
    elRef.value.$el.focus()  // _nope_. elRef.$el is an HTMLDivElement 😱 b/c it falls through onto <PBaseInput>
    elRef.value.$el.querySelector("textarea")?.focus()  // 🙈 well this works at least
  })
```

## Solution
This PR follows the same pattern/convention as `PTextInput` which just _exposes_ a property called `el` on the component's VM. In the above example, you can now do `elRef.value.el.focus()`.