### PR TITLE
Chore: Update PSelectOptions to handle its own selection logic

### DIFF
--- a/src/components/NativeSelect/PNativeSelect.vue
+++ b/src/components/NativeSelect/PNativeSelect.vue
@@ -38,11 +38,12 @@
   import { computed } from 'vue'
   import PBaseInput from '@/components/BaseInput/PBaseInput.vue'
   import PIcon from '@/components/Icon/PIcon.vue'
+  import { MaybeReadonly } from '@/types'
   import { SelectModelValue, SelectOptionGroup, normalizeSelectOption, isSelectOptionGroup, flattenSelectOptions, SelectOption } from '@/types/selectOption'
 
   const props = defineProps<{
     modelValue: string | number | boolean | null | SelectModelValue[] | undefined,
-    options: (SelectOption | SelectOptionGroup)[],
+    options: MaybeReadonly<(SelectOption | SelectOptionGroup)[]>,
   }>()
 
   const emits = defineEmits<{

--- a/src/components/Select/PSelect.vue
+++ b/src/components/Select/PSelect.vue
@@ -17,7 +17,6 @@
           :class="classes.control"
           :disabled="disabled"
           v-bind="attrs"
-          :options="selectOptions"
           @click="toggleSelect"
         >
           <template #default>
@@ -62,21 +61,19 @@
           :class="classes.control"
           :disabled="disabled"
           v-bind="attrs"
-          :options="selectOptions"
+          :options="options"
         />
       </template>
     </template>
 
     <PSelectOptions
       v-model="modelValue"
-      v-model:highlightedValue="highlightedValue"
       class="p-select__options"
-      :options="selectOptions"
+      :options="options"
       :style="styles.option"
       :multiple="multiple"
       @update:model-value="closeIfNotMultiple"
       @keydown="handleKeydown"
-      @mouseleave="setHighlightedValueUnselected"
       @bottom="emit('bottom')"
     >
       <template v-for="(index, name) in $slots" #[name]="data">
@@ -104,10 +101,9 @@
   import PTag from '@/components/Tag/PTag.vue'
   import PTagWrapper from '@/components/TagWrapper/PTagWrapper.vue'
   import { useAttrsStylesAndClasses } from '@/compositions/attributes'
-  import { useHighlightedValue } from '@/compositions/useHighlightedValue'
   import { MaybeReadonly } from '@/types'
   import { isAlphaNumeric, keys } from '@/types/keyEvent'
-  import { SelectModelValue, flattenSelectOptions, normalizeSelectOption, SelectOptionGroup, SelectOptionNormalized, SelectOption, isSelectOptionNormalized } from '@/types/selectOption'
+  import { SelectModelValue, flattenSelectOptions, normalizeSelectOption, SelectOptionGroup, SelectOptionNormalized, SelectOption } from '@/types/selectOption'
   import { TagValue } from '@/types/tag'
   import { asArray, isArray } from '@/utilities/arrays'
   import { media } from '@/utilities/media'
@@ -134,6 +130,10 @@
 
   const modelValue = computed({
     get() {
+      if (multiple.value) {
+        return props.modelValue ?? []
+      }
+
       return props.modelValue ?? null
     },
     set(value) {
@@ -148,24 +148,18 @@
     }))
   })
 
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const multiple = computed(() => props.multiple || isArray(modelValue.value))
 
   const isOpen = computed(() => popOver.value?.visible ?? false)
   const showShowEmptyMessage = computed(() => {
-    if (isArray(modelValue.value)) {
-      return modelValue.value.length === 0
+    if (multiple.value) {
+      return asArray(modelValue.value).length === 0
     }
 
     return modelValue.value === null
   })
 
-  const selectOptions = computed(() => {
-    return props.options.map(normalizeSelectOption)
-  })
-
-  const flatSelectOptions = computed(() => flattenSelectOptions(selectOptions.value))
-  const { highlightedValue, isUnselected, setHighlightedValueUnselected, setNextHighlightedValue, setPreviousHighlightedValue } = useHighlightedValue(flatSelectOptions)
+  const flatSelectOptions = computed(() => flattenSelectOptions(props.options.map(normalizeSelectOption)))
 
   function getSelectOption(value: unknown): SelectOptionNormalized | undefined {
     return flatSelectOptions.value.find(option => option.value === value)
@@ -231,24 +225,6 @@
     }
   }
 
-  function setValue(newValue: SelectModelValue): void {
-    if (Array.isArray(modelValue.value)) {
-      const index = modelValue.value.indexOf(newValue)
-
-      if (index > -1) {
-        modelValue.value = [...modelValue.value.slice(0, index), ...modelValue.value.slice(index + 1)]
-      } else {
-        modelValue.value = [...modelValue.value, newValue]
-      }
-    } else {
-      modelValue.value = newValue
-    }
-
-    if (!multiple.value) {
-      closeSelect()
-    }
-  }
-
   function handleOpenChange(open: boolean): void {
     if (open) {
       emit('open')
@@ -270,46 +246,13 @@
         closeSelect()
         break
       case keys.upArrow:
-        if (!isOpen.value) {
-          openSelect()
-        } else {
-          setPreviousHighlightedValue()
-        }
-        event.preventDefault()
-        break
       case keys.downArrow:
-        if (!isOpen.value) {
-          openSelect()
-        } else {
-          setNextHighlightedValue()
-        }
-        event.preventDefault()
-        break
       case keys.space:
         if (!isOpen.value) {
           openSelect()
-        } else if (!isUnselected(highlightedValue.value)) {
-          setValue(highlightedValue.value)
-        }
-        event.preventDefault()
-        break
-      case keys.enter:
-        if (!isOpen.value) {
-          return
-        }
-
-        if (selectOptions.value.length === 1) {
-          const [first] = selectOptions.value
-
-          if (isSelectOptionNormalized(first)) {
-            setValue(first.value)
-          }
-        } else if (!isUnselected(highlightedValue.value)) {
-          setValue(highlightedValue.value)
           event.preventDefault()
         }
-        break
-      default:
+
         break
     }
   }

--- a/src/utilities/arrays.ts
+++ b/src/utilities/arrays.ts
@@ -30,3 +30,15 @@ export function isArray<T>(value: T | T[]): value is T[] {
 export function sortStringArray(array: string[]): string[] {
   return array.sort((stringA: string, stringB: string) => stringA.localeCompare(stringB))
 }
+
+export function toggleArrayValue<T>(array: T[], value: T): T[] {
+  const index = array.indexOf(value)
+
+  if (index > -1) {
+    array = [...array.slice(0, index), ...array.slice(index + 1)]
+  } else {
+    array = [...array, value]
+  }
+
+  return array
+}


### PR DESCRIPTION
# Description
Small refactor so that PSelectOptions can be used on its own without reproducing all of the logic for highlighting and selecting values. 