### PR TITLE
Chore: Separate the PDateInput and PDateRangeInput

### DIFF
--- a/src/components/DateInput/PDateInput.vue
+++ b/src/components/DateInput/PDateInput.vue
@@ -1,16 +1,15 @@
 <template>
-  <PPopOver
-    ref="popOver"
-    :placement="[bottomRight, topRight, bottomLeft, topLeft, rightInside, leftInside]"
-    class="p-date-input"
-    auto-close
-    @open="handleOpenChange"
-    @keydown="handleKeydown"
-  >
-    <template #target>
-      <slot v-bind="{ openPicker, closePicker, isOpen, disabled }">
+  <PInputPopOver class="p-date-input">
+    <template #input="{ open, visible }">
+      <slot v-bind="{ open, visible }">
         <template v-if="media.hover">
-          <PDateButton :date="internalModelValue" :class="classes.control" v-bind="{ showTime, disabled, clearable }" @click="openPicker" @clear="clear" />
+          <PDateButton
+            :date="internalModelValue"
+            :class="getControlClass(visible)"
+            v-bind="{ showTime, disabled, clearable }"
+            @click="open"
+            @clear="clear"
+          />
         </template>
         <template v-else>
           <PNativeDateInput v-model="internalModelValue" v-bind="{ min, max, disabled }" />
@@ -18,32 +17,31 @@
       </slot>
     </template>
 
-    <PDatePicker
-      v-model="internalModelValue"
-      v-model:viewing-date="internalViewingDate"
-      class="p-date-input__date-picker"
-      v-bind="{ min, max, showTime }"
-      @click.stop
-      @close="closePicker"
-      @keydown="closeOnEscape"
-    >
-      <template v-for="(index, name) in $slots" #[name]="data">
-        <slot :name="name" v-bind="data" />
-      </template>
-    </PDatePicker>
-  </PPopOver>
+    <template #default="{ close }">
+      <PDatePicker
+        v-model="internalModelValue"
+        v-model:viewing-date="internalViewingDate"
+        class="p-date-input__date-picker"
+        v-bind="{ min, max, showTime }"
+        @close="close"
+      >
+        <template v-for="(index, name) in $slots" #[name]="data">
+          <slot :name="name" v-bind="data" />
+        </template>
+      </PDatePicker>
+    </template>
+  </PInputPopOver>
 </template>
 
 <script lang="ts" setup>
-  import { computed, ref } from 'vue'
+  import { computed } from 'vue'
   import PDateButton from '@/components/DateInput/PDateButton.vue'
+  import PInputPopOver from '@/components/DateInput/PInputPopOver.vue'
   import PDatePicker from '@/components/DatePicker/PDatePicker.vue'
   import PNativeDateInput from '@/components/NativeDateInput/PNativeDateInput.vue'
-  import PPopOver from '@/components/PopOver/PPopOver.vue'
-  import { keys } from '@/types'
+  import { ClassValue } from '@/types'
   import { keepDateInRange } from '@/utilities/dates'
   import { media } from '@/utilities/media'
-  import { bottomRight, topRight, bottomLeft, topLeft, rightInside, leftInside } from '@/utilities/position'
 
   const props = defineProps<{
     modelValue: Date | null | undefined,
@@ -58,10 +56,7 @@
   const emit = defineEmits<{
     (event: 'update:modelValue', value: Date | null): void,
     (event: 'update:viewingDate', value: Date | undefined): void,
-    (event: 'open' | 'close'): void,
   }>()
-
-  const popOver = ref<typeof PPopOver>()
 
   const internalModelValue = computed({
     get() {
@@ -81,60 +76,14 @@
     },
   })
 
-  const isOpen = computed(() => popOver.value?.visible ?? false)
-
-  const classes = computed(() => ({
-    control: {
-      'p-date-input--open': isOpen.value,
-    },
-  }))
+  function getControlClass(open: boolean): ClassValue {
+    return {
+      'p-date-input--open': open,
+    }
+  }
 
   function clear(): void {
     emit('update:modelValue', null)
-  }
-
-  function openPicker(): void {
-    if (!isOpen.value && !props.disabled) {
-      popOver.value!.open()
-    }
-  }
-
-  function closePicker(): void {
-    if (isOpen.value) {
-      popOver.value!.close()
-    }
-  }
-
-  function closeOnEscape(event: KeyboardEvent): void {
-    if (media.hover && event.key === keys.escape) {
-      closePicker()
-      event.preventDefault()
-    }
-  }
-
-  function handleOpenChange(open: boolean): void {
-    if (open) {
-      emit('open')
-    } else {
-      emit('close')
-    }
-  }
-
-  function handleKeydown(event: KeyboardEvent): void {
-    switch (event.key) {
-      case keys.escape:
-      case keys.tab:
-        closePicker()
-        break
-      case keys.space:
-        if (!isOpen.value) {
-          openPicker()
-        }
-        event.preventDefault()
-        break
-      default:
-        break
-    }
   }
 </script>
 

--- a/src/components/DateInput/PInputPopOver.vue
+++ b/src/components/DateInput/PInputPopOver.vue
@@ -1,0 +1,71 @@
+<template>
+  <PPopOver
+    ref="popOver"
+    :placement="[bottomRight, topRight, bottomLeft, topLeft, rightInside, leftInside]"
+    class="p-input-pop-over"
+    auto-close
+    @keydown="onKeydown"
+  >
+    <template #target="scope">
+      <slot name="input" v-bind="scope" />
+    </template>
+
+    <template #default="scope">
+      <slot v-bind="scope" />
+    </template>
+  </PPopOver>
+</template>
+
+<script lang="ts" setup>
+  import { useKeyDown } from '@prefecthq/vue-compositions'
+  import { computed, ref } from 'vue'
+  import PPopOver from '@/components/PopOver/PPopOver.vue'
+  import { keys } from '@/types/keyEvent'
+  import { media } from '@/utilities/media'
+  import { bottomRight, topRight, bottomLeft, topLeft, rightInside, leftInside } from '@/utilities/position'
+
+  const props = defineProps<{
+    disabled?: boolean,
+  }>()
+
+  const popOver = ref<typeof PPopOver>()
+  const isOpen = computed(() => popOver.value?.visible ?? false)
+
+  function openPicker(): void {
+    if (!isOpen.value && !props.disabled) {
+      popOver.value!.open()
+    }
+  }
+
+  function closePicker(): void {
+    if (isOpen.value) {
+      popOver.value!.close()
+    }
+  }
+
+  useKeyDown('Escape', onEscape)
+
+  function onEscape(event: KeyboardEvent): void {
+    if (media.hover && isOpen.value) {
+      closePicker()
+      event.preventDefault()
+    }
+  }
+
+  function onKeydown(event: KeyboardEvent): void {
+    switch (event.key) {
+      case keys.escape:
+      case keys.tab:
+        closePicker()
+        break
+      case keys.space:
+        if (!isOpen.value) {
+          openPicker()
+        }
+        event.preventDefault()
+        break
+      default:
+        break
+    }
+  }
+</script>

--- a/src/components/DateRangeInput/PDateRangeInput.vue
+++ b/src/components/DateRangeInput/PDateRangeInput.vue
@@ -1,60 +1,45 @@
 <template>
-  <PDateInput v-model="dummy" v-model:viewingDate="internalViewingDate" v-bind="{ showTime, min, max, clearable, disabled }" @update:model-value="update">
-    <template #default="{ openPicker, isOpen, disabled: buttonDisabled }">
-      <PDateButton
-        :date="startDate"
-        class="p-date-range-input__trigger"
-        :class="classes.trigger(isOpen)"
-        :disabled="buttonDisabled"
-        :clearable="clearable"
-        @click="openPicker"
-        @clear="clear"
-      >
-        <div class="p-date-range-input__target">
-          {{ displayValue }}
-        </div>
-      </PDateButton>
-    </template>
-
-    <template #date="{ date, disabled: dateDisabled, today, inMonth }">
-      <div class="p-date-range-input__date-wrapper" :class="classes.dateWrapper(date)">
-        <p-button
-          class="p-date-range-input__date"
-          :class="classes.date(today, inMonth)"
-          :disabled="dateDisabled"
-          small
-          flat
-          @click="setDate(date)"
+  <PInputPopOver class="p-date-input">
+    <template #input="{ open, visible }">
+      <slot v-bind="{ open, visible }">
+        <PDateButton
+          :date="startDate ?? endDate"
+          :class="getControlClass(visible)"
+          v-bind="{ showTime, disabled, clearable }"
+          @click="open"
+          @clear="clear"
         >
-          <slot
-            name="date"
-            :date="date"
-            :is-selected="isSelectedDate(date)"
-            :is-in-selected-range="isDateInSelectedRange(date)"
-          >
-            {{ date.getDate() }}
-          </slot>
-        </p-button>
-      </div>
+          <div class="p-date-range-input__target">
+            {{ displayValue }}
+          </div>
+        </PDateButton>
+      </slot>
     </template>
 
-    <template #controls>
-      <PContent>
-        <PDateTimeInputGroup v-model="internalStartDate" :show-time="showTime" label="Start Date" />
-        <PDateTimeInputGroup v-model="internalEndDate" :show-time="showTime" label="End Date" />
-      </PContent>
+    <template #default="{ close }">
+      <PDateRangePicker
+        v-model:start-date="internalStartDate"
+        v-model:end-date="internalEndDate"
+        v-model:viewing-date="internalViewingDate"
+        class="p-date-input__date-picker"
+        v-bind="{ min, max, showTime }"
+        @close="close"
+      >
+        <template v-for="(index, name) in $slots" #[name]="data">
+          <slot :name="name" v-bind="data" />
+        </template>
+      </PDateRangePicker>
     </template>
-  </PDateInput>
+  </PInputPopOver>
 </template>
 
 <script lang="ts" setup>
-  import { format, isSameDay, startOfDay, endOfDay } from 'date-fns'
-  import { computed, ref } from 'vue'
-  import PContent from '@/components/Content/PContent.vue'
+  import { format, startOfDay, endOfDay } from 'date-fns'
+  import { computed } from 'vue'
   import PDateButton from '@/components/DateInput/PDateButton.vue'
-  import PDateInput from '@/components/DateInput/PDateInput.vue'
-  import PDateTimeInputGroup from '@/components/DateTimeInputGroup/PDateTimeInputGroup.vue'
-  import { isDateBefore, isDateInRange } from '@/utilities'
+  import PInputPopOver from '@/components/DateInput/PInputPopOver.vue'
+  import PDateRangePicker from '@/components/DateRangePicker/PDateRangePicker.vue'
+  import { ClassValue } from '@/types'
 
   const props = defineProps<{
     startDate: Date | null | undefined,
@@ -72,13 +57,7 @@
     (event: 'update:viewingDate', value: Date | undefined): void,
   }>()
 
-  // this dummy ref is bound to PDatInput's v-model but isn't directly used for anything
-  // this component tracks its own dates
-  const dummy = ref()
-
   const dateFormat = 'MMM do, yyyy'
-  const internalStartDate = ref(props.startDate)
-  const internalEndDate = ref(props.endDate)
 
   const displayValue = computed(() => {
     if (props.startDate && props.endDate) {
@@ -86,6 +65,24 @@
     }
 
     return 'Select dates'
+  })
+
+  const internalStartDate = computed({
+    get() {
+      return props.startDate
+    },
+    set(value) {
+      emit('update:startDate', value)
+    },
+  })
+
+  const internalEndDate = computed({
+    get() {
+      return props.endDate
+    },
+    set(value) {
+      emit('update:endDate', value)
+    },
   })
 
   const internalViewingDate = computed({
@@ -97,60 +94,10 @@
     },
   })
 
-  const classes = computed(() => ({
-    trigger: (isOpen: boolean) => ({
-      'p-date-range-input__trigger--open': isOpen,
-    }),
-    dateWrapper: (date: Date) => ({
-      'p-date-range-input__date-wrapper--selected': isSelectedDate(date),
-      'p-date-range-input__date-wrapper--selected-start': isSelectedStartDate(date),
-      'p-date-range-input__date-wrapper--selected-end': isSelectedEndDate(date),
-      'p-date-range-input__date-wrapper--in-range': isDateInSelectedRange(date),
-    }),
-    date: (today: boolean, inMonth: boolean) => ({
-      'p-date-range-input__date--today': today,
-      'p-date-range-input__date--out-of-month': !inMonth,
-    }),
-  }))
-
-  function isSelectedDate(date: Date): boolean {
-    return isSelectedStartDate(date) || isSelectedEndDate(date)
-  }
-
-  function isSelectedStartDate(date: Date): boolean {
-    return !!internalStartDate.value && isSameDay(date, internalStartDate.value)
-  }
-
-  function isSelectedEndDate(date: Date): boolean {
-    return !!internalEndDate.value && isSameDay(date, internalEndDate.value)
-  }
-
-  function isDateInSelectedRange(date: Date): boolean {
-    if (!internalStartDate.value || !internalEndDate.value) {
-      return false
+  function getControlClass(open: boolean): ClassValue {
+    return {
+      'p-date-input--open': open,
     }
-
-    return isDateInRange(date, { min: internalStartDate.value, max: internalEndDate.value }, 'day')
-  }
-
-  function setDate(value: Date): void {
-    if (internalStartDate.value && isDateBefore(value, internalStartDate.value)) {
-      setEndDate(internalEndDate.value ? null : internalStartDate.value)
-      setStartDate(value)
-
-      return
-    }
-
-    if (!internalStartDate.value) {
-      return setStartDate(value)
-    }
-
-    if (!internalEndDate.value) {
-      return setEndDate(value)
-    }
-
-    setStartDate(value)
-    setEndDate(null)
   }
 
   function setStartDate(value: Date | null): void {
@@ -159,11 +106,6 @@
 
   function setEndDate(value: Date | null): void {
     internalEndDate.value = value ? endOfDay(value) : value
-  }
-
-  function update(): void {
-    emit('update:startDate', internalStartDate.value)
-    emit('update:endDate', internalEndDate.value)
   }
 
   function clear(): void {
@@ -175,80 +117,6 @@
 </script>
 
 <style>
-.p-date-range-input__date-wrapper { @apply
-  grid
-  grid-cols-1
-  p-0
-  aspect-square
-}
-
-.p-date-range-input__date { @apply
-  justify-center
-  p-0
-}
-
-.p-date-range-input__date--today,
-.p-date-range-input__date--today:not(:disabled):hover,
-.p-date-range-input__date--today:not(:disabled):active { @apply
-  border-[1px]
-  border-live
-}
-
-.p-date-range-input__date-wrapper--selected { @apply
-  bg-[var(--p-color-input-checked-bg)]
-}
-
-.p-date-range-input__date-wrapper--selected-start { @apply
-  rounded-l-sm
-}
-
-.p-date-range-input__date-wrapper--selected-start::before { @apply
-  !hidden
-}
-
-.p-date-range-input__date-wrapper--selected-end::after { @apply
-  !hidden
-}
-
-.p-date-range-input__date-wrapper--selected-end { @apply
-  rounded-r-sm
-}
-
-.p-date-range-input__date-wrapper--in-range { @apply
-  relative
-}
-
-.p-date-range-input__date-wrapper--in-range:not(.p-date-range-input__date-wrapper--selected) { @apply
-  bg-selected
-}
-
-.p-date-range-input__date-wrapper--in-range::before,
-.p-date-range-input__date-wrapper--in-range::after { @apply
-  absolute
-  content-['']
-  block
-  bg-selected
-  top-0
-  bottom-0
-  w-1.5
-}
-
-.p-date-range-input__date-wrapper--in-range::before { @apply
-  right-full
-}
-
-.p-date-range-input__date-wrapper--in-range::after { @apply
-  left-full
-}
-
-.p-date-range-input__date:not(:disabled):hover { @apply
-  bg-selectable-hover
-}
-
-.p-date-range-input__date--out-of-month:not(:disabled) { @apply
-  text-subdued
-}
-
 .p-date-range-input__trigger--open { @apply
   ring-spacing-focus-ring
   ring-focus-ring

--- a/src/components/DateRangePicker/PDateRangePicker.vue
+++ b/src/components/DateRangePicker/PDateRangePicker.vue
@@ -1,5 +1,5 @@
 <template>
-  <PDatePicker v-model:viewingDate="viewingDate" :model-value="null" v-bind="{ min, max }" class="p-date-picker" @update:model-value="update">
+  <PDatePicker v-model:viewingDate="viewingDate" :model-value="startDate ?? endDate" v-bind="{ min, max }" class="p-date-picker" @update:model-value="update">
     <template #date="{ date, disabled: dateDisabled, today, inMonth }">
       <div class="p-date-range-picker__date-wrapper" :class="classes.dateWrapper(date)">
         <p-button

--- a/src/components/DateRangePicker/PDateRangePicker.vue
+++ b/src/components/DateRangePicker/PDateRangePicker.vue
@@ -1,0 +1,216 @@
+<template>
+  <PDatePicker v-model:viewingDate="viewingDate" :model-value="null" v-bind="{ min, max }" class="p-date-picker" @update:model-value="update">
+    <template #date="{ date, disabled: dateDisabled, today, inMonth }">
+      <div class="p-date-range-picker__date-wrapper" :class="classes.dateWrapper(date)">
+        <p-button
+          class="p-date-range-picker__date"
+          :class="classes.date(today, inMonth)"
+          :disabled="dateDisabled"
+          small
+          flat
+          @click="setDate(date)"
+        >
+          <slot
+            name="date"
+            :date="date"
+            :is-selected="isSelectedDate(date)"
+            :is-in-selected-range="isDateInSelectedRange(date)"
+          >
+            {{ date.getDate() }}
+          </slot>
+        </p-button>
+      </div>
+    </template>
+
+    <template #controls>
+      <PContent>
+        <PDateTimeInputGroup v-model="selectedStartDate" :show-time="showTime" label="Start Date" />
+        <PDateTimeInputGroup v-model="selectedEndDate" :show-time="showTime" label="End Date" />
+      </PContent>
+    </template>
+  </PDatePicker>
+</template>
+
+<script lang="ts" setup>
+  import { endOfDay, isSameDay, startOfDay } from 'date-fns'
+  import { computed, ref } from 'vue'
+  import PButton from '@/components/Button/PButton.vue'
+  import PDatePicker from '@/components/DatePicker/PDatePicker.vue'
+  import PDateTimeInputGroup from '@/components/DateTimeInputGroup/PDateTimeInputGroup.vue'
+  import { isDateBefore, isDateInRange } from '@/utilities/dates'
+
+  const props = defineProps<{
+    startDate: Date | null | undefined,
+    endDate: Date | null | undefined,
+    viewingDate?: Date | null | undefined,
+    showTime?: boolean,
+    min?: Date | null | undefined,
+    max?: Date | null | undefined,
+  }>()
+
+  const emit = defineEmits<{
+    'update:startDate': [value: Date | null | undefined],
+    'update:endDate': [value: Date | null | undefined],
+    'update:viewingDate': [value: Date | null | undefined],
+    'close': [],
+  }>()
+
+  const selectedStartDate = ref(props.startDate)
+  const selectedEndDate = ref(props.endDate)
+
+  const viewingDate = computed({
+    get() {
+      return props.viewingDate ?? null
+    },
+    set(value) {
+      emit('update:viewingDate', value)
+    },
+  })
+
+  const classes = computed(() => ({
+    dateWrapper: (date: Date) => ({
+      'p-date-range-picker__date-wrapper--selected': isSelectedDate(date),
+      'p-date-range-picker__date-wrapper--selected-start': isSelectedStartDate(date),
+      'p-date-range-picker__date-wrapper--selected-end': isSelectedEndDate(date),
+      'p-date-range-picker__date-wrapper--in-range': isDateInSelectedRange(date),
+    }),
+    date: (today: boolean, inMonth: boolean) => ({
+      'p-date-range-picker__date--today': today,
+      'p-date-range-picker__date--out-of-month': !inMonth,
+    }),
+  }))
+
+  function isSelectedDate(date: Date): boolean {
+    return isSelectedStartDate(date) || isSelectedEndDate(date)
+  }
+
+  function isSelectedStartDate(date: Date): boolean {
+    return !!selectedStartDate.value && isSameDay(date, selectedStartDate.value)
+  }
+
+  function isSelectedEndDate(date: Date): boolean {
+    return !!selectedEndDate.value && isSameDay(date, selectedEndDate.value)
+  }
+
+  function isDateInSelectedRange(date: Date): boolean {
+    if (!selectedStartDate.value || !selectedEndDate.value) {
+      return false
+    }
+
+    return isDateInRange(date, { min: selectedStartDate.value, max: selectedEndDate.value }, 'day')
+  }
+
+  function setDate(value: Date): void {
+    if (selectedStartDate.value && isDateBefore(value, selectedStartDate.value)) {
+      setEndDate(selectedEndDate.value ? null : selectedStartDate.value)
+      setStartDate(value)
+
+      return
+    }
+
+    if (!selectedStartDate.value) {
+      return setStartDate(value)
+    }
+
+    if (!selectedEndDate.value) {
+      return setEndDate(value)
+    }
+
+    setStartDate(value)
+    setEndDate(null)
+  }
+
+  function setStartDate(value: Date | null): void {
+    selectedStartDate.value = value ? startOfDay(value) : value
+  }
+
+  function setEndDate(value: Date | null): void {
+    selectedEndDate.value = value ? endOfDay(value) : value
+  }
+
+  function update(): void {
+    emit('update:startDate', selectedStartDate.value)
+    emit('update:endDate', selectedEndDate.value)
+    close()
+  }
+
+  function close(): void {
+    emit('close')
+  }
+</script>
+
+<style>
+.p-date-range-picker__date-wrapper { @apply
+  grid
+  grid-cols-1
+  p-0
+  aspect-square
+}
+
+.p-date-range-picker__date { @apply
+  justify-center
+  p-0
+}
+
+.p-date-range-picker__date--today,
+.p-date-range-picker__date--today:not(:disabled):hover,
+.p-date-range-picker__date--today:not(:disabled):active { @apply
+  border-[1px]
+  border-live
+}
+
+.p-date-range-picker__date-wrapper--selected { @apply
+  bg-[var(--p-color-input-checked-bg)]
+}
+
+.p-date-range-picker__date-wrapper--selected-start { @apply
+  rounded-l-sm
+}
+
+.p-date-range-picker__date-wrapper--selected-start::before { @apply
+  !hidden
+}
+
+.p-date-range-picker__date-wrapper--selected-end::after { @apply
+  !hidden
+}
+
+.p-date-range-picker__date-wrapper--selected-end { @apply
+  rounded-r-sm
+}
+
+.p-date-range-picker__date-wrapper--in-range { @apply
+  relative
+}
+
+.p-date-range-picker__date-wrapper--in-range:not(.p-date-range-picker__date-wrapper--selected) { @apply
+  bg-selected
+}
+
+.p-date-range-picker__date-wrapper--in-range::before,
+.p-date-range-picker__date-wrapper--in-range::after { @apply
+  absolute
+  content-['']
+  block
+  bg-selected
+  top-0
+  bottom-0
+  w-1.5
+}
+
+.p-date-range-picker__date-wrapper--in-range::before { @apply
+  right-full
+}
+
+.p-date-range-picker__date-wrapper--in-range::after { @apply
+  left-full
+}
+
+.p-date-range-picker__date:not(:disabled):hover { @apply
+  bg-selectable-hover
+}
+
+.p-date-range-picker__date--out-of-month:not(:disabled) { @apply
+  text-subdued
+}
+</style>

--- a/src/components/DateRangePicker/index.ts
+++ b/src/components/DateRangePicker/index.ts
@@ -1,0 +1,8 @@
+import { App } from 'vue'
+import PDateRangePicker from '@/components/DateRangePicker/PDateRangePicker.vue'
+
+const install = (app: App): void => {
+  app.component('PDateRangePicker', PDateRangePicker)
+}
+
+export { PDateRangePicker, install }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,6 +20,7 @@ import { PContextSidebar, install as installPContextSidebar } from '@/components
 import { PDateInput, install as installPDateInput } from '@/components/DateInput'
 import { PDatePicker, install as installPDatePicker } from '@/components/DatePicker'
 import { PDateRangeInput, install as installPDateRangeInput } from '@/components/DateRangeInput'
+import { PDateRangePicker, install as installPDateRangePicker } from '@/components/DateRangePicker'
 import { PDialog, install as installPDialog } from '@/components/Dialog'
 import { PDivider, install as installPDivider } from '@/components/Divider'
 import { PDrawer, install as installPDrawer } from '@/components/Drawer'
@@ -109,6 +110,7 @@ export {
   PDateInput,
   PDatePicker,
   PDateRangeInput,
+  PDateRangePicker,
   PDialog,
   PDivider,
   PDrawer,
@@ -209,6 +211,7 @@ export const installs = [
   installPDateInput,
   installPDatePicker,
   installPDateRangeInput,
+  installPDateRangePicker,
   installPDialog,
   installPDivider,
   installPDrawer,
@@ -299,6 +302,7 @@ declare module '@vue/runtime-core' {
     PDateInput: typeof PDateInput,
     PDatePicker: typeof PDatePicker,
     PDateRangeInput: typeof PDateRangeInput,
+    PDateRangePicker: typeof PDateRangePicker,
     PDialog: typeof PDialog,
     PDivider: typeof PDivider,
     PDrawer: typeof PDrawer,


### PR DESCRIPTION
# Description
Over reliance on slots was making it hard to reuse the date range input's picker for the new date range select. Separating out more of the functionality between the date input and the date range input will make it a lot simpler to work with these component. 

Note: These components should remain functionally and visually the same. 