### PR TITLE
Feature: PDateRangeSelect

### DIFF
--- a/demo/sections/components/DateRangeSelect.vue
+++ b/demo/sections/components/DateRangeSelect.vue
@@ -1,0 +1,44 @@
+<template>
+  <ComponentPage title="Date Range Select" :demos="[{ title: 'Date Range Select' }]">
+    <template #description>
+      <DemoState v-model:state="exampleState" v-model:disabled="disabled" />
+    </template>
+
+    <template #date-range-select>
+      <p-content>
+        <p-date-range-select v-model="value" />
+        <p-code inline>
+          value: {{ JSON.stringify(value) }}
+        </p-code>
+        <div class="flex justify-start gap-4">
+          <p-checkbox v-model="isClearableDate" :disabled="disabled" label="Clearable" />
+        </div>
+        <div class="flex gap-4 w-1/2">
+          <p-label label="Min Value" :message="minDate ? format(minDate, 'MMM do, yyyy h:mm a') : ''">
+            <p-native-date-input v-model="minDate" :disabled="disabled" :state="exampleState" />
+          </p-label>
+
+          <p-label label="Max Value" :message="maxDate ? format(maxDate, 'MMM do, yyyy h:mm a') : ''">
+            <p-native-date-input v-model="maxDate" :disabled="disabled" :state="exampleState" />
+          </p-label>
+        </div>
+      </p-content>
+    </template>
+  </ComponentPage>
+</template>
+
+<script lang="ts" setup>
+  import { State } from '@/types'
+  import { format } from 'date-fns'
+  import { ref } from 'vue'
+  import ComponentPage from '@/demo/components/ComponentPage.vue'
+  import DemoState from '@/demo/components/DemoState.vue'
+
+  const exampleState = ref<State>()
+  const disabled = ref(false)
+
+  const value = ref()
+  const minDate = ref<Date | null>(null)
+  const maxDate = ref<Date | null>(null)
+  const isClearableDate = ref(false)
+</script>

--- a/demo/sections/components/DateRangeSelect.vue
+++ b/demo/sections/components/DateRangeSelect.vue
@@ -6,12 +6,12 @@
 
     <template #date-range-select>
       <p-content>
-        <p-date-range-select v-model="value" v-bind="{ min, max }" />
+        <p-date-range-select v-model="value" v-bind="{ min, max, clearable }" />
         <p-code inline>
           value: {{ JSON.stringify(value) }}
         </p-code>
         <div class="flex justify-start gap-4">
-          <p-checkbox v-model="isClearableDate" :disabled="disabled" label="Clearable" />
+          <p-checkbox v-model="clearable" :disabled="disabled" label="Clearable" />
         </div>
         <div class="flex gap-4 w-1/2">
           <p-label label="Min Value" :message="min ? format(min, 'MMM do, yyyy h:mm a') : ''">
@@ -40,5 +40,5 @@
   const value = ref()
   const min = ref<Date>()
   const max = ref<Date>()
-  const isClearableDate = ref(false)
+  const clearable = ref(true)
 </script>

--- a/demo/sections/components/DateRangeSelect.vue
+++ b/demo/sections/components/DateRangeSelect.vue
@@ -6,7 +6,7 @@
 
     <template #date-range-select>
       <p-content>
-        <p-date-range-select v-model="value" />
+        <p-date-range-select v-model="value" v-bind="{ min, max }" />
         <p-code inline>
           value: {{ JSON.stringify(value) }}
         </p-code>
@@ -14,12 +14,12 @@
           <p-checkbox v-model="isClearableDate" :disabled="disabled" label="Clearable" />
         </div>
         <div class="flex gap-4 w-1/2">
-          <p-label label="Min Value" :message="minDate ? format(minDate, 'MMM do, yyyy h:mm a') : ''">
-            <p-native-date-input v-model="minDate" :disabled="disabled" :state="exampleState" />
+          <p-label label="Min Value" :message="min ? format(min, 'MMM do, yyyy h:mm a') : ''">
+            <p-native-date-input v-model="min" :disabled="disabled" :state="exampleState" />
           </p-label>
 
-          <p-label label="Max Value" :message="maxDate ? format(maxDate, 'MMM do, yyyy h:mm a') : ''">
-            <p-native-date-input v-model="maxDate" :disabled="disabled" :state="exampleState" />
+          <p-label label="Max Value" :message="max ? format(max, 'MMM do, yyyy h:mm a') : ''">
+            <p-native-date-input v-model="max" :disabled="disabled" :state="exampleState" />
           </p-label>
         </div>
       </p-content>
@@ -38,7 +38,7 @@
   const disabled = ref(false)
 
   const value = ref()
-  const minDate = ref<Date | null>(null)
-  const maxDate = ref<Date | null>(null)
+  const min = ref<Date>()
+  const max = ref<Date>()
   const isClearableDate = ref(false)
 </script>

--- a/demo/sections/components/DateRangeSelect.vue
+++ b/demo/sections/components/DateRangeSelect.vue
@@ -6,7 +6,7 @@
 
     <template #date-range-select>
       <p-content>
-        <p-date-range-select v-model="value" v-bind="{ min, max, clearable }" />
+        <p-date-range-select v-model="value" v-bind="{ min, max, clearable, disabled }" />
         <p-code inline>
           value: {{ JSON.stringify(value) }}
         </p-code>

--- a/demo/sections/components/index.ts
+++ b/demo/sections/components/index.ts
@@ -17,6 +17,7 @@ export const components: Section = {
   contextSidebar: () => import('./ContextSidebar.vue'),
   dateInput: () => import('./DateInput.vue'),
   dateRangeInput: () => import('./DateRangeInput.vue'),
+  dateRangeSelect: () => import('./DateRangeSelect.vue'),
   dialog: () => import('./Dialog.vue'),
   divider: () => import('./Divider.vue'),
   drawer: () => import('./Drawer.vue'),

--- a/src/components/DateInput/PDateInput.vue
+++ b/src/components/DateInput/PDateInput.vue
@@ -21,7 +21,6 @@
       <PDatePicker
         v-model="internalModelValue"
         v-model:viewing-date="internalViewingDate"
-        class="p-date-input__date-picker"
         v-bind="{ min, max, showTime }"
         @close="close"
       >
@@ -88,13 +87,6 @@
 </script>
 
 <style>
-.p-date-input__date-picker { @apply
-  bg-floating
-  my-1
-  rounded-default
-  shadow-lg
-}
-
 .p-date-input--open { @apply
   ring-spacing-focus-ring
   ring-focus-ring

--- a/src/components/DatePicker/PDatePicker.vue
+++ b/src/components/DatePicker/PDatePicker.vue
@@ -74,6 +74,10 @@
 
 <style>
 .p-date-picker { @apply
+  bg-floating
+  my-1
+  rounded-default
+  shadow-lg
   flex
   flex-col
   p-2

--- a/src/components/DateRangeInput/PDateRangeInput.vue
+++ b/src/components/DateRangeInput/PDateRangeInput.vue
@@ -21,7 +21,6 @@
         v-model:start-date="internalStartDate"
         v-model:end-date="internalEndDate"
         v-model:viewing-date="internalViewingDate"
-        class="p-date-input__date-picker"
         v-bind="{ min, max, showTime }"
         @close="close"
       >

--- a/src/components/DateRangePicker/PDateRangePicker.vue
+++ b/src/components/DateRangePicker/PDateRangePicker.vue
@@ -1,5 +1,12 @@
 <template>
-  <PDatePicker v-model:viewingDate="viewingDate" :model-value="startDate ?? endDate" v-bind="{ min, max }" class="p-date-range-picker" @update:model-value="update">
+  <PDatePicker
+    v-model:viewingDate="viewingDate"
+    :model-value="startDate ?? endDate"
+    v-bind="{ min, max }"
+    class="p-date-range-picker"
+    @update:model-value="update"
+    @close="close"
+  >
     <template #date="{ date, disabled: dateDisabled, today, inMonth }">
       <div class="p-date-range-picker__date-wrapper" :class="classes.dateWrapper(date)">
         <p-button

--- a/src/components/DateRangePicker/PDateRangePicker.vue
+++ b/src/components/DateRangePicker/PDateRangePicker.vue
@@ -59,6 +59,7 @@
     'update:startDate': [value: Date | null | undefined],
     'update:endDate': [value: Date | null | undefined],
     'update:viewingDate': [value: Date | null | undefined],
+    'apply': [],
     'close': [],
   }>()
 
@@ -138,6 +139,7 @@
   function update(): void {
     emit('update:startDate', selectedStartDate.value)
     emit('update:endDate', selectedEndDate.value)
+    emit('apply')
     close()
   }
 

--- a/src/components/DateRangePicker/PDateRangePicker.vue
+++ b/src/components/DateRangePicker/PDateRangePicker.vue
@@ -31,15 +31,15 @@
 
     <template #controls>
       <PContent>
-        <PDateTimeInputGroup v-model="selectedStartDate" :show-time="showTime" label="Start Date" />
-        <PDateTimeInputGroup v-model="selectedEndDate" :show-time="showTime" label="End Date" />
+        <PDateTimeInputGroup :model-value="selectedStartDate" :show-time="showTime" label="Start Date" @update:model-value="setStartDateAndTime" />
+        <PDateTimeInputGroup :model-value="selectedEndDate" :show-time="showTime" label="End Date" @update:model-value="setEndDateAndTime" />
       </PContent>
     </template>
   </PDatePicker>
 </template>
 
 <script lang="ts" setup>
-  import { endOfDay, isSameDay, startOfDay } from 'date-fns'
+  import { endOfDay, endOfMinute, isSameDay, startOfDay, startOfMinute } from 'date-fns'
   import { computed, ref } from 'vue'
   import PButton from '@/components/Button/PButton.vue'
   import PDatePicker from '@/components/DatePicker/PDatePicker.vue'
@@ -134,6 +134,14 @@
 
   function setEndDate(value: Date | null): void {
     selectedEndDate.value = value ? endOfDay(value) : value
+  }
+
+  function setStartDateAndTime(value: Date | null): void {
+    selectedStartDate.value = value ? startOfMinute(value) : value
+  }
+
+  function setEndDateAndTime(value: Date | null): void {
+    selectedEndDate.value = value ? endOfMinute(value) : value
   }
 
   function update(): void {

--- a/src/components/DateRangePicker/PDateRangePicker.vue
+++ b/src/components/DateRangePicker/PDateRangePicker.vue
@@ -1,5 +1,5 @@
 <template>
-  <PDatePicker v-model:viewingDate="viewingDate" :model-value="startDate ?? endDate" v-bind="{ min, max }" class="p-date-picker" @update:model-value="update">
+  <PDatePicker v-model:viewingDate="viewingDate" :model-value="startDate ?? endDate" v-bind="{ min, max }" class="p-date-range-picker" @update:model-value="update">
     <template #date="{ date, disabled: dateDisabled, today, inMonth }">
       <div class="p-date-range-picker__date-wrapper" :class="classes.dateWrapper(date)">
         <p-button

--- a/src/components/DateRangeSelect/PDateRangeSelect.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelect.vue
@@ -103,7 +103,6 @@
     },
   }))
 
-
   function selectSpan(value: DateRangeSelectOptionsValue): void {
     if (value === 'range') {
       mode.value = 'range'

--- a/src/components/DateRangeSelect/PDateRangeSelect.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelect.vue
@@ -40,14 +40,14 @@
 </template>
 
 <script lang="ts" setup>
-  import { addSeconds, differenceInSeconds, format, intervalToDuration, isAfter, isBefore } from 'date-fns'
+  import { addSeconds, differenceInSeconds, isAfter, isBefore } from 'date-fns'
   import { computed, ref, watch } from 'vue'
   import PButton from '@/components/Button/PButton.vue'
   import PDateRangePicker from '@/components/DateRangePicker/PDateRangePicker.vue'
   import PDateRangeSelectOptions, { DateRangeSelectOptionsValue } from '@/components/DateRangeSelect/PDateRangeSelectOptions.vue'
+  import { getDateRangeLabel, getDateSpanLabel } from '@/components/DateRangeSelect/utilities'
   import PIcon from '@/components/Icon/PIcon.vue'
   import PPopOver from '@/components/PopOver/PPopOver.vue'
-  import { toPluralString } from '@/utilities'
   import { bottomRight, topRight, bottomLeft, topLeft, rightInside, leftInside } from '@/utilities/position'
 
   export type DateRangeSelectSpanValue = { type: 'span', seconds: number }
@@ -72,7 +72,6 @@
   const span = ref<number | null>(null)
   const startDate = ref<Date | null>(null)
   const endDate = ref<Date | null>(null)
-  const dateFormat = 'MMM do, yyyy'
 
   const modelValue = computed({
     get() {
@@ -86,39 +85,16 @@
   const placeholder = computed(() => props.placeholder ?? 'Select a time span')
 
   const label = computed(() => {
-    if (!modelValue.value) {
-      return placeholder.value
+    if (modelValue.value?.type === 'span') {
+      return getDateSpanLabel(modelValue.value.seconds)
     }
 
-    if (modelValue.value.type === 'span') {
-      return getSpanLabel(modelValue.value.seconds)
+    if (modelValue.value?.type === 'range') {
+      return getDateRangeLabel(modelValue.value)
     }
 
-    const { startDate, endDate } = modelValue.value
-
-    return `${format(startDate, dateFormat)} - ${format(endDate, dateFormat)}`
+    return placeholder.value
   })
-
-  function getSpanLabel(seconds: number): string {
-    const now = new Date()
-    const duration = intervalToDuration({
-      start: now,
-      end: addSeconds(now, seconds),
-    })
-
-    const reduced = Object.entries(duration).reduce<string[]>((durations, [key, value]) => {
-      if (value) {
-        const unit = key.slice(0, -1)
-        durations.push(`${value} ${toPluralString(unit, value)}`)
-      }
-
-      return durations
-    }, [])
-
-    const direction = seconds < 0 ? 'Past' : 'Next'
-
-    return `${direction} ${reduced.join(' ')}`
-  }
 
   const classes = computed(() => ({
     label: {

--- a/src/components/DateRangeSelect/PDateRangeSelect.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelect.vue
@@ -1,7 +1,7 @@
 <template>
   <PPopOver ref="popover" class="p-date-range-select" :placement="placement" auto-close>
     <template #target="{ open }">
-      <PButton class="p-date-range-select__button" icon="ArrowSmallLeftIcon" />
+      <PButton class="p-date-range-select__button" icon="ArrowSmallLeftIcon" :disabled="previousDisabled" @click="previous" />
       <PButton class="p-date-range-select__button p-date-range-select__input" @click="open">
         <div class="p-date-range-select__content">
           <PIcon icon="CalendarIcon" />
@@ -15,7 +15,7 @@
       <template v-if="modelValue">
         <PButton class="p-date-range-select__button" icon="XCircleIcon" @click="clear" />
       </template>
-      <PButton class="p-date-range-select__button" icon="ArrowSmallRightIcon" />
+      <PButton class="p-date-range-select__button" icon="ArrowSmallRightIcon" :disabled="nextDisabled" @click="next" />
     </template>
 
     <template #default>
@@ -40,7 +40,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { addSeconds, format, intervalToDuration } from 'date-fns'
+  import { addSeconds, differenceInSeconds, format, intervalToDuration, isBefore, subSeconds } from 'date-fns'
   import { computed, ref, watch } from 'vue'
   import PButton from '@/components/Button/PButton.vue'
   import PDateRangePicker from '@/components/DateRangePicker/PDateRangePicker.vue'
@@ -147,6 +147,69 @@
     }
 
     modelValue.value = null
+  }
+
+  function getIntervalInSeconds(): number {
+    if (modelValue.value?.type === 'span') {
+      return Math.abs(modelValue.value.seconds)
+    }
+
+    if (modelValue.value?.type === 'range') {
+      const { startDate, endDate } = modelValue.value
+
+      return Math.abs(differenceInSeconds(startDate, endDate))
+    }
+
+    return 0
+  }
+
+  const previousDisabled = computed<boolean>(() => {
+    const seconds = getIntervalInSeconds()
+
+    if (!seconds || !modelValue.value) {
+      return true
+    }
+
+    if (!props.min) {
+      return false
+    }
+
+    if (modelValue.value.type === 'span') {
+      return isBefore(subSeconds(new Date(), seconds), props.min)
+    }
+
+    const { startDate } = modelValue.value
+
+    return isBefore(subSeconds(startDate, seconds), props.min)
+  })
+
+  function previous(): void {
+
+  }
+
+  const nextDisabled = computed<boolean>(() => {
+    const seconds = getIntervalInSeconds()
+
+    if (!seconds || !modelValue.value) {
+      return true
+    }
+
+    if (!props.max) {
+      return false
+    }
+
+    if (modelValue.value.type === 'span') {
+      return isBefore(addSeconds(new Date(), seconds), props.max)
+    }
+
+    const { startDate } = modelValue.value
+
+    return isBefore(addSeconds(startDate, seconds), props.max)
+
+  })
+
+  function next(): void {
+
   }
 
   function close(): void {

--- a/src/components/DateRangeSelect/PDateRangeSelect.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelect.vue
@@ -65,7 +65,7 @@
     'update:modelValue': [DateRangeSelectValue],
   }>()
 
-  const placement = [bottomRight, topRight, bottomLeft, topLeft, rightInside, leftInside]
+  const placement = [bottomLeft, topLeft, bottomRight, topRight, leftInside, rightInside]
   const popover = ref<InstanceType<typeof PPopOver>>()
   const mode = ref<'relative' | 'range'>('relative')
 

--- a/src/components/DateRangeSelect/PDateRangeSelect.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelect.vue
@@ -12,7 +12,7 @@
         </div>
       </PButton>
 
-      <template v-if="modelValue">
+      <template v-if="modelValue && clearable">
         <PButton class="p-date-range-select__button" icon="XCircleIcon" @click="clear" />
       </template>
       <PButton class="p-date-range-select__button" icon="ArrowSmallRightIcon" :disabled="nextDisabled" @click="next" />
@@ -58,6 +58,7 @@
   const props = defineProps<{
     modelValue: DateRangeSelectValue,
     placeholder?: string,
+    clearable?: boolean,
     min?: Date,
     max?: Date,
   }>()

--- a/src/components/DateRangeSelect/PDateRangeSelect.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelect.vue
@@ -36,7 +36,9 @@
   import PPopOver from '@/components/PopOver/PPopOver.vue'
   import { bottomRight, topRight, bottomLeft, topLeft, rightInside, leftInside } from '@/utilities/position'
 
-  export type DateRangeSelectValue = number | [Date, Date] | null | undefined
+  export type DateRangeSelectSpanValue = { type: 'span', value: number }
+  export type DateRangeSelectRangeValue = { type: 'range', value: [Date, Date] }
+  export type DateRangeSelectValue = DateRangeSelectSpanValue | DateRangeSelectRangeValue | null | undefined
 
   const props = defineProps<{
     modelValue: DateRangeSelectValue,

--- a/src/components/DateRangeSelect/PDateRangeSelect.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelect.vue
@@ -21,7 +21,7 @@
     <template #default>
       <div class="p-date-range-select__picker" @click.stop>
         <template v-if="mode === 'relative'">
-          <PDateRangeSelectOptions :model-value="span" v-bind="{ min, max }" @update:model-value="selectSpan" />
+          <PDateRangeSelectOptions :model-value="span" v-bind="{ min, max, maxSpanInSeconds }" @update:model-value="selectSpan" />
         </template>
 
         <template v-if="mode === 'range'">
@@ -58,6 +58,7 @@
   const props = defineProps<{
     modelValue: DateRangeSelectValue,
     placeholder?: string,
+    maxSpanInSeconds?: number,
     clearable?: boolean,
     disabled?: boolean,
     min?: Date,

--- a/src/components/DateRangeSelect/PDateRangeSelect.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelect.vue
@@ -2,8 +2,12 @@
   <PPopOver ref="popover" class="p-date-range-select" :placement="placement" auto-close>
     <template #target="{ open }">
       <PButton class="p-date-range-select__button" icon="ArrowSmallLeftIcon" />
-      <PButton class="p-date-range-select__button p-date-range-select__input" icon="CalendarIcon" icon-append="ChevronDownIcon" @click="open">
-        Past 8h
+      <PButton class="p-date-range-select__button p-date-range-select__input" @click="open">
+        <div class="p-date-range-select__content">
+          <PIcon icon="CalendarIcon" />
+          {{ label }}
+          <PIcon icon="ChevronDownIcon" class="ml-auto" />
+        </div>
       </PButton>
 
       <template v-if="modelValue">
@@ -23,10 +27,12 @@
 </template>
 
 <script lang="ts" setup>
+  import { addSeconds, format, intervalToDuration } from 'date-fns'
   import { computed, ref, watch } from 'vue'
   import PButton from '@/components/Button/PButton.vue'
   import PDateRangePicker from '@/components/DateRangePicker/PDateRangePicker.vue'
   import PDateRangeSelectOptions, { DateRangeSelectOptionsValue } from '@/components/DateRangeSelect/PDateRangeSelectOptions.vue'
+  import PIcon from '@/components/Icon/PIcon.vue'
   import PPopOver from '@/components/PopOver/PPopOver.vue'
   import { bottomRight, topRight, bottomLeft, topLeft, rightInside, leftInside } from '@/utilities/position'
 
@@ -49,6 +55,7 @@
   const span = ref<number | null>(null)
   const startDate = ref<Date | null>(null)
   const endDate = ref<Date | null>(null)
+  const dateFormat = 'MMM do, yyyy'
 
   const modelValue = computed({
     get() {
@@ -58,6 +65,26 @@
       emit('update:modelValue', value)
     },
   })
+
+  const label = computed(() => {
+    if (typeof modelValue.value === 'number') {
+      const duration = intervalToDuration({
+        start: new Date(),
+        end: addSeconds(new Date(), modelValue.value),
+      })
+
+      return `Past ${JSON.stringify(duration)}`
+    }
+
+    if (Array.isArray(modelValue.value)) {
+      const [startDate, endDate] = modelValue.value
+
+      return `${format(startDate, dateFormat)} - ${format(endDate, dateFormat)}`
+    }
+
+    return 'select'
+  })
+
 
   function selectSpan(value: DateRangeSelectOptionsValue): void {
     if (value === 'range') {
@@ -120,5 +147,12 @@
 
 .p-date-range-select__input { @apply
   grow
+}
+
+.p-date-range-select__content { @apply
+  w-full
+  flex
+  items-center
+  gap-2
 }
 </style>

--- a/src/components/DateRangeSelect/PDateRangeSelect.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelect.vue
@@ -2,7 +2,7 @@
   <PPopOver ref="popover" class="p-date-range-select" :placement="placement" auto-close>
     <template #target="{ open }">
       <PButton class="p-date-range-select__button" icon="ArrowSmallLeftIcon" :disabled="previousDisabled" @click="previous" />
-      <PButton class="p-date-range-select__button p-date-range-select__input" @click="open">
+      <PButton class="p-date-range-select__button p-date-range-select__input" :disabled="disabled" @click="open">
         <div class="p-date-range-select__content">
           <PIcon icon="CalendarIcon" class="shrink-0" />
           <span class="p-date-range-select__label" :class="classes.label">
@@ -12,7 +12,7 @@
         </div>
       </PButton>
 
-      <template v-if="modelValue && clearable">
+      <template v-if="modelValue && clearable && !disabled">
         <PButton class="p-date-range-select__button" icon="XCircleIcon" @click="clear" />
       </template>
       <PButton class="p-date-range-select__button" icon="ArrowSmallRightIcon" :disabled="nextDisabled" @click="next" />
@@ -59,6 +59,7 @@
     modelValue: DateRangeSelectValue,
     placeholder?: string,
     clearable?: boolean,
+    disabled?: boolean,
     min?: Date,
     max?: Date,
   }>()
@@ -144,7 +145,7 @@
     const seconds = getIntervalInSeconds()
     const { startDate } = getNewRange(seconds * -1) ?? {}
 
-    if (!startDate || !seconds) {
+    if (!startDate || !seconds || props.disabled) {
       return true
     }
 
@@ -169,7 +170,7 @@
     const seconds = getIntervalInSeconds()
     const { endDate } = getNewRange(seconds) ?? {}
 
-    if (!endDate || !seconds) {
+    if (!endDate || !seconds || props.disabled) {
       return true
     }
 

--- a/src/components/DateRangeSelect/PDateRangeSelect.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelect.vue
@@ -5,7 +5,9 @@
       <PButton class="p-date-range-select__button p-date-range-select__input" @click="open">
         <div class="p-date-range-select__content">
           <PIcon icon="CalendarIcon" />
-          {{ label }}
+          <span class="p-date-range-select__label" :class="classes.label">
+            {{ label }}
+          </span>
           <PIcon icon="ChevronDownIcon" class="ml-auto" />
         </div>
       </PButton>
@@ -42,6 +44,7 @@
 
   const props = defineProps<{
     modelValue: DateRangeSelectValue,
+    placeholder?: string,
     min?: Date,
     max?: Date,
   }>()
@@ -68,6 +71,8 @@
     },
   })
 
+  const placeholder = computed(() => props.placeholder ?? 'Select a time span')
+
   const label = computed(() => {
     if (typeof modelValue.value === 'number') {
       const duration = intervalToDuration({
@@ -84,8 +89,14 @@
       return `${format(startDate, dateFormat)} - ${format(endDate, dateFormat)}`
     }
 
-    return 'select'
+    return placeholder.value
   })
+
+  const classes = computed(() => ({
+    label: {
+      'p-date-range-select__label--placeholder': label.value === placeholder.value,
+    },
+  }))
 
 
   function selectSpan(value: DateRangeSelectOptionsValue): void {
@@ -156,5 +167,9 @@
   flex
   items-center
   gap-2
+}
+
+.p-date-range-select__label--placeholder { @apply
+  text-subdued
 }
 </style>

--- a/src/components/DateRangeSelect/PDateRangeSelect.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelect.vue
@@ -1,0 +1,101 @@
+<template>
+  <PPopOver ref="popover" class="p-date-range-select" auto-close>
+    <template #target="{ toggle }">
+      <PButton class="p-date-range-select__button" icon="ArrowSmallLeftIcon" />
+      <PButton class="p-date-range-select__button p-date-range-select__input" icon="CalendarIcon" icon-append="ChevronDownIcon" @click="toggle">
+        Past 8h
+      </PButton>
+
+      <template v-if="modelValue">
+        <PButton class="p-date-range-select__button" icon="XCircleIcon" />
+      </template>
+      <PButton class="p-date-range-select__button" icon="ArrowSmallRightIcon" />
+    </template>
+
+    <template #default>
+      <PDateRangeSelectOptions v-show="mode === 'relative'" v-model="option" @update:model-value="selectOption" />
+
+      <template v-if="mode === 'range'">
+        hello
+      </template>
+    </template>
+  </PPopOver>
+</template>
+
+<script lang="ts" setup>
+  import { computed, ref, watch } from 'vue'
+  import PButton from '@/components/Button/PButton.vue'
+  import PDateRangeSelectOptions, { DateRangeSelectOptionsValue } from '@/components/DateRangeSelect/PDateRangeSelectOptions.vue'
+  import PPopOver from '@/components/PopOver/PPopOver.vue'
+
+  export type DateRangeSelectValue = number | [Date, Date] | null | undefined
+
+  const props = defineProps<{
+    modelValue: DateRangeSelectValue,
+    min?: Date,
+    max?: Date,
+  }>()
+
+  const emit = defineEmits<{
+    'update:modelValue': [DateRangeSelectValue],
+  }>()
+
+  const popover = ref<InstanceType<typeof PPopOver>>()
+  const mode = ref<'relative' | 'range'>('relative')
+  const option = ref()
+
+  const value = computed({
+    get() {
+      return props.modelValue
+    },
+    set(value) {
+      emit('update:modelValue', value)
+    },
+  })
+
+  function selectOption(value: DateRangeSelectOptionsValue): void {
+    if (value === 'range') {
+      mode.value = 'range'
+      return
+    }
+
+    popover.value?.close()
+  }
+
+  watch(() => popover.value?.visible, (visible) => {
+    if (!visible) {
+      mode.value = 'relative'
+    }
+  })
+</script>
+
+<style>
+.p-date-range-select { @apply
+  w-full
+  flex
+  flex-nowrap
+  items-center
+}
+
+.p-date-range-select__button { @apply
+  rounded-none
+  -ml-[1px]
+}
+
+.p-date-range-select__button:hover { @apply
+  z-10
+}
+
+.p-date-range-select__button:first-child { @apply
+  ml-0
+  rounded-l-default
+}
+
+.p-date-range-select__button:last-child { @apply
+  rounded-r-default
+}
+
+.p-date-range-select__input { @apply
+  grow
+}
+</style>

--- a/src/components/DateRangeSelect/PDateRangeSelect.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelect.vue
@@ -13,17 +13,28 @@
       </PButton>
 
       <template v-if="modelValue">
-        <PButton class="p-date-range-select__button" icon="XCircleIcon" />
+        <PButton class="p-date-range-select__button" icon="XCircleIcon" @click="clear" />
       </template>
       <PButton class="p-date-range-select__button" icon="ArrowSmallRightIcon" />
     </template>
 
     <template #default>
-      <PDateRangeSelectOptions v-show="mode === 'relative'" :model-value="span" v-bind="{ min, max }" @update:model-value="selectSpan" />
+      <div class="p-date-range-select__picker" @click.stop>
+        <template v-if="mode === 'relative'">
+          <PDateRangeSelectOptions :model-value="span" v-bind="{ min, max }" @update:model-value="selectSpan" />
+        </template>
 
-      <template v-if="mode === 'range'">
-        <PDateRangePicker v-model:start-date="startDate" v-model:end-date="endDate" v-bind="{ min, max }" @close="close" @apply="selectRange" />
-      </template>
+        <template v-if="mode === 'range'">
+          <PDateRangePicker
+            v-model:start-date="startDate"
+            v-model:end-date="endDate"
+            v-bind="{ min, max }"
+            show-time
+            @close="close"
+            @apply="selectRange"
+          />
+        </template>
+      </div>
     </template>
   </PPopOver>
 </template>
@@ -140,6 +151,10 @@
 
   function close(): void {
     popover.value?.close()
+  }
+
+  function clear(): void {
+    emit('update:modelValue', null)
   }
 
   watch(() => popover.value?.visible, (visible) => {

--- a/src/components/DateRangeSelect/PDateRangeSelect.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelect.vue
@@ -19,7 +19,7 @@
     </template>
 
     <template #default>
-      <PDateRangeSelectOptions v-show="mode === 'relative'" :model-value="span" @update:model-value="selectSpan" />
+      <PDateRangeSelectOptions v-show="mode === 'relative'" :model-value="span" v-bind="{ min, max }" @update:model-value="selectSpan" />
 
       <template v-if="mode === 'range'">
         <PDateRangePicker v-model:start-date="startDate" v-model:end-date="endDate" v-bind="{ min, max }" @close="close" @apply="selectRange" />

--- a/src/components/DateRangeSelect/PDateRangeSelect.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelect.vue
@@ -4,11 +4,11 @@
       <PButton class="p-date-range-select__button" icon="ArrowSmallLeftIcon" :disabled="previousDisabled" @click="previous" />
       <PButton class="p-date-range-select__button p-date-range-select__input" @click="open">
         <div class="p-date-range-select__content">
-          <PIcon icon="CalendarIcon" />
+          <PIcon icon="CalendarIcon" class="shrink-0" />
           <span class="p-date-range-select__label" :class="classes.label">
             {{ label }}
           </span>
-          <PIcon icon="ChevronDownIcon" class="ml-auto" />
+          <PIcon icon="ChevronDownIcon" class="ml-auto shrink-0" />
         </div>
       </PButton>
 
@@ -262,6 +262,8 @@
 
 .p-date-range-select__input { @apply
   grow
+  shrink
+  min-w-0
 }
 
 .p-date-range-select__content { @apply
@@ -269,6 +271,14 @@
   flex
   items-center
   gap-2
+  min-w-0
+}
+
+.p-date-range-select__label { @apply
+  shrink
+  min-w-0
+  overflow-hidden
+  whitespace-nowrap
 }
 
 .p-date-range-select__label--placeholder { @apply

--- a/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
@@ -2,7 +2,7 @@
   <PSelectOptions v-model="value" :options="options" class="p-date-range-select-options">
     <template #pre-options>
       <div class="p-1">
-        <PTextInput ref="input" v-model="search" />
+        <PTextInput ref="input" v-model="search" placeholder="Enter a unit like &quot;15&quot;" />
       </div>
     </template>
   </PSelectOptions>

--- a/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
@@ -79,3 +79,9 @@
     ]
   })
 </script>
+
+<style>
+.p-date-range-select-options {
+  min-width: 300px;
+}
+</style>

--- a/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
@@ -9,11 +9,11 @@
 </template>
 
 <script lang="ts" setup>
-  import { secondsInDay, secondsInHour, secondsInMinute, secondsInWeek } from 'date-fns'
+  import { secondsInDay, secondsInHour, secondsInMinute } from 'date-fns'
   import { computed, onMounted, ref } from 'vue'
   import PSelectOptions from '@/components/Select/PSelectOptions.vue'
   import PTextInput from '@/components/TextInput/PTextInput.vue'
-  import { SelectOption } from '@/types'
+  import { SelectOption, SelectOptionGroup } from '@/types'
 
   export type DateRangeSelectOptionsValue = number | 'range' | null | undefined
 
@@ -43,15 +43,24 @@
   const input = ref<InstanceType<typeof PTextInput>>()
   const search = ref('')
 
-  const options = computed<SelectOption[]>(() => {
+  // eslint keeps breaking the parens here
+  // eslint-disable-next-line no-extra-parens
+  const options = computed<(SelectOption | SelectOptionGroup)[]>(() => {
     const parsed = parseInt(search.value || '1')
     const unit = isNaN(parsed) ? 1 : parsed
 
     return [
-      { label: `Past ${unit}m`, value: unit * secondsInMinute },
-      { label: `Past ${unit}h`, value: unit * secondsInHour },
-      { label: `Past ${unit}d`, value: unit * secondsInDay },
-      { label: `Past ${unit}w`, value: unit * secondsInWeek },
+      {
+        label: 'Test',
+        options: [
+          { label: `Past ${unit} minutes`, value: unit * secondsInMinute * -1 },
+          { label: `Past ${unit} hours`, value: unit * secondsInHour * -1 },
+          { label: `Past ${unit} days`, value: unit * secondsInDay * -1 },
+          { label: `Next ${unit} minutes`, value: unit * secondsInMinute },
+          { label: `Next ${unit} hours`, value: unit * secondsInHour },
+          { label: `Next ${unit} days`, value: unit * secondsInDay },
+        ],
+      },
       { label: 'Select from calendar', value: 'range' },
     ]
   })

--- a/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { addSeconds, isAfter, isBefore, secondsInDay, secondsInHour, secondsInMinute } from 'date-fns'
+  import { addSeconds, isAfter, isBefore, secondsInDay, secondsInHour, secondsInMinute, secondsInWeek } from 'date-fns'
   import { computed, onMounted, ref } from 'vue'
   import PSelectOptions from '@/components/Select/PSelectOptions.vue'
   import PTextInput from '@/components/TextInput/PTextInput.vue'
@@ -70,7 +70,7 @@
         return false
       }
 
-      return true
+      return Math.abs(option.value) < secondsInWeek
     })
 
     return [

--- a/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { addSeconds, isAfter, isBefore, secondsInDay, secondsInHour, secondsInMinute, secondsInWeek } from 'date-fns'
+  import { addSeconds, isAfter, isBefore, secondsInDay, secondsInHour, secondsInMinute, secondsInMonth, secondsInWeek } from 'date-fns'
   import { computed, onMounted, ref } from 'vue'
   import PSelectOptions from '@/components/Select/PSelectOptions.vue'
   import PTextInput from '@/components/TextInput/PTextInput.vue'
@@ -20,6 +20,7 @@
 
   const props = defineProps<{
     modelValue: DateRangeSelectOptionsValue,
+    maxSpanInSeconds?: number,
     min?: Date,
     max?: Date,
   }>()
@@ -52,12 +53,15 @@
       { label: `Past ${unit} ${toPluralString('minute', unit)}`, value: unit * secondsInMinute * -1 },
       { label: `Past ${unit} ${toPluralString('hour', unit)}`, value: unit * secondsInHour * -1 },
       { label: `Past ${unit} ${toPluralString('day', unit)}`, value: unit * secondsInDay * -1 },
+      { label: `Past ${unit} ${toPluralString('week', unit)}`, value: unit * secondsInWeek * -1 },
       { label: `Next ${unit} ${toPluralString('minute', unit)}`, value: unit * secondsInMinute },
       { label: `Next ${unit} ${toPluralString('hour', unit)}`, value: unit * secondsInHour },
       { label: `Next ${unit} ${toPluralString('day', unit)}`, value: unit * secondsInDay },
+      { label: `Next ${unit} ${toPluralString('week', unit)}`, value: unit * secondsInWeek },
     ]
 
     const now = new Date()
+    const maxSpanInSeconds = props.maxSpanInSeconds ?? secondsInMonth * 2
 
     const filteredSpans = spans.filter(option => {
       const time = addSeconds(now, option.value)
@@ -70,7 +74,11 @@
         return false
       }
 
-      return Math.abs(option.value) < secondsInWeek
+      if (maxSpanInSeconds) {
+        return Math.abs(option.value) < maxSpanInSeconds
+      }
+
+      return true
     })
 
     return [
@@ -83,5 +91,10 @@
 <style>
 .p-date-range-select-options {
   min-width: 300px;
+}
+
+.p-date-range-select-options,
+.p-date-range-select-options .p-select-options__options {
+  max-height: 400px;
 }
 </style>

--- a/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
@@ -14,6 +14,7 @@
   import PSelectOptions from '@/components/Select/PSelectOptions.vue'
   import PTextInput from '@/components/TextInput/PTextInput.vue'
   import { SelectOption } from '@/types'
+  import { toPluralString } from '@/utilities'
 
   export type DateRangeSelectOptionsValue = number | 'range' | null | undefined
 
@@ -48,12 +49,12 @@
     const unit = isNaN(parsed) ? 1 : parsed
 
     const spans = [
-      { label: `Past ${unit} minutes`, value: unit * secondsInMinute * -1 },
-      { label: `Past ${unit} hours`, value: unit * secondsInHour * -1 },
-      { label: `Past ${unit} days`, value: unit * secondsInDay * -1 },
-      { label: `Next ${unit} minutes`, value: unit * secondsInMinute },
-      { label: `Next ${unit} hours`, value: unit * secondsInHour },
-      { label: `Next ${unit} days`, value: unit * secondsInDay },
+      { label: `Past ${unit} ${toPluralString('minute', unit)}`, value: unit * secondsInMinute * -1 },
+      { label: `Past ${unit} ${toPluralString('hour', unit)}`, value: unit * secondsInHour * -1 },
+      { label: `Past ${unit} ${toPluralString('day', unit)}`, value: unit * secondsInDay * -1 },
+      { label: `Next ${unit} ${toPluralString('minute', unit)}`, value: unit * secondsInMinute },
+      { label: `Next ${unit} ${toPluralString('hour', unit)}`, value: unit * secondsInHour },
+      { label: `Next ${unit} ${toPluralString('day', unit)}`, value: unit * secondsInDay },
     ]
 
     const now = new Date()

--- a/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
@@ -1,0 +1,62 @@
+<template>
+  <PSelectOptions v-model="value" :options="options" class="p-date-range-select-options">
+    <template #pre-options>
+      <div class="p-1">
+        <PTextInput ref="input" v-model="search" />
+      </div>
+    </template>
+  </PSelectOptions>
+</template>
+
+<script lang="ts" setup>
+  import { secondsInDay, secondsInHour, secondsInMinute, secondsInWeek } from 'date-fns'
+  import { computed, onMounted, ref } from 'vue'
+  import PSelectOptions from '@/components/Select/PSelectOptions.vue'
+  import PTextInput from '@/components/TextInput/PTextInput.vue'
+  import { SelectOption } from '@/types'
+
+  export type DateRangeSelectOptionsValue = number | 'range' | null | undefined
+
+  const props = defineProps<{
+    modelValue: DateRangeSelectOptionsValue,
+    min?: Date,
+    max?: Date,
+  }>()
+
+  const emit = defineEmits<{
+    'update:modelValue': [DateRangeSelectOptionsValue],
+  }>()
+
+  onMounted(() => {
+    input.value?.el?.focus()
+  })
+
+  const value = computed({
+    get() {
+      return props.modelValue
+    },
+    set(value) {
+      emit('update:modelValue', value)
+    },
+  })
+
+  const input = ref<InstanceType<typeof PTextInput>>()
+  const search = ref('')
+
+  const options = computed<SelectOption[]>(() => {
+    const parsed = parseInt(search.value || '1')
+    const unit = isNaN(parsed) ? 1 : parsed
+
+    return [
+      { label: `Past ${unit}m`, value: unit * secondsInMinute },
+      { label: `Past ${unit}h`, value: unit * secondsInHour },
+      { label: `Past ${unit}d`, value: unit * secondsInDay },
+      { label: `Past ${unit}w`, value: unit * secondsInWeek },
+      { label: 'Select from calendar', value: 'range' },
+    ]
+  })
+</script>
+
+<style>
+
+</style>

--- a/src/components/DateRangeSelect/index.ts
+++ b/src/components/DateRangeSelect/index.ts
@@ -1,0 +1,8 @@
+import { App } from 'vue'
+import PDateRangeSelect from '@/components/DateRangeSelect/PDateRangeSelect.vue'
+
+const install = (app: App): void => {
+  app.component('PDateRangeSelect', PDateRangeSelect)
+}
+
+export { PDateRangeSelect, install }

--- a/src/components/DateRangeSelect/utilities.ts
+++ b/src/components/DateRangeSelect/utilities.ts
@@ -37,7 +37,7 @@ export function getDateRangeLabel({ startDate, endDate }: DateRange): string {
     return format(startDate, dateFormat)
   }
 
-  if (isPickerDateRange({ startDate, endDate })) {
+  if (isFullDateRange({ startDate, endDate })) {
     return `${format(startDate, dateFormat)} - ${format(endDate, dateFormat)}`
   }
 
@@ -45,9 +45,9 @@ export function getDateRangeLabel({ startDate, endDate }: DateRange): string {
 }
 
 function isPickerSingleDayRange({ startDate, endDate }: DateRange): boolean {
-  return isPickerDateRange({ startDate, endDate }) && isSameDay(startDate, endDate)
+  return isFullDateRange({ startDate, endDate }) && isSameDay(startDate, endDate)
 }
 
-export function isPickerDateRange({ startDate, endDate }: DateRange): boolean {
+export function isFullDateRange({ startDate, endDate }: DateRange): boolean {
   return startOfDay(startDate).getTime() === startDate.getTime() && endOfDay(endDate).getTime() === endDate.getTime()
 }

--- a/src/components/DateRangeSelect/utilities.ts
+++ b/src/components/DateRangeSelect/utilities.ts
@@ -1,4 +1,4 @@
-import { addSeconds, format, intervalToDuration, isSameDay } from 'date-fns'
+import { addSeconds, endOfDay, format, intervalToDuration, isSameDay, startOfDay } from 'date-fns'
 import { toPluralString } from '@/utilities'
 
 type DateRange = {
@@ -33,21 +33,21 @@ export function getDateSpanLabel(seconds: number): string {
 }
 
 export function getDateRangeLabel({ startDate, endDate }: DateRange): string {
-  if (isSingleDay({ startDate, endDate })) {
+  if (isPickerSingleDayRange({ startDate, endDate })) {
     return format(startDate, dateFormat)
   }
 
-  if (isDateRange({ startDate, endDate })) {
+  if (isPickerDateRange({ startDate, endDate })) {
     return `${format(startDate, dateFormat)} - ${format(endDate, dateFormat)}`
   }
 
   return `${format(startDate, dateTimeFormat)} - ${format(endDate, dateTimeFormat)}`
 }
 
-function isSingleDay({ startDate, endDate }: DateRange): boolean {
-  return isDateRange({ startDate, endDate }) && isSameDay(startDate, endDate)
+function isPickerSingleDayRange({ startDate, endDate }: DateRange): boolean {
+  return isPickerDateRange({ startDate, endDate }) && isSameDay(startDate, endDate)
 }
 
-function isDateRange({ startDate, endDate }: DateRange): boolean {
-  return startDate.getMinutes() === 0 && endDate.getMinutes() === 59
+export function isPickerDateRange({ startDate, endDate }: DateRange): boolean {
+  return startOfDay(startDate).getTime() === startDate.getTime() && endOfDay(endDate).getTime() === endDate.getTime()
 }

--- a/src/components/DateRangeSelect/utilities.ts
+++ b/src/components/DateRangeSelect/utilities.ts
@@ -1,0 +1,53 @@
+import { addSeconds, format, intervalToDuration, isSameDay } from 'date-fns'
+import { toPluralString } from '@/utilities'
+
+type DateRange = {
+  startDate: Date,
+  endDate: Date,
+}
+
+const dateFormat = 'MMM do, yyyy'
+const timeFormat = 'hh:mm a'
+const dateTimeFormat = `${dateFormat} 'at' ${timeFormat}`
+
+export function getDateSpanLabel(seconds: number): string {
+
+  const now = new Date()
+  const duration = intervalToDuration({
+    start: now,
+    end: addSeconds(now, seconds),
+  })
+
+  const reduced = Object.entries(duration).reduce<string[]>((durations, [key, value]) => {
+    if (value) {
+      const unit = key.slice(0, -1)
+      durations.push(`${value} ${toPluralString(unit, value)}`)
+    }
+
+    return durations
+  }, [])
+
+  const direction = seconds < 0 ? 'Past' : 'Next'
+
+  return `${direction} ${reduced.join(' ')}`
+}
+
+export function getDateRangeLabel({ startDate, endDate }: DateRange): string {
+  if (isSingleDay({ startDate, endDate })) {
+    return format(startDate, dateFormat)
+  }
+
+  if (isDateRange({ startDate, endDate })) {
+    return `${format(startDate, dateFormat)} - ${format(endDate, dateFormat)}`
+  }
+
+  return `${format(startDate, dateTimeFormat)} - ${format(endDate, dateTimeFormat)}`
+}
+
+function isSingleDay({ startDate, endDate }: DateRange): boolean {
+  return isDateRange({ startDate, endDate }) && isSameDay(startDate, endDate)
+}
+
+function isDateRange({ startDate, endDate }: DateRange): boolean {
+  return startDate.getMinutes() === 0 && endDate.getMinutes() === 59
+}

--- a/src/components/DateTimeInputGroup/PDateTimeInputGroup.vue
+++ b/src/components/DateTimeInputGroup/PDateTimeInputGroup.vue
@@ -10,10 +10,10 @@
     </template>
 
     <PContent secondary>
-      <PNativeDateInput v-model="date" disable-picker />
+      <PNativeDateInput v-model="startDate" disable-picker />
 
       <template v-if="showTime">
-        <PNativeTimeInput v-model="date" disable-picker />
+        <PNativeTimeInput v-model="startTime" disable-picker />
       </template>
     </PContent>
   </PLabel>
@@ -38,7 +38,7 @@
     (event: 'update:modelValue', value: Date | null): void,
   }>()
 
-  const date = computed({
+  const startDate = computed({
     get() {
       return props.modelValue ?? null
     },
@@ -47,6 +47,18 @@
     },
   })
 
+  const startTime = computed({
+    get() {
+      return props.modelValue ?? null
+    },
+    set(value) {
+      if (!value) {
+        return
+      }
+
+      emit('update:modelValue', value)
+    },
+  })
   const nowOrTodayLabel = computed(() => props.showTime ? 'Now' : 'Today')
 
   function setToTodayOrNow(): void {

--- a/src/components/NativeDateInput/PNativeDateInput.vue
+++ b/src/components/NativeDateInput/PNativeDateInput.vue
@@ -64,7 +64,14 @@
   })
 
   const stringMin = computed(() => props.min ? format(props.min, 'yyyy-MM-dd') : undefined)
-  const stringMax = computed(() => props.max ? format(props.max, 'yyyy-MM-dd') : undefined)
+  const stringMax = computed(() => {
+    if (props.max) {
+      return format(props.max, 'yyyy-MM-dd')
+    }
+
+    // max date with a 4 digit year
+    return '2999-12-31'
+  })
 
   function showPicker(): void {
     inputElement.value?.showPicker()

--- a/src/components/SelectOption/PSelectOption.vue
+++ b/src/components/SelectOption/PSelectOption.vue
@@ -125,6 +125,7 @@
   flex
   gap-2
   items-center
+  cursor-pointer
 }
 
 .p-select-option--selected { @apply

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -21,6 +21,7 @@ import { PDateInput, install as installPDateInput } from '@/components/DateInput
 import { PDatePicker, install as installPDatePicker } from '@/components/DatePicker'
 import { PDateRangeInput, install as installPDateRangeInput } from '@/components/DateRangeInput'
 import { PDateRangePicker, install as installPDateRangePicker } from '@/components/DateRangePicker'
+import { PDateRangeSelect, install as installPDateRangeSelect } from '@/components/DateRangeSelect'
 import { PDialog, install as installPDialog } from '@/components/Dialog'
 import { PDivider, install as installPDivider } from '@/components/Divider'
 import { PDrawer, install as installPDrawer } from '@/components/Drawer'
@@ -111,6 +112,7 @@ export {
   PDatePicker,
   PDateRangeInput,
   PDateRangePicker,
+  PDateRangeSelect,
   PDialog,
   PDivider,
   PDrawer,
@@ -212,6 +214,7 @@ export const installs = [
   installPDatePicker,
   installPDateRangeInput,
   installPDateRangePicker,
+  installPDateRangeSelect,
   installPDialog,
   installPDivider,
   installPDrawer,
@@ -303,6 +306,7 @@ declare module '@vue/runtime-core' {
     PDatePicker: typeof PDatePicker,
     PDateRangeInput: typeof PDateRangeInput,
     PDateRangePicker: typeof PDateRangePicker,
+    PDateRangeSelect: typeof PDateRangeSelect,
     PDialog: typeof PDialog,
     PDivider: typeof PDivider,
     PDrawer: typeof PDrawer,


### PR DESCRIPTION
# Description
The date range select is a new component for selecting date ranges either of a fixed date/time or a relative time span like "Past 15 minutes". 

It has a single v-model that returns a value based on the user's selection. If a relative value is selected the number of seconds in the selected span is returned. If a fixed range is selected the start and end dates are returned. This value can be type guarded with the `modelValue.type` which is either `span` or `range`

Recommend checking out the [deploy preview ](https://deploy-preview-1048--prefect-design.netlify.app/components/date-range-select)and playing around this the component. 

Relative span
<img width="1065" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6200442/7b6856bc-72e3-431d-ba88-728ec4f728ce">
<img width="1052" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6200442/a3b61696-9143-4c76-ba38-915bb3d69bac">

Fixed date range
<img width="1046" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6200442/4d592dc1-de73-49e6-85f4-d0263ade352e">
<img width="1051" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6200442/4a7f4e71-fd33-4006-86a8-981ff3cf94cc">
