### PR TITLE
BugFix: Emit the bottom event if the native select is mounted

### DIFF
--- a/src/components/Select/PSelect.vue
+++ b/src/components/Select/PSelect.vue
@@ -62,6 +62,7 @@
           :disabled="disabled"
           v-bind="attrs"
           :options="options"
+          @vue:mounted="emit('bottom')"
         />
       </template>
     </template>


### PR DESCRIPTION
# Description
If a select or combobox is using the bottom event to async load options no options will appear if a native select is used. This can happen if the `media.hover` check is false. 

Emitting the `bottom` event when the native select is mounted ensures at least the first page of results is shown. 

Note: This is a stop gap to get options showing at all. To restore full functionality to mobile devices we'll need to rethink our mobile strategy for selects