### PR TITLE
Enhancement: PDateRangeSelect overflow and escape to close

### DIFF
--- a/src/components/DateRangePicker/PDateRangePicker.vue
+++ b/src/components/DateRangePicker/PDateRangePicker.vue
@@ -181,7 +181,7 @@
 }
 
 .p-date-range-picker__date-wrapper--selected-start { @apply
-  rounded-l-sm
+  rounded-l-default
 }
 
 .p-date-range-picker__date-wrapper--selected-start::before { @apply
@@ -193,7 +193,7 @@
 }
 
 .p-date-range-picker__date-wrapper--selected-end { @apply
-  rounded-r-sm
+  rounded-r-default
 }
 
 .p-date-range-picker__date-wrapper--in-range { @apply

--- a/src/components/DateRangeSelect/PDateRangeSelect.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelect.vue
@@ -277,6 +277,7 @@
 }
 
 .p-date-range-select__input { @apply
+  overflow-hidden
   grow
   shrink
   min-w-0
@@ -293,7 +294,6 @@
 .p-date-range-select__label { @apply
   shrink
   min-w-0
-  overflow-hidden
   whitespace-nowrap
 }
 

--- a/src/components/DateRangeSelect/PDateRangeSelect.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelect.vue
@@ -40,6 +40,7 @@
 </template>
 
 <script lang="ts" setup>
+  import { useKeyDown } from '@prefecthq/vue-compositions'
   import { addDays, addSeconds, differenceInSeconds, isAfter, isBefore, secondsInDay, startOfMinute } from 'date-fns'
   import { computed, ref, watch } from 'vue'
   import PButton from '@/components/Button/PButton.vue'
@@ -66,6 +67,10 @@
   const emit = defineEmits<{
     'update:modelValue': [DateRangeSelectValue],
   }>()
+
+  useKeyDown('Escape', () => {
+    popover.value?.close()
+  })
 
   const placement = [bottomLeft, topLeft, bottomRight, topRight, leftInside, rightInside]
   const popover = ref<InstanceType<typeof PPopOver>>()

--- a/src/components/DateRangeSelect/PDateRangeSelect.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelect.vue
@@ -257,7 +257,6 @@
 
 <style>
 .p-date-range-select { @apply
-  w-full
   flex
   flex-nowrap
   items-center


### PR DESCRIPTION
# Description
Fixes the label overflowing the button if there is not enough room. Also allows the popover to be closed by pressing escape. Also updates the date range picker's styling to match the border radius to the buttons. 