### PR TITLE
Fix: tags input not taking advantage of available width

### DIFF
--- a/demo/sections/components/Tags.vue
+++ b/demo/sections/components/Tags.vue
@@ -60,7 +60,7 @@
         <div>
           <p>Inline</p>
           <div class="border border-default p-2 max-w-full">
-            <p-tag-wrapper :tags="numberArr" justify="left" inline class="border border-red-500" />
+            <p-tag-wrapper :tags="numberArr" justify="left" inline class="border border-default" />
           </div>
         </div>
       </div>

--- a/demo/sections/components/Tags.vue
+++ b/demo/sections/components/Tags.vue
@@ -60,7 +60,7 @@
         <div>
           <p>Inline</p>
           <div class="border border-default p-2 max-w-full">
-            <p-tag-wrapper :tags="numberArr" justify="left" inline class="border border-default" />
+            <p-tag-wrapper :tags="numberArr" justify="left" inline class="border border-red-500" />
           </div>
         </div>
       </div>

--- a/demo/sections/components/Tags.vue
+++ b/demo/sections/components/Tags.vue
@@ -35,9 +35,9 @@
 
     <template #using-p-tag-wrapper>
       <div class="flex flex-col gap-3">
-        <p-tag-wrapper class="h-[48px]" :tags="numberArr" justify="left" />
+        <p-tag-wrapper :tags="numberArr" justify="left" />
 
-        <p-tag-wrapper class="h-[48px]" :tags="numberArr">
+        <p-tag-wrapper :tags="numberArr">
           <template #tag="{ tag }">
             <p-tag icon="Prefect">
               {{ tag }}
@@ -51,7 +51,7 @@
           </template>
         </p-tag-wrapper>
 
-        <p-tag-wrapper class="h-[48px]" justify="right">
+        <p-tag-wrapper justify="right">
           <p-tag v-for="i in 20" :key="i">
             Tag {{ i }}
           </p-tag>
@@ -59,8 +59,8 @@
 
         <div>
           <p>Inline</p>
-          <div class="border border-default p-2 inline-flex max-w-full">
-            <p-tag-wrapper class="h-[48px]" :tags="numberArr" justify="left" inline />
+          <div class="border border-default p-2 max-w-full">
+            <p-tag-wrapper :tags="numberArr" justify="left" inline class="border border-default" />
           </div>
         </div>
       </div>

--- a/demo/sections/components/Tags.vue
+++ b/demo/sections/components/Tags.vue
@@ -7,6 +7,7 @@
       { title: 'Multiple' },
       { title: 'Using p-tag-wrapper' },
     ]"
+    use-resizable
   >
     <template #basic>
       <div class="tags__list">
@@ -55,6 +56,13 @@
             Tag {{ i }}
           </p-tag>
         </p-tag-wrapper>
+
+        <div>
+          <p>Inline</p>
+          <div class="border border-default p-2 inline-flex max-w-full">
+            <p-tag-wrapper class="h-[48px]" :tags="numberArr" justify="left" inline />
+          </div>
+        </div>
       </div>
     </template>
   </ComponentPage>

--- a/demo/sections/components/TagsInput.vue
+++ b/demo/sections/components/TagsInput.vue
@@ -6,7 +6,7 @@
 
     <template #tags-input>
       <div class="tags-input__demo">
-        <p-tags-input v-model="exampleTagsValue" :disabled="disabled" :state="exampleState" />
+        <p-tags-input v-model="exampleTagsValue" empty-message="All tags" :disabled="disabled" :state="exampleState" />
 
         <p-code inline>
           value: {{ JSON.stringify(exampleTagsValue) }}

--- a/src/components/Select/PSelect.vue
+++ b/src/components/Select/PSelect.vue
@@ -29,7 +29,7 @@
             </template>
 
             <template v-else-if="multiple">
-              <PTagWrapper :tags="tags">
+              <PTagWrapper :tags="tags" inline>
                 <template #tag="{ tag }">
                   <slot name="tag" :label="tag.label" :value="tag.value" :dismiss="() => dismissTag(tag)">
                     <PTag :dismissible="isDismissible(tag)" @dismiss="dismissTag(tag)">

--- a/src/components/TagWrapper/PTagWrapper.vue
+++ b/src/components/TagWrapper/PTagWrapper.vue
@@ -76,6 +76,8 @@
     const tags = Array.from(container.value.children)
       .filter(child => !child.classList.contains('p-tag-wrapper__tag-overflow')) as HTMLElement[]
 
+    setTagVisibility(overflowTag.value!, 'hidden')
+
     setAllTagsInvisible(tags)
 
     if (props.inline) {
@@ -87,7 +89,7 @@
     tags.forEach(tag => {
       const { right } = tag.getBoundingClientRect()
 
-      if (right > containerRightEdge) {
+      if (right > containerRightEdge || overflowCount.value > 0) {
         setTagVisibility(tag, 'hidden')
         overflowCount.value++
         if (tag.textContent) {
@@ -100,7 +102,12 @@
     })
 
     if (overflowCount.value > 0) {
-      const { right: overflowTagRight, width: overflowTagWidth } = overflowTag.value!.getBoundingClientRect()
+      setTagVisibility(overflowTag.value!, 'visible')
+
+      const {
+        right: overflowTagRight,
+        width: overflowTagWidth,
+      } = overflowTag.value!.getBoundingClientRect()
 
       if (overflowTagRight > containerRightEdge) {
         const visibleTags = tags.filter(child => !child.classList.contains(hiddenTagClass)).reverse()
@@ -149,9 +156,9 @@
   }
 
   function setInlineContainerWidth(tags: HTMLElement[]): void {
-    console.log('---------')
     const totalTagsWidth = tags.reduce((acc, tag) => {
       const boundingBox = tag.getBoundingClientRect()
+
       return acc + Math.ceil(boundingBox.width)
     }, 0)
 

--- a/src/components/TagWrapper/PTagWrapper.vue
+++ b/src/components/TagWrapper/PTagWrapper.vue
@@ -167,7 +167,7 @@
     const totalTagsWidth = children.reduce((acc, child) => {
       setTagVisibility(child, 'invisible')
       const boundingBox = child.getBoundingClientRect()
-
+      console.log('tag width', Math.ceil(boundingBox.width))
       return acc + Math.ceil(boundingBox.width)
     }, 0)
 

--- a/src/components/TagWrapper/PTagWrapper.vue
+++ b/src/components/TagWrapper/PTagWrapper.vue
@@ -1,24 +1,22 @@
 <template>
-  <div ref="container" class="p-tag-wrapper">
-    <div class="p-tag-wrapper__tag-container" :class="classes.tagContainer">
-      <slot>
-        <template v-for="tag in tags" :key="tag">
-          <div class="p-tag-wrapper__tag" :class="classes.tag">
-            <slot name="tag" :tag="tag">
-              <PTag :value="tag" />
-            </slot>
-          </div>
-        </template>
+  <div ref="container" class="p-tag-wrapper" :class="classes.tagContainer">
+    <slot>
+      <template v-for="tag in tags" :key="tag">
+        <div class="p-tag-wrapper__tag" :class="classes.tag">
+          <slot name="tag" :tag="tag">
+            <PTag :value="tag" />
+          </slot>
+        </div>
+      </template>
+    </slot>
+
+
+    <div ref="overflowTag" class="p-tag-wrapper__tag-overflow" :class="classes.overflowTag" :title="hiddenText">
+      <slot name="overflow-tags" :overflowed-children="overflowCount">
+        <PTag>
+          +{{ overflowCount }}
+        </PTag>
       </slot>
-
-
-      <div ref="overflowTag" class="p-tag-wrapper__tag-overflow" :class="classes.overflowTag" :title="hiddenText">
-        <slot name="overflow-tags" :overflowed-children="overflowChildren">
-          <PTag>
-            +{{ overflowChildren }}
-          </PTag>
-        </slot>
-      </div>
     </div>
   </div>
 </template>
@@ -36,22 +34,24 @@
 
   const container: Ref<HTMLDivElement | undefined> = ref()
   const ready = ref(false)
-  const overflowChildren = ref(0)
+  const overflowCount = ref(0)
   const overflowTag: Ref<HTMLDivElement | undefined> = ref()
   const hiddenText = ref('')
 
+  const invisibleTagClass = 'p-tag-wrapper__tag--invisible'
+  const hiddenTagClass = 'p-tag-wrapper__tag--hidden'
   const classes = computed(() => {
     return {
-      overflowTag: [
-        `p-tag-wrapper__tag--${props.justify ?? 'left'}`,
-        { 'p-tag-wrapper__tag--hidden': !hasOverflowChildren.value },
-      ],
-      tag: [`p-tag-wrapper__tag--${props.justify ?? 'left'}`],
       tagContainer:
         [
-          `p-tag-wrapper__tag-container--${props.justify ?? 'left'}`,
-          { 'p-tag-wrapper__tag-container--invisible': !ready.value },
+          `p-tag-wrapper--${props.justify ?? 'left'}`,
+          { 'p-tag-wrapper--invisible': !ready.value },
         ],
+      overflowTag: [
+        `p-tag-wrapper__tag--${props.justify ?? 'left'}`,
+        { 'p-tag-wrapper__tag--hidden': !isOverflowing.value },
+      ],
+      tag: [`p-tag-wrapper__tag--${props.justify ?? 'left'}`],
     }
   })
 
@@ -62,87 +62,66 @@
   })
 
   let resizeObserver: ResizeObserver | null = null
-  const hasOverflowChildren = computed(() => overflowChildren.value > 0)
-
-  const invisibleTagClass = 'p-tag-wrapper__tag--invisible'
-  const hiddenTagClass = 'p-tag-wrapper__tag--hidden'
+  const isOverflowing = computed(() => overflowCount.value > 0)
 
   const calculateOverflow = (): void => {
-    const hiddenChildTexts = []
-    const overflowBoundingBox = overflowTag.value!.getBoundingClientRect()
-    let largestChildHeight = overflowBoundingBox.height
-    let overflowed = false
-    let tagsWidth = 0
+    if (!container.value) {
+      return
+    }
 
-    const children = Array.from(
-      container.value?.querySelector('.p-tag-wrapper__tag-container')?.children ?? [],
-    ).filter(child => !child.classList.contains('p-tag-wrapper__tag-overflow')) as HTMLElement[]
+    overflowCount.value = 0
+    hiddenText.value = ''
 
-    overflowChildren.value = children.length
+    const hiddenTags = []
+    const tags = Array.from(container.value.children)
+      .filter(child => !child.classList.contains('p-tag-wrapper__tag-overflow')) as HTMLElement[]
+
+    setAllTagsInvisible(tags)
 
     if (props.inline) {
-      setInlineContainerWidth(children)
+      setInlineContainerWidth(tags)
     }
 
-    const containerBoundingBox = container.value!.getBoundingClientRect()
+    const containerRightEdge = container.value.getBoundingClientRect().right
 
-    for (const child of children) {
-      setTagVisibility(child, 'invisible')
+    tags.forEach(tag => {
+      const { right } = tag.getBoundingClientRect()
 
-      if (overflowed) {
-        setTagVisibility(child, 'hidden')
-        hiddenChildTexts.push(child.innerText)
-      } else {
-        const boundingBox = child.getBoundingClientRect()
-        overflowed = tagsWidth + boundingBox.width >= containerBoundingBox.width
-
-        if (overflowed) {
-          setTagVisibility(child, 'hidden')
-          hiddenChildTexts.push(child.innerText)
-        } else {
-          setTagVisibility(child, 'visible')
-
-          tagsWidth += boundingBox.width
-          largestChildHeight = Math.max(largestChildHeight, boundingBox.height)
-          overflowChildren.value--
+      if (right > containerRightEdge) {
+        setTagVisibility(tag, 'hidden')
+        overflowCount.value++
+        if (tag.textContent) {
+          hiddenTags.push(tag.textContent)
         }
+        return
       }
-    }
 
-    if (overflowChildren.value > 0) {
-      let overflowBoundingBox = overflowTag.value!.getBoundingClientRect()
-      let totalWidth = tagsWidth + overflowBoundingBox.width
+      setTagVisibility(tag, 'visible')
+    })
 
-      if (totalWidth > containerBoundingBox.width) {
-        const visibleChildren = children.filter(child => !child.classList.contains(hiddenTagClass)).reverse()
+    if (overflowCount.value > 0) {
+      const { right: overflowTagRight, width: overflowTagWidth } = overflowTag.value!.getBoundingClientRect()
 
-        reverse: for (const child of visibleChildren) {
-          overflowChildren.value++
-          const boundingBox = child.getBoundingClientRect()
-          tagsWidth -= boundingBox.width
-          overflowBoundingBox = overflowTag.value!.getBoundingClientRect()
+      if (overflowTagRight > containerRightEdge) {
+        const visibleTags = tags.filter(child => !child.classList.contains(hiddenTagClass)).reverse()
 
-          totalWidth = tagsWidth + overflowBoundingBox.width
-          const overflow = totalWidth > containerBoundingBox.width
+        for (const tag of visibleTags) {
+          const { right } = tag.getBoundingClientRect()
 
-          child.classList.add(hiddenTagClass)
-          hiddenChildTexts.unshift(child.innerText)
+          if (right + overflowTagWidth < containerRightEdge) {
+            break
+          }
 
-          if (overflow) {
-            continue reverse
-          } else {
-            break reverse
+          overflowCount.value++
+          setTagVisibility(tag, 'hidden')
+          if (tag.textContent) {
+            hiddenTags.unshift(tag.textContent)
           }
         }
       }
     }
 
-    if (container.value && largestChildHeight) {
-      container.value.style.height = `${largestChildHeight}px`
-    }
-
-    hiddenText.value = hiddenChildTexts.join(', ')
-
+    hiddenText.value = hiddenTags.join(', ')
     ready.value = true
   }
 
@@ -163,11 +142,16 @@
     }
   }
 
-  function setInlineContainerWidth(children: HTMLElement[]): void {
-    const totalTagsWidth = children.reduce((acc, child) => {
-      setTagVisibility(child, 'invisible')
-      const boundingBox = child.getBoundingClientRect()
-      console.log('tag width', Math.ceil(boundingBox.width))
+  function setAllTagsInvisible(tags: HTMLElement[]): void {
+    for (const tag of tags) {
+      setTagVisibility(tag, 'invisible')
+    }
+  }
+
+  function setInlineContainerWidth(tags: HTMLElement[]): void {
+    console.log('---------')
+    const totalTagsWidth = tags.reduce((acc, tag) => {
+      const boundingBox = tag.getBoundingClientRect()
       return acc + Math.ceil(boundingBox.width)
     }, 0)
 
@@ -198,11 +182,32 @@
 
 <style>
 .p-tag-wrapper { @apply
-  relative
-  block
   whitespace-nowrap
   align-middle
   max-w-full
+  flex
+  items-center
+}
+
+.p-tag-wrapper--invisible {
+  visibility: hidden !important;
+}
+
+.p-tag-wrapper--right { @apply
+  text-right
+}
+
+.p-tag-wrapper--center { @apply
+  text-center
+}
+
+.p-tag-wrapper--left { @apply
+  text-left
+}
+
+.p-tag-wrapper__tag { @apply
+  inline-flex
+  items-center
 }
 
 .p-tag-wrapper__tag--hidden { @apply
@@ -211,11 +216,6 @@
 
 .p-tag-wrapper__tag--invisible {
   visibility: hidden !important;
-}
-
-.p-tag-wrapper__tag { @apply
-  inline-flex
-  items-center
 }
 
 .p-tag-wrapper__tag--right { @apply
@@ -230,33 +230,7 @@
   pr-1;
 }
 
-.p-tag-wrapper__tag-overflow {
-  display: inline-block;
-}
-
-.p-tag-wrapper__tag-container { @apply
-  absolute
-  left-0
-  top-0
-  w-full
-  h-full
-  flex
-  items-center
-}
-
-.p-tag-wrapper__tag-container--invisible {
-  visibility: hidden !important;
-}
-
-.p-tag-wrapper__tag-container--right { @apply
-  text-right
-}
-
-.p-tag-wrapper__tag-container--center { @apply
-  text-center
-}
-
-.p-tag-wrapper__tag-container--left { @apply
-  text-left
+.p-tag-wrapper__tag-overflow { @apply
+  inline-block
 }
 </style>


### PR DESCRIPTION
The tags input required a fixed width to really take advantage of the `+n` overflow display. This made it so the input was unusually long on the dashboard or never read out the selected tags:

<img width="236" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6776415/d6978837-5dca-4870-bf38-7f22db5937f1">


This PR makes it so that the tags list has an inline option and will allow the input to scale with the content.

https://github.com/PrefectHQ/prefect-design/assets/6776415/06893d8f-f0ff-409b-a833-5a556cad4c66


https://github.com/PrefectHQ/prefect-design/assets/6776415/0ce71b18-0e10-45cc-91fb-573326f8a387

