### PR TITLE
Fix: prevent default layout header blowouts

### DIFF
--- a/src/layouts/PLayoutDefault/PLayoutDefault.vue
+++ b/src/layouts/PLayoutDefault/PLayoutDefault.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="p-layout-default">
     <div v-if="$slots.header" class="p-layout-default__header">
-      <slot name="header" class="p-layout-default__header" />
+      <slot name="header" />
     </div>
     <div class="p-layout-default__content">
       <slot />
@@ -10,8 +10,7 @@
 </template>
 
 <style>
-.p-layout-default {
-  @apply
+.p-layout-default { @apply
   p-4
   grid
   grid-rows-[max-content_max-content]
@@ -20,8 +19,12 @@
   w-full
 }
 
-.p-layout-default__content {
-  @apply
+.p-layout-default__header { @apply
+  min-w-0
+  max-w-full
+}
+
+.p-layout-default__content { @apply
   grid
   grid-cols-[minmax(0,1fr)]
   gap-4


### PR DESCRIPTION
This is all part of some effort to make the dashboard header more responsive. Prevents flex content from blowing out the container.