### PR TITLE
Fix: Prevent long content from blowing out the list header

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,7 @@
   "javascript.format.enable": false,
   "eslint.alwaysShowStatus": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.options": {
     "extensions": [

--- a/src/components/ListHeader/PListHeader.vue
+++ b/src/components/ListHeader/PListHeader.vue
@@ -71,6 +71,7 @@
 }
 
 .list-header__controls { @apply
+  min-w-0
   grid
   grid-cols-1
   md:flex


### PR DESCRIPTION
Before:
<img width="1121" alt="Screenshot 2023-12-19 at 2 29 52 PM" src="https://github.com/PrefectHQ/prefect-design/assets/6776415/f619400b-bbad-4078-963d-00b592e9add5">

After:
<img width="1059" alt="Screenshot 2023-12-19 at 2 29 34 PM" src="https://github.com/PrefectHQ/prefect-design/assets/6776415/7dc9a2cb-41c5-4fee-9d6c-a0ca02ddafe1">
