### PR TITLE
Fix: remove height 100% from layouts

### DIFF
--- a/src/layouts/PLayoutDefault/PLayoutDefault.vue
+++ b/src/layouts/PLayoutDefault/PLayoutDefault.vue
@@ -15,7 +15,6 @@
   grid
   grid-rows-[max-content_max-content]
   gap-4
-  h-full
   w-full
 }
 

--- a/src/layouts/PLayoutFull/PLayoutFull.vue
+++ b/src/layouts/PLayoutFull/PLayoutFull.vue
@@ -12,6 +12,7 @@
 .p-layout-full { @apply
   relative
   w-full
+  h-full
 }
 
 .p-layout-full__header { @apply

--- a/src/layouts/PLayoutFull/PLayoutFull.vue
+++ b/src/layouts/PLayoutFull/PLayoutFull.vue
@@ -12,7 +12,6 @@
 .p-layout-full { @apply
   relative
   w-full
-  h-full
 }
 
 .p-layout-full__header { @apply

--- a/src/layouts/PLayoutWell/PLayoutWell.vue
+++ b/src/layouts/PLayoutWell/PLayoutWell.vue
@@ -20,7 +20,6 @@
   grid-cols-[1fr_1fr_250px]
   grid-rows-[max-content_max-content]
   gap-4
-  h-full
   w-full
 }
 


### PR DESCRIPTION
Layouts had a height assignment of 100%, but these weren't neccesary. It made it so that if a layout had content above (e.g. the incidents banner) or below it, the height of the layout would be the height of it's inner+neighboring content, causing too much padding at the bottom of it's inner contents and causing the left navigation to scroll. CSS is weird and hard sometimes.