### PR TITLE
Add "period" as a date range value type for things like "Today"

### DIFF
--- a/src/components/DateRangeSelect/PDateRangeSelect.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelect.vue
@@ -21,7 +21,7 @@
     <template #default>
       <div class="p-date-range-select__picker" @click.stop>
         <template v-if="mode === null">
-          <PDateRangeSelectOptions v-model:mode="mode" />
+          <PDateRangeSelectOptions v-model:mode="mode" @apply="apply" />
         </template>
 
         <template v-if="mode === 'span'">

--- a/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
@@ -1,12 +1,12 @@
 <template>
-  <PSelectOptions v-model="mode" :options="options" class="p-date-range-select-options" />
+  <PSelectOptions v-model="selected" :options="options" class="p-date-range-select-options" />
 </template>
 
 <script lang="ts" setup>
   import { computed } from 'vue'
   import { DateRangeSelectMode } from '@/components/DateRangeSelect/PDateRangeSelect.vue'
   import PSelectOptions from '@/components/Select/PSelectOptions.vue'
-  import { SelectOption } from '@/types'
+  import { DateRangeSelectPeriod, DateRangeSelectPeriodValue, SelectOption, isDateRangeSelectPeriod } from '@/types'
 
   const props = defineProps<{
     mode: DateRangeSelectMode,
@@ -14,18 +14,26 @@
 
   const emit = defineEmits<{
     'update:mode': [DateRangeSelectMode],
+    'apply': [DateRangeSelectPeriodValue | null],
   }>()
 
-  const mode = computed({
+  const selected = computed<DateRangeSelectMode | DateRangeSelectPeriod>({
     get() {
       return props.mode
     },
-    set(mode) {
-      emit('update:mode', mode)
+    set(selected) {
+      if (isDateRangeSelectPeriod(selected)) {
+        emit('apply', { type: 'period', period: selected })
+        return
+      }
+
+      emit('update:mode', selected)
     },
   })
 
-  const options: (SelectOption & { value: DateRangeSelectMode })[] = [
+  const options: (SelectOption & { value: DateRangeSelectMode | DateRangeSelectPeriod })[] = [
+    { label: 'Today', value: 'Today' },
+    { label: 'This week', value: 'This week' },
     { label: 'Relative time', value: 'span' },
     { label: 'Around a time', value: 'around' },
     { label: 'Date Range', value: 'range' },
@@ -35,5 +43,10 @@
 <style>
 .p-date-range-select-options {
   min-width: 300px;
+}
+
+.p-date-range-select-options .p-select-option:nth-of-type(2) { @apply
+  border-b
+  border-b-divider
 }
 </style>

--- a/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
@@ -33,7 +33,6 @@
 
   const options: (SelectOption & { value: DateRangeSelectMode | DateRangeSelectPeriod })[] = [
     { label: 'Today', value: 'Today' },
-    { label: 'This week', value: 'This week' },
     { label: 'Relative time', value: 'span' },
     { label: 'Around a time', value: 'around' },
     { label: 'Date range', value: 'range' },

--- a/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
@@ -3,10 +3,11 @@
 </template>
 
 <script lang="ts" setup>
+  import { secondsInDay, secondsInHour, secondsInWeek } from 'date-fns'
   import { computed } from 'vue'
   import { DateRangeSelectMode } from '@/components/DateRangeSelect/PDateRangeSelect.vue'
   import PSelectOptions from '@/components/Select/PSelectOptions.vue'
-  import { DateRangeSelectPeriod, DateRangeSelectPeriodValue, SelectOption, isDateRangeSelectPeriod } from '@/types'
+  import { DateRangeSelectPeriod, DateRangeSelectPeriodValue, DateRangeSelectSpanValue, SelectOption, isDateRangeSelectPeriod } from '@/types'
 
   const props = defineProps<{
     mode: DateRangeSelectMode,
@@ -14,7 +15,7 @@
 
   const emit = defineEmits<{
     'update:mode': [DateRangeSelectMode],
-    'apply': [DateRangeSelectPeriodValue | null],
+    'apply': [DateRangeSelectPeriodValue | DateRangeSelectSpanValue | null],
   }>()
 
   const selected = computed<DateRangeSelectMode | DateRangeSelectPeriod>({
@@ -27,11 +28,19 @@
         return
       }
 
+      if (typeof selected === 'number') {
+        emit('apply', { type: 'span', seconds: selected })
+        return
+      }
+
       emit('update:mode', selected)
     },
   })
 
-  const options: (SelectOption & { value: DateRangeSelectMode | DateRangeSelectPeriod })[] = [
+  const options: (SelectOption & { value: DateRangeSelectMode | DateRangeSelectPeriod | number })[] = [
+    { label: 'Past hour', value: secondsInHour * -1 },
+    { label: 'Past day', value: secondsInDay * -1 },
+    { label: 'Past week', value: secondsInWeek * -1 },
     { label: 'Today', value: 'Today' },
     { label: 'Relative time', value: 'span' },
     { label: 'Around a time', value: 'around' },
@@ -44,7 +53,7 @@
   min-width: 300px;
 }
 
-.p-date-range-select-options .p-select-option:nth-of-type(2) { @apply
+.p-date-range-select-options .p-select-option:nth-of-type(4) { @apply
   border-b
   border-b-divider
 }

--- a/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
@@ -36,7 +36,7 @@
     { label: 'This week', value: 'This week' },
     { label: 'Relative time', value: 'span' },
     { label: 'Around a time', value: 'around' },
-    { label: 'Date Range', value: 'range' },
+    { label: 'Date range', value: 'range' },
   ]
 </script>
 

--- a/src/components/DateRangeSelect/utilities.ts
+++ b/src/components/DateRangeSelect/utilities.ts
@@ -1,5 +1,5 @@
 import { intervalToDuration, addSeconds, format, isSameDay, startOfDay, endOfDay } from 'date-fns'
-import { DateRangeSelectAroundValue, DateRangeSelectRangeValue, DateRangeSelectSpanValue, DateRangeSelectValue } from '@/types'
+import { DateRangeSelectAroundValue, DateRangeSelectPeriodValue, DateRangeSelectRangeValue, DateRangeSelectSpanValue, DateRangeSelectValue } from '@/types'
 import { toPluralString } from '@/utilities'
 
 type DateRange = {
@@ -24,6 +24,8 @@ export function getDateRangeSelectValueLabel(value: DateRangeSelectValue): strin
       return getDateRangeLabel(value)
     case 'around':
       return getDateAroundLabel(value)
+    case 'period':
+      return getPeriodLabel(value)
     default:
       const exhaustive: never = type
       throw new Error(`Label not found for date range type: ${exhaustive}`)
@@ -67,6 +69,10 @@ function getDateAroundLabel({ date, quantity, unit }: DateRangeSelectAroundValue
   const dateString = isStartOfDay(date) ? format(date, dateFormat) : format(date, dateTimeFormat)
 
   return `${quantity} ${toPluralString(unit, quantity)} around ${dateString}`
+}
+
+function getPeriodLabel({ period }: DateRangeSelectPeriodValue): string {
+  return period
 }
 
 function isStartOfDay(date: Date): boolean {

--- a/src/types/dateRange.ts
+++ b/src/types/dateRange.ts
@@ -1,7 +1,15 @@
 export type DateRangeSelectSpanValue = { type: 'span', seconds: number }
 export type DateRangeSelectRangeValue = { type: 'range', startDate: Date, endDate: Date }
 
+const dateRangeSelectPeriod = ['Today', 'This week'] as const
+export type DateRangeSelectPeriod = typeof dateRangeSelectPeriod[number]
+export type DateRangeSelectPeriodValue = { type: 'period', period: DateRangeSelectPeriod }
+
+export function isDateRangeSelectPeriod(value: unknown): value is DateRangeSelectPeriod {
+  return dateRangeSelectPeriod.includes(value as DateRangeSelectPeriod)
+}
+
 export type DateRangeSelectAroundUnit = 'second' | 'minute' | 'hour' | 'day'
 export type DateRangeSelectAroundValue = { type: 'around', date: Date, quantity: number, unit: DateRangeSelectAroundUnit }
 
-export type DateRangeSelectValue = DateRangeSelectSpanValue | DateRangeSelectRangeValue | DateRangeSelectAroundValue | null | undefined
+export type DateRangeSelectValue = DateRangeSelectSpanValue | DateRangeSelectRangeValue | DateRangeSelectAroundValue | DateRangeSelectPeriodValue | null | undefined

--- a/src/types/dateRange.ts
+++ b/src/types/dateRange.ts
@@ -1,7 +1,7 @@
 export type DateRangeSelectSpanValue = { type: 'span', seconds: number }
 export type DateRangeSelectRangeValue = { type: 'range', startDate: Date, endDate: Date }
 
-const dateRangeSelectPeriod = ['Today', 'This week'] as const
+const dateRangeSelectPeriod = ['Today'] as const
 export type DateRangeSelectPeriod = typeof dateRangeSelectPeriod[number]
 export type DateRangeSelectPeriodValue = { type: 'period', period: DateRangeSelectPeriod }
 

--- a/src/utilities/dateRangeSelect.ts
+++ b/src/utilities/dateRangeSelect.ts
@@ -1,5 +1,5 @@
-import { addSeconds, differenceInSeconds, secondsInDay, secondsInHour, secondsInMinute, subSeconds } from 'date-fns'
-import { DateRangeSelectAroundUnit, DateRangeSelectAroundValue, DateRangeSelectRangeValue, DateRangeSelectSpanValue, DateRangeSelectValue } from '@/types/dateRange'
+import { addSeconds, differenceInSeconds, endOfToday, endOfWeek, secondsInDay, secondsInHour, secondsInMinute, startOfToday, startOfWeek, subSeconds } from 'date-fns'
+import { DateRangeSelectAroundUnit, DateRangeSelectAroundValue, DateRangeSelectPeriodValue, DateRangeSelectRangeValue, DateRangeSelectSpanValue, DateRangeSelectValue } from '@/types/dateRange'
 
 function nowWithoutMilliseconds(): Date {
   const now = new Date()
@@ -55,6 +55,38 @@ function getMultiplierForUnit(unit: DateRangeSelectAroundUnit): number {
   }
 }
 
+function mapDateRangeSelectPeriodToDateRange({ period }: DateRangeSelectPeriodValue): DateRangeWithTimeSpan {
+  if (period === 'Today') {
+    const startDate = startOfToday()
+    const endDate = endOfToday()
+    const timeSpanInSeconds = differenceInSeconds(endDate, startDate)
+
+    return {
+      startDate,
+      endDate,
+      timeSpanInSeconds,
+    }
+  }
+
+  // I want a condition for each value so that the exhaustive check below works correctly
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  if (period === 'This week') {
+    const now = new Date()
+    const startDate = startOfWeek(now)
+    const endDate = endOfWeek(now)
+    const timeSpanInSeconds = differenceInSeconds(endDate, startDate)
+
+    return {
+      startDate,
+      endDate,
+      timeSpanInSeconds,
+    }
+  }
+
+  const exhaustive: never = period
+  throw new Error(`No handler for period: ${exhaustive}`)
+}
+
 export function mapDateRangeSelectValueToDateRange(source: DateRangeSelectValue): DateRangeWithTimeSpan | null {
   if (!source) {
     return null
@@ -67,6 +99,8 @@ export function mapDateRangeSelectValueToDateRange(source: DateRangeSelectValue)
       return mapDateRangeSelectSpanValueToDateRange(source)
     case 'around':
       return mapDateRangeSelectAroundValueToDateRange(source)
+    case 'period':
+      return mapDateRangeSelectPeriodToDateRange(source)
     default:
       const exhaustive: never = source
       throw new Error(`No handler for DateRangeSelectValue.type: ${exhaustive}`)

--- a/src/utilities/dateRangeSelect.ts
+++ b/src/utilities/dateRangeSelect.ts
@@ -56,24 +56,11 @@ function getMultiplierForUnit(unit: DateRangeSelectAroundUnit): number {
 }
 
 function mapDateRangeSelectPeriodToDateRange({ period }: DateRangeSelectPeriodValue): DateRangeWithTimeSpan {
+  // I want a condition for each value so that the exhaustive check below works correctly
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (period === 'Today') {
     const startDate = startOfToday()
     const endDate = endOfToday()
-    const timeSpanInSeconds = differenceInSeconds(endDate, startDate)
-
-    return {
-      startDate,
-      endDate,
-      timeSpanInSeconds,
-    }
-  }
-
-  // I want a condition for each value so that the exhaustive check below works correctly
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-  if (period === 'This week') {
-    const now = new Date()
-    const startDate = startOfWeek(now)
-    const endDate = endOfWeek(now)
     const timeSpanInSeconds = differenceInSeconds(endDate, startDate)
 
     return {


### PR DESCRIPTION
# Description
Adds "Today" and as a "period" options to the DateRangeSelect component. Added "Today", "Past hour", 'Past day", and "Past week" as shortcut options visible when first opening the input. 

<img width="740" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6200442/c647d43f-d4f2-48c2-8b14-633dd282ee10">
