### PR TITLE
Allow filtering by unit when using the DateRangeSelect's relative time dropdown

### DIFF
--- a/src/components/DateRangeSelect/PDateRangeSelectRelative.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelectRelative.vue
@@ -31,18 +31,20 @@
   const search = ref('')
 
   const options = computed<SelectOption[]>(() => {
-    const parsed = parseInt(search.value || '1')
-    const unit = isNaN(parsed) ? 1 : parsed
+    const [quantitySearch = ''] = search.value.match(/\d+/) ?? []
+    const [unitSearch = ''] = search.value.match(/[a-zA-Z]+/) ?? []
+    const parsed = parseInt(quantitySearch)
+    const quantity = isNaN(parsed) ? 1 : parsed
 
     const spans = [
-      { label: `Past ${unit} ${toPluralString('minute', unit)}`, value: unit * secondsInMinute * -1 },
-      { label: `Past ${unit} ${toPluralString('hour', unit)}`, value: unit * secondsInHour * -1 },
-      { label: `Past ${unit} ${toPluralString('day', unit)}`, value: unit * secondsInDay * -1 },
-      { label: `Past ${unit} ${toPluralString('week', unit)}`, value: unit * secondsInWeek * -1 },
-      { label: `Next ${unit} ${toPluralString('minute', unit)}`, value: unit * secondsInMinute },
-      { label: `Next ${unit} ${toPluralString('hour', unit)}`, value: unit * secondsInHour },
-      { label: `Next ${unit} ${toPluralString('day', unit)}`, value: unit * secondsInDay },
-      { label: `Next ${unit} ${toPluralString('week', unit)}`, value: unit * secondsInWeek },
+      { label: `Past ${quantity} ${toPluralString('minute', quantity)}`, unit: 'minute', value: quantity * secondsInMinute * -1 },
+      { label: `Past ${quantity} ${toPluralString('hour', quantity)}`, unit: 'hour', value: quantity * secondsInHour * -1 },
+      { label: `Past ${quantity} ${toPluralString('day', quantity)}`, unit: 'day', value: quantity * secondsInDay * -1 },
+      { label: `Past ${quantity} ${toPluralString('week', quantity)}`, unit: 'week', value: quantity * secondsInWeek * -1 },
+      { label: `Next ${quantity} ${toPluralString('minute', quantity)}`, unit: 'minute', value: quantity * secondsInMinute },
+      { label: `Next ${quantity} ${toPluralString('hour', quantity)}`, unit: 'hour', value: quantity * secondsInHour },
+      { label: `Next ${quantity} ${toPluralString('day', quantity)}`, unit: 'day', value: quantity * secondsInDay },
+      { label: `Next ${quantity} ${toPluralString('week', quantity)}`, unit: 'week', value: quantity * secondsInWeek },
     ]
 
     const now = new Date()
@@ -59,11 +61,10 @@
         return false
       }
 
-      if (maxSpanInSeconds) {
-        return Math.abs(option.value) < maxSpanInSeconds
-      }
+      const withinSpan = Math.abs(option.value) < maxSpanInSeconds
+      const unitMatches = toPluralString(option.unit, quantity).includes(unitSearch)
 
-      return true
+      return withinSpan && unitMatches
     })
 
     return filteredSpans

--- a/src/components/DateRangeSelect/PDateRangeSelectRelative.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelectRelative.vue
@@ -33,6 +33,7 @@
   const options = computed<SelectOption[]>(() => {
     const [quantitySearch = ''] = search.value.match(/\d+/) ?? []
     const [unitSearch = ''] = search.value.match(/[a-zA-Z]+/) ?? []
+    const [directionSearch = ''] = search.value.match(/[+-]+/) ?? []
     const parsed = parseInt(quantitySearch)
     const quantity = isNaN(parsed) ? 1 : parsed
 
@@ -63,8 +64,10 @@
 
       const withinSpan = Math.abs(option.value) < maxSpanInSeconds
       const unitMatches = toPluralString(option.unit, quantity).includes(unitSearch)
+      const optionDirection = option.value > 0 ? '+' : '-'
+      const directionMatches = optionDirection.includes(directionSearch)
 
-      return withinSpan && unitMatches
+      return withinSpan && unitMatches && directionMatches
     })
 
     return filteredSpans


### PR DESCRIPTION
# Description
Previously only the number value was considered when typing into the search. Now it will also filter the options based on any string value. So the search `20m` will filter the results to `Past 20 minutes` and `Next 20 minutes`. Also supports `20 min`, `minutes`, etc

Also adds visual indicators of shortcuts for filtering
<img width="345" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6200442/90fb4968-dc53-437b-a1f5-9ca596fe03b0">
<img width="327" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6200442/c6dd694e-43fa-45d4-a14a-a2f7b2b9c69d">

