### PR TITLE
Enhancement: `PStepper` should always emit user-entered values

### DIFF
--- a/src/components/Stepper/PStepper.vue
+++ b/src/components/Stepper/PStepper.vue
@@ -48,9 +48,7 @@
       return props.modelValue ?? props.min ?? 0
     },
     set(value) {
-      if (isWithinRange(value)) {
-        emits('update:modelValue', value)
-      }
+      emits('update:modelValue', value)
     },
   })
 
@@ -63,10 +61,6 @@
 
   function isWithinMax(value: number): boolean {
     return typeof props.max !== 'number' || value <= props.max
-  }
-
-  function isWithinRange(value: number): boolean {
-    return isWithinMin(value) && isWithinMax(value)
   }
 </script>
 


### PR DESCRIPTION
This brings the `PStepper` component more in line with the HTML spec by no longer preventing the v-models from updating when a user has entered a value outside the range of described by the `min` and `max` attrs