### PR TITLE
Enhancement: Modal plugin for consistent teleporting of modals

### DIFF
--- a/src/components/Modal/PModal.vue
+++ b/src/components/Modal/PModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <teleport to="body">
+  <teleport :to="modalTeleportTarget">
     <Transition name="modal">
       <div
         v-if="showModal"
@@ -61,6 +61,7 @@
   import PIcon from '@/components/Icon/PIcon.vue'
   import { useGlobalEventListener, useModal } from '@/compositions'
   import { useFocusableElements } from '@/compositions/useFocusableElements'
+  import { modalTeleportTarget } from '@/plugins/Modal'
   import { keys } from '@/types'
   import { Icon } from '@/types/icon'
   import { isKeyEvent } from '@/utilities'
@@ -141,9 +142,14 @@
 
 <style>
 .p-modal { @apply
+  hidden
   fixed
   z-10
   inset-0
+}
+
+.p-modal:last-child { @apply
+  block
 }
 
 .p-modal__container { @apply

--- a/src/plugins/Modal/index.ts
+++ b/src/plugins/Modal/index.ts
@@ -1,0 +1,20 @@
+import { Plugin } from 'vue'
+
+export const modalTeleportTarget = '#p-modal-teleport-target'
+
+function createTeleportTarget(): void {
+  if (document.body.querySelector(modalTeleportTarget)) {
+    return
+  }
+
+  const element = document.createElement('div')
+  element.id = modalTeleportTarget.slice(1)
+  document.body.appendChild(element)
+}
+
+
+export const ModalPlugin: Required<Plugin> = {
+  install: () => {
+    createTeleportTarget()
+  },
+}

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,3 +1,5 @@
+import { ModalPlugin } from '@/plugins/Modal'
 import { ToastPlugin } from '@/plugins/Toast'
 export * from './Toast'
-export const plugins = [ToastPlugin.install]
+
+export const plugins = [ToastPlugin.install, ModalPlugin.install]


### PR DESCRIPTION
# Description
Currently modals get teleported to the body. Which is fine but its not predictable. So I'm introducing a plugin that creates a div on the body so that all modals get teleported to that div. 

This allows for some consistency and also means we can add css around the assumption that nothing but modals will be in that div. Will be building off this to fix some block creation UX where users can lose the work they were doing because of redirects. 