### PR TITLE
PDraggableList: Only prevent default if taking an action. Add shift to enter and delete

### DIFF
--- a/src/components/DraggableList/PDraggableList.vue
+++ b/src/components/DraggableList/PDraggableList.vue
@@ -217,14 +217,9 @@
     const altKeyIsPressed = event.altKey
     const shiftKeyIsPressed = event.shiftKey
 
-    const handledKeys = ['Enter', 'Delete', 'ArrowUp', 'ArrowDown']
-    const shouldPreventDefault = handledKeys.includes(event.key)
-
-    if (shouldPreventDefault) {
+    if (shiftKeyIsPressed && event.key === 'Enter') {
       event.preventDefault()
-    }
 
-    if (event.key === 'Enter') {
       const newIndex = index + 1
 
       if (newIndex === props.modelValue.length && props.allowCreate) {
@@ -233,13 +228,16 @@
 
       // Wait for the new item to be rendered before focusing it
       nextTick(() => focusItemAtIndex(newIndex))
+
       return
     }
 
-    if (event.key === 'Delete') {
+    if (shiftKeyIsPressed && event.key === 'Delete') {
       if (!props.allowDelete) {
         return
       }
+
+      event.preventDefault()
 
       deleteItemAtIndex(index)
       return
@@ -251,6 +249,8 @@
       if (newIndex < 0) {
         return
       }
+
+      event.preventDefault()
 
       if (altKeyIsPressed) {
         moveItemTo(index, newIndex)
@@ -266,6 +266,8 @@
       if (newIndex >= props.modelValue.length) {
         return
       }
+
+      event.preventDefault()
 
       if (altKeyIsPressed) {
         moveItemTo(index, newIndex)


### PR DESCRIPTION
# Description
Makes some tweaks to the keydown handler so that enter and delete are combined with shift. Otherwise if you use the slot and use something like a code input or a textarea adding a newline adds a new item. Also not being able to use the delete is bad. So adding shift to those. I think the arrow keys will also need some tweaking. But leaving those for now. 