### PR TITLE
Enhancement: add lvl-3 bg color token

### DIFF
--- a/demo/sections/DesignTokens.vue
+++ b/demo/sections/DesignTokens.vue
@@ -216,7 +216,7 @@
 
     <template #backgrounds-and-borders>
       <p class="design_tokens__paragraph">
-        There are 3 base levels of background colors. If we encounter a design calling for more levels of background colors than this, we should reconsider the design.
+        There are 4 base levels of background colors.
       </p>
       <div class="border border-default rounded-default my-4 p-6">
         <p><strong>Level 0:</strong> The base background color of the application, applied globally.</p>
@@ -234,6 +234,15 @@
                 .p-background .p-background {}
               </p-code> style.
             </p>
+            <div class="p-background mt-4 p-6 rounded-default">
+              <p>
+                <strong>Level 3:</strong> This level should be rare. If you reach this level, maybe reconsider the design. Adding the class <p-code inline>
+                  p-background
+                </p-code> directly to a container will automatically apply the level 3 background color when it's nested within a level 2 background, using a simple <p-code inline>
+                  .p-background .p-background .p-background {}
+                </p-code> style.
+              </p>
+            </div>
           </div>
         </div>
       </div>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -31,6 +31,7 @@
     --p-color-bg-0: #26272B;
     --p-color-bg-1: #1C1D20;
     --p-color-bg-2: var(--p-color-bg-0);
+    --p-color-bg-3: #303237;
     --p-color-bg-floating: #35363C;
     --p-color-bg-floating-sticky: rgba(28, 29, 32, 0.9);
     --p-color-bg-code: #121317;
@@ -199,6 +200,7 @@
     --p-color-bg-0: #EFEFF0;
     --p-color-bg-1: #FFFFFF;
     --p-color-bg-2: #F5F5F5;
+    --p-color-bg-3: #EAEAEA;
     --p-color-bg-floating: #FAFAFA;
     --p-color-bg-floating-sticky: rgba(255, 255, 255, 0.8);
     --p-color-bg-code: #DEDEE3;
@@ -380,4 +382,7 @@ body {
 }
 .p-background .p-background {
   background-color: var(--p-color-bg-2);
+}
+.p-background .p-background .p-background {
+  background-color: var(--p-color-bg-3);
 }


### PR DESCRIPTION
Because the schema form UI can reach a third layer of card nesting relatively easily, we're adding a third level bg token that otherwise should be considered undesirable to use. 

Dark mode:
<img width="1205" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6776415/e19793e0-c88f-4064-9392-b95edbe65eee">

Light mode:
<img width="1226" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6776415/7e09ee68-13d6-4136-83a9-0b57a5f6d731">
