### PR TITLE
bugfix: date-range-select span to range transition

### DIFF
--- a/src/utilities/dateRangeSelect.ts
+++ b/src/utilities/dateRangeSelect.ts
@@ -25,8 +25,9 @@ function mapDateRangeSelectSpanValueToDateRange({ seconds }: DateRangeSelectSpan
   const now = nowWithoutMilliseconds()
   const then = addSeconds(now, seconds)
   const [startDate, endDate] = [now, then].sort((dateA, dateB) => dateA.getTime() - dateB.getTime())
+  const timeSpanInSeconds = Math.abs(seconds)
 
-  return { startDate, endDate, timeSpanInSeconds: seconds }
+  return { startDate, endDate, timeSpanInSeconds }
 }
 
 function mapDateRangeSelectAroundValueToDateRange({ date, quantity, unit }: DateRangeSelectAroundValue): DateRangeWithTimeSpan {


### PR DESCRIPTION
Because a span like "Past 1 day" uses a negative time interval, the `mapDateRangeSelectSpanValueToDateRange` needs to return the absolute interval for use in downstream next/previous calculations. When simply returning the same interval, a negative interval for Past 1 Day would be converted into a positive interval for calculating a previous time (on press of the "previous" button), which would make it progress forward a day.

Before:
https://github.com/PrefectHQ/prefect-design/assets/6776415/ef2d92d8-8997-4030-ade6-fed7ba513fca

After:
https://github.com/PrefectHQ/prefect-design/assets/6776415/0e115af0-f970-4471-95d8-1cb06d71b1f6

