### PR TITLE
Design: Bump icon sizes down 1pt each

### DIFF
--- a/src/components/Icon/PIcon.vue
+++ b/src/components/Icon/PIcon.vue
@@ -42,17 +42,17 @@
 
 <style>
 .p-icon { @apply
-  w-5
-  h-5
-}
-
-.p-icon--small { @apply
   w-4
   h-4
 }
 
+.p-icon--small { @apply
+  w-3
+  h-3
+}
+
 .p-icon--large { @apply
-  w-6
-  h-6
+  w-5
+  h-5
 }
 </style>


### PR DESCRIPTION
In line with #1117, makes icon sizes smaller by default