### PR TITLE
Enhancement: Improve language on selected date span label

### DIFF
--- a/src/components/DateRangeSelect/utilities.ts
+++ b/src/components/DateRangeSelect/utilities.ts
@@ -42,6 +42,11 @@ function getDateSpanLabel({ seconds }: DateRangeSelectSpanValue): string {
   const reduced = Object.entries(duration).reduce<string[]>((durations, [key, value]) => {
     if (value) {
       const unit = key.slice(0, -1)
+      if (value === 1) {
+        durations.push(unit)
+        return durations
+      }
+
       durations.push(`${value} ${toPluralString(unit, value)}`)
     }
 


### PR DESCRIPTION
Instead of saying "Previous 1 hour" or "Next 1 day", selected date range spans should now say "Previous hour" or "Next day"