### PR TITLE
Enhancement: Use a tooltip instead of a title tag for overflowing tags

### DIFF
--- a/src/components/TagWrapper/PTagWrapper.vue
+++ b/src/components/TagWrapper/PTagWrapper.vue
@@ -11,12 +11,14 @@
     </slot>
 
 
-    <div ref="overflowTag" class="p-tag-wrapper__tag-overflow" :class="classes.overflowTag" :title="hiddenText">
-      <slot name="overflow-tags" :overflowed-children="overflowCount">
-        <PTag>
-          +{{ overflowCount }}
-        </PTag>
-      </slot>
+    <div ref="overflowTag" class="p-tag-wrapper__tag-overflow" :class="classes.overflowTag">
+      <p-tooltip :text="hiddenText">
+        <slot name="overflow-tags" :overflowed-children="overflowCount">
+          <PTag>
+            +{{ overflowCount }}
+          </PTag>
+        </slot>
+      </p-tooltip>
     </div>
   </div>
 </template>

--- a/src/components/TagWrapper/PTagWrapper.vue
+++ b/src/components/TagWrapper/PTagWrapper.vue
@@ -12,13 +12,13 @@
 
 
     <div ref="overflowTag" class="p-tag-wrapper__tag-overflow" :class="classes.overflowTag">
-      <p-tooltip :text="hiddenText">
+      <PTooltip :text="hiddenText">
         <slot name="overflow-tags" :overflowed-children="overflowCount">
           <PTag>
             +{{ overflowCount }}
           </PTag>
         </slot>
-      </p-tooltip>
+      </PTooltip>
     </div>
   </div>
 </template>
@@ -26,6 +26,7 @@
 <script lang="ts" setup>
   import { computed, ref, Ref, onMounted, onUnmounted, watch, nextTick } from 'vue'
   import PTag from '@/components/Tag/PTag.vue'
+  import PTooltip from '@/components/Tooltip/PTooltip.vue'
   import { TagValue, normalize } from '@/types/tag'
 
   const props = defineProps<{


### PR DESCRIPTION
<img width="544" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6776415/33a24cfb-8bc8-4818-ad00-1e288dd3aecc">
