### PR TITLE
Fix p-divider sometimes has 0 width.

### DIFF
--- a/src/components/Divider/PDivider.vue
+++ b/src/components/Divider/PDivider.vue
@@ -1,18 +1,25 @@
 <template>
-  <div class="flex items-center gap-x-2">
-    <hr class="p-divider">
+  <div class="p-divider">
+    <hr class="p-divider__line">
 
     <template v-if="$slots.default">
       <div class="p-divider__text">
         <slot />
       </div>
-      <hr class="p-divider">
+      <hr class="p-divider__line">
     </template>
   </div>
 </template>
 
 <style>
   .p-divider { @apply
+    flex
+    items-center
+    gap-x-2
+    w-full
+  }
+
+  .p-divider__line { @apply
     border-none
     h-[1px]
     bg-divider


### PR DESCRIPTION
Fixes small regression from https://github.com/PrefectHQ/prefect-design/pull/1037

|     | **Before** | **After** |
| ---- | ---- | ---- |
| Deployment details well | <img width="355" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/22418768/37512f9f-7dd7-4292-a823-09e52d7b2777"> | <img width="305" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/22418768/7da1de29-33b9-4d2a-ad5c-a9e788301f1a"> |
| Artifact page well | <img width="273" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/22418768/b044459e-7b75-4440-acf0-074e4b8045f6"> | <img width="268" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/22418768/88f98854-1286-4202-ba79-4bf3edddbeff"> |