### PR TITLE
design: add right border to sidebar

### DIFF
--- a/src/components/NavigationBar/PNavigationBar.vue
+++ b/src/components/NavigationBar/PNavigationBar.vue
@@ -60,6 +60,8 @@
   h-screen
   w-64
   shadow
+  border-r
+  border-divider
 }
 
 .p-navigation-bar--horizontal { @apply


### PR DESCRIPTION
This PR adds a 1px right divider-colored border to the sidebar.

This is one of a series of PRs to better compartmentalize or "bento" the UI. 

This _may_ necessitate removing or shifting the `decorative_iso-pixel-grid_light.svg` background image. These don't conflict outright, but the pixel grid image _feels_ hard to have in a bento world. Would love to find another way to incorporate the brand imagery, but this doesn't feel like a blocking question for now. 

before:
<img width="1716" alt="Screenshot 2024-02-26 at 10 46 12 PM" src="https://github.com/PrefectHQ/prefect-design/assets/33043305/4718540d-453c-463a-b128-0c64f6ff0a1f">

after:
<img width="1716" alt="Screenshot 2024-02-26 at 10 46 05 PM" src="https://github.com/PrefectHQ/prefect-design/assets/33043305/6accc4f0-d6a0-4f10-a31e-88a607d52d04">

