### PR TITLE
Standardize gap spacing in p-form to match p-content

### DIFF
--- a/demo/sections/components/Form.vue
+++ b/demo/sections/components/Form.vue
@@ -6,17 +6,16 @@
 
     <template #form>
       <p-form @submit="submit">
-        <p-content>
-          <fieldset :disabled="disabled">
-            <p-label label="Name">
-              <p-text-input v-model="name" :state="exampleState" />
-            </p-label>
+        <fieldset :disabled="disabled">
+          <p-label label="Name">
+            <p-text-input v-model="name" :state="exampleState" />
+          </p-label>
 
-            <p-label label="Description (Optional)">
-              <p-textarea v-model="description" rows="7" :state="exampleState" />
-            </p-label>
-          </fieldset>
-        </p-content>
+          <p-label label="Description (Optional)">
+            <p-textarea v-model="description" rows="7" :state="exampleState" />
+          </p-label>
+        </fieldset>
+
         <template #footer>
           <p-button type="submit" :state="exampleState" :disabled="disabled">
             Submit

--- a/src/components/Form/PForm.vue
+++ b/src/components/Form/PForm.vue
@@ -37,7 +37,7 @@
   w-full
   flex
   flex-col
-  gap-y-6
+  gap-y-4
 }
 
 .p-form__header { @apply


### PR DESCRIPTION
# Description
`p-form` has built in spacing for child elements so that forms have consistent spacing. But its set to spacing 6 when we generally use spacing 4. So we have a decent bit of forms that have a `p-content` wrapping all of their content to get the right spacing. Updating `p-form` to use spacing 4 means we can just use the form by itself without a `p-content`. 