### PR TITLE
update p-key-value

### DIFF
--- a/src/components/KeyValue/PKeyValue.vue
+++ b/src/components/KeyValue/PKeyValue.vue
@@ -68,17 +68,16 @@
 .p-key-value {
   @apply
   w-full
-  text-sm
   flex
   flex-col
   gap-y-1
-  leading-6
   items-start
 }
 
 .p-key-value__label {
   @apply
-  font-semibold
+  text-xs
+  text-subdued
   cursor-default
 }
 
@@ -94,7 +93,5 @@
 .p-key-value--alt {
   @apply
   text-xs
-  leading-4
-  font-normal
 }
 </style>


### PR DESCRIPTION
Updates `p-key-value` to use `xs` subdued text as we've been increasingly using in designs and needing in new feature work.

This also removes the `sm` value font size as the default. Instead of the default being `sm` and `alternate` being `xs`, `alternate` will now be `sm`. From my observations in the app, we typically want default text for the value with the exception of wells, where the smaller text is helpful in decluttering the dense information. `small` is a better prop name than `alternative`, but the ubiquity of this component makes me hesitate to updated it under some deadline pressures.

## Samples

Work pool detail page before. Specifically the well. Here the instances in the well are using the `alternate` styling.
<img width="1512" alt="Screenshot 2024-03-01 at 2 04 34 PM" src="https://github.com/PrefectHQ/prefect-design/assets/6776415/1dd61538-6c5f-4794-971c-6b856ea7bbe8">

After
<img width="1512" alt="Screenshot 2024-03-01 at 2 02 14 PM" src="https://github.com/PrefectHQ/prefect-design/assets/6776415/810d4bc9-d0c0-493c-a3d0-6427df90b861">

Deployment details page before
<img width="1512" alt="Screenshot 2024-03-01 at 2 04 21 PM" src="https://github.com/PrefectHQ/prefect-design/assets/6776415/c4458723-f9cc-4e6f-a8d3-f78ecaaa844b">

After. I do plan to do a fallow up PR for this one instance to set these to the `alternate` styling.
<img width="1512" alt="Screenshot 2024-03-01 at 2 01 49 PM" src="https://github.com/PrefectHQ/prefect-design/assets/6776415/46ad0e5d-5302-4f1b-baf1-47105cf6d824">

Flow run page, details tab, before
<img width="1511" alt="Screenshot 2024-03-01 at 2 04 45 PM" src="https://github.com/PrefectHQ/prefect-design/assets/6776415/e52f2706-457f-4996-8a0a-f660d9e6271f">

After
<img width="1512" alt="Screenshot 2024-03-01 at 2 02 33 PM" src="https://github.com/PrefectHQ/prefect-design/assets/6776415/86a9e8fb-95c8-4625-aec5-8b4dc1c30460">
