### PR TITLE
Fix p-card flat prop not working when nesting

### DIFF
--- a/src/components/Card/PCard.vue
+++ b/src/components/Card/PCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="p-card p-background" :class="classes">
+  <div class="p-card" :class="classes">
     <slot />
   </div>
 </template>
@@ -13,6 +13,7 @@
 
   const classes = computed(() => ({
     'p-card--flat': props.flat,
+    'p-background': !props.flat,
   }))
 </script>
 


### PR DESCRIPTION
# Description
`p-card` uses `p-background` to determine the correctly background color. But it also has a `flat` prop which is supposed to remove the background. But if the `p-background` class is not removed the `flat` prop only works if its not nested within another element with `p-background`. 

Removing the `p-background` class when `flat` is used fixes this. 