### PR TITLE
Fix: Update PLayoutToolbarGrid.vue

### DIFF
--- a/src/layouts/PLayoutToolbarGrid/PLayoutToolbarGrid.vue
+++ b/src/layouts/PLayoutToolbarGrid/PLayoutToolbarGrid.vue
@@ -93,13 +93,13 @@
     h-[calc(100%-theme('spacing.12')-theme('spacing.14'))]
     w-full
     relative
-    overflow-auto
     flex-nowrap;
   }
 
   .p-layout-grid__content {
     @apply
     flex-1
+    overflow-auto
     border-[color:var(--p-color-divider-subdued)];
   }
   .p-layout-grid__main-leading {


### PR DESCRIPTION
Adds overflow-auto to the layout's primary content, instead of the content's container.

Enables, among other things properly working sticky headers. 

Before (note there's a sticky header that's scrolled off)
<img width="1215" alt="Screenshot 2024-03-13 at 8 01 29 PM" src="https://github.com/PrefectHQ/prefect-design/assets/33043305/6dad7fe4-ed6f-48f3-b198-1312f794accc">

After (there it is!)
<img width="1217" alt="Screenshot 2024-03-13 at 8 00 54 PM" src="https://github.com/PrefectHQ/prefect-design/assets/33043305/0ec146f6-c74f-4e7f-b8c5-86ba54e70bbd">
