### PR TITLE
Fix: check popover parent in auto-close

### DIFF
--- a/src/components/PopOver/PPopOver.vue
+++ b/src/components/PopOver/PPopOver.vue
@@ -78,7 +78,13 @@
   }
 
   function eventHandler(event: MouseEvent | FocusEvent): void {
-    if (target.value?.contains(event.target as Node) || content.value?.contains(event.target as Node)) {
+    const eventTarget = event.target as Element
+
+    if (
+      target.value?.contains(eventTarget)
+      || content.value?.contains(eventTarget)
+      || eventTarget.closest('.p-pop-over-content') !== null
+    ) {
       return
     }
 


### PR DESCRIPTION
This adds a check for popover-content parents when attempting to auto-close a popover. This is for a very special use case of a pop-over inside a pop-over, where clicking the second one would dismiss before registering the link click:

<img width="466" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6776415/08b4ade5-1600-4565-a794-61a3b3577473">
