### PR TITLE
Indeterminate `<p-checkbox />` styles

### DIFF
--- a/demo/sections/components/Checkbox.vue
+++ b/demo/sections/components/Checkbox.vue
@@ -4,7 +4,7 @@
     :demos="[
       { title: 'Checkbox' },
       { title: 'Multiple', description: 'For multiple checkboxes, the v-model value can be an array to be shared across all checkboxes. See also: p-checkbox-group' },
-      { title: 'Indeterminate', description: 'A checkbox can either be on or off, but there is a third, visual-only state called indeterminate. This is used to indicate that a checkbox is in a mixed state, for example, when a parent checkbox is checked, but not all of its children are.' },
+      { title: 'Indeterminate', description: 'A checkbox can either be on or off, but there is a third, visual-only state called indeterminate. This is used to indicate that a checkbox is in a mixed state, for example, when a parent checkbox is checked, but not all of its children are like a `Select All` checkbox.' },
       { title: 'Label Slot', description: 'In addition to the label prop, there is a slot available for label content.' },
     ]"
   >

--- a/demo/sections/components/Checkbox.vue
+++ b/demo/sections/components/Checkbox.vue
@@ -4,7 +4,7 @@
     :demos="[
       { title: 'Checkbox' },
       { title: 'Multiple', description: 'For multiple checkboxes, the v-model value can be an array to be shared across all checkboxes. See also: p-checkbox-group' },
-      { title: 'Indeterminate', description: 'A checkbox can either be on or off, but there is a third, visual-only state called indeterminate. This is used to indicate that a checkbox is in a mixed state, for example, when a parent checkbox is checked, but not all of its children are like a `Select All` checkbox.' },
+      { title: 'Indeterminate', description: 'A checkbox can either be on or off, but there is a third, visual-only state called indeterminate. This is used to indicate that a checkbox is in a mixed state, for example, when a parent checkbox is checked, but not all of its children are - e.g. a `Select All` checkbox.' },
       { title: 'Label Slot', description: 'In addition to the label prop, there is a slot available for label content.' },
     ]"
   >

--- a/demo/sections/components/Checkbox.vue
+++ b/demo/sections/components/Checkbox.vue
@@ -3,8 +3,8 @@
     title="Checkbox"
     :demos="[
       { title: 'Checkbox' },
-      { title: 'Multiple', description: 'See also: p-checkbox-group' },
-      { title: 'Label Slot' },
+      { title: 'Multiple', description: 'For multiple checkboxes, the v-model value can be an array to be shared across all checkboxes. See also: p-checkbox-group' },
+      { title: 'Label Slot', description: 'In addition to the label prop, there is a slot available for label content.' },
     ]"
   >
     <template #description>

--- a/demo/sections/components/Checkbox.vue
+++ b/demo/sections/components/Checkbox.vue
@@ -4,6 +4,7 @@
     :demos="[
       { title: 'Checkbox' },
       { title: 'Multiple', description: 'For multiple checkboxes, the v-model value can be an array to be shared across all checkboxes. See also: p-checkbox-group' },
+      { title: 'Indeterminate', description: 'A checkbox can either be on or off, but there is a third, visual-only state called indeterminate. This is used to indicate that a checkbox is in a mixed state, for example, when a parent checkbox is checked, but not all of its children are.' },
       { title: 'Label Slot', description: 'In addition to the label prop, there is a slot available for label content.' },
     ]"
   >
@@ -35,6 +36,20 @@
       </div>
     </template>
 
+    <template #indeterminate>
+      <ul>
+        <li>
+          <p-checkbox v-model="indeterminateParent" :indeterminate="indeterminate.length && indeterminate.length < indeterminateOptions.length" label="Tall Things" :disabled="disabled" :state="exampleState" />
+
+          <ul class="ml-6">
+            <li v-for="option in indeterminateOptions" :key="option">
+              <p-checkbox v-model="indeterminate" :value="option" :label="option" :disabled="disabled" :state="exampleState" />
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </template>
+
     <template #label-slot>
       <div class="checkbox__demo">
         <p-checkbox v-model="slot" :state="exampleState" :disabled="disabled">
@@ -53,7 +68,7 @@
 
 <script lang="ts" setup>
   import { State } from '@/types'
-  import { ref } from 'vue'
+  import { computed, ref } from 'vue'
   import ComponentPage from '@/demo/components/ComponentPage.vue'
   import DemoState from '@/demo/components/DemoState.vue'
 
@@ -61,7 +76,28 @@
   const disabled = ref(false)
 
   const simple = ref(false)
+
   const multiple = ref([])
+
+  const indeterminateOptions = ['Buildings', 'Giants', 'Two sandwiches']
+  const indeterminate = ref<string[]>([])
+  /** Checking the parent should either select or deselect all children and its visual state reflects its children's aggregate state.
+   *
+   * If all children are checked, the parent should be checked.
+   * If all children are unchecked, the parent should be unchecked.
+   * If some children are checked, the parent should be indeterminate.
+   */
+  const indeterminateParent = computed({
+    get: () => indeterminate.value.length > 0,
+    set: (value: boolean) => {
+      if (value) {
+        indeterminate.value = indeterminateOptions
+      } else {
+        indeterminate.value = []
+      }
+    },
+  })
+
   const slot = ref(false)
 </script>
 

--- a/src/components/Checkbox/PCheckbox.vue
+++ b/src/components/Checkbox/PCheckbox.vue
@@ -97,8 +97,8 @@
   focus:ring-offset-focus-ring
   focus:ring-offset-focus-ring-offset;
   background-color: var(--p-color-input-bg);
+  color: var(--p-color-input-bg);
   border-color: var(--p-color-input-border);
-  color: var(--p-color-input-text);
 }
 
 .p-checkbox__input:focus:not(:focus-visible) { @apply
@@ -107,17 +107,20 @@
 }
 
 .p-checkbox__input:not(:disabled):hover {
-  background-color: var(--p-color-input-bg);
+  color: var(--p-color-input-bg);
   border-color: var(--p-color-input-border-focus);
-  color: var(--p-color-input-text);
 }
 
 .p-checkbox__input:checked,
 .p-checkbox__input:checked:hover,
 .p-checkbox__input:checked:focus {
-  background-color: var(--p-color-input-checked-bg);
+  color: var(--p-color-input-checked-bg);
   border-color: var(--p-color-input-checked-border);
-  color: var(--p-color-input-checked-text);
+}
+
+.p-checkbox__input:indeterminate {
+  border-color: var(--p-color-input-border);
+  background-image: var(--p-color-input-checkbox-indeterminate-bg-img);
 }
 
 .p-checkbox--failed {
@@ -127,7 +130,7 @@
 .p-checkbox--failed .p-checkbox__input,
 .p-checkbox--failed .p-checkbox__input:hover,
 .p-checkbox--failed .p-checkbox__input:focus {
-  background-color: var(--p-color-input-bg-invalid);
+  color: var(--p-color-input-bg-invalid);
   border-color: var(--p-color-input-border-invalid);
 }
 

--- a/src/components/Checkbox/PCheckbox.vue
+++ b/src/components/Checkbox/PCheckbox.vue
@@ -120,7 +120,7 @@
 
 .p-checkbox__input:indeterminate {
   border-color: var(--p-color-input-border);
-  background-image: var(--p-color-input-checkbox-indeterminate-bg-img);
+  background-image: var(--p-input-checkbox-indeterminate-bg-img);
 }
 
 .p-checkbox--failed {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -277,7 +277,8 @@
     --p-color-input-checked-border: var(--p-color-selected);
     --p-color-input-checked-text: var(--p-color-text-default);
 
-    --p-input-checkbox-indeterminate-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='' viewBox='0 0 16 16'%3e%3cpath stroke='%2370707B' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e");
+    /* Note: this url has a hardcoded usage of `--p-color-text-default` here however it uses `%23171717` instead of `#171717` since `#` within a url is a fragment. -*/
+    --p-input-checkbox-indeterminate-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='' viewBox='0 0 16 16'%3e%3cpath stroke='%23171717' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e");
 
     /* Toggle */
     --p-color-toggle-bg: var(--p-color-input-border);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -105,6 +105,8 @@
     --p-color-input-checked-border: var(--p-color-selected);
     --p-color-input-checked-text: var(--p-color-text-default);
 
+    --p-color-input-checkbox-indeterminate-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='' viewBox='0 0 16 16'%3e%3cpath stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e");
+
     /* Toggle */
     --p-color-toggle-bg: var(--p-color-divider);
     --p-color-toggle-trigger: var(--p-color-input-text);
@@ -274,6 +276,8 @@
     --p-color-input-checked-bg: #2e90fb;
     --p-color-input-checked-border: var(--p-color-selected);
     --p-color-input-checked-text: var(--p-color-text-default);
+
+    --p-color-input-checkbox-indeterminate-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='' viewBox='0 0 16 16'%3e%3cpath stroke='%2370707B' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e");
 
     /* Toggle */
     --p-color-toggle-bg: var(--p-color-input-border);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -105,7 +105,7 @@
     --p-color-input-checked-border: var(--p-color-selected);
     --p-color-input-checked-text: var(--p-color-text-default);
 
-    --p-color-input-checkbox-indeterminate-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='' viewBox='0 0 16 16'%3e%3cpath stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e");
+    --p-input-checkbox-indeterminate-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='' viewBox='0 0 16 16'%3e%3cpath stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e");
 
     /* Toggle */
     --p-color-toggle-bg: var(--p-color-divider);
@@ -277,7 +277,7 @@
     --p-color-input-checked-border: var(--p-color-selected);
     --p-color-input-checked-text: var(--p-color-text-default);
 
-    --p-color-input-checkbox-indeterminate-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='' viewBox='0 0 16 16'%3e%3cpath stroke='%2370707B' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e");
+    --p-input-checkbox-indeterminate-bg-img: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='' viewBox='0 0 16 16'%3e%3cpath stroke='%2370707B' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 8h8'/%3e%3c/svg%3e");
 
     /* Toggle */
     --p-color-toggle-bg: var(--p-color-input-border);


### PR DESCRIPTION
This PR enhances the `<p-checkbox />` component to better handle [indeterminate state checkboxes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes). This PR adds a new section to the checkbox demo - check it out there. Below is a static version of it:

| Description | 📸 from Demo |
| ---- | ---- |
| None selected | ![image](https://github.com/PrefectHQ/prefect-design/assets/22418768/b36b3e0a-c33b-474b-acaf-a173f2c6793c) |
| Some selected | ![image](https://github.com/PrefectHQ/prefect-design/assets/22418768/39d3e823-3fc9-437f-a95d-abb9009a3c38) |
| All selected | ![image](https://github.com/PrefectHQ/prefect-design/assets/22418768/fab5c618-d678-45c6-b444-af13804bf1c6) |

At the moment like a lot of the other checkbox styles, the indeterminate state styles are coming from from the tailwindcss-forms plugin (https://github.com/tailwindlabs/tailwindcss-forms/blob/e6bcd1ff718ad2d0380a65ded0564369e4cbda32/src/index.js#L291C3-L316C9) however as-is, they clash with some of our additional styles and also don't conform well to dark/light mode. 

| Mode | **Before** | **After** |
| ---- | ---- | ---- |
| 🌑 | <img width="192" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/22418768/e65ade49-764a-4a4f-a513-34f52297e148"> | ![image](https://github.com/PrefectHQ/prefect-design/assets/22418768/f66c38db-d489-457e-86a2-f842a971e7a8) |
| 🌕 | <img width="199" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/22418768/2f18a341-1a4e-467e-91fa-f174e242b775"> | ![image](https://github.com/PrefectHQ/prefect-design/assets/22418768/b1b262d3-e1a4-46d1-973f-dce66ecc1341) |

