### PR TITLE
Enhancement: `PCodeHighlight` singleton worker

### DIFF
--- a/src/components/CodeHighlight/worker.ts
+++ b/src/components/CodeHighlight/worker.ts
@@ -20,7 +20,8 @@ import {
   isVueLanguageRef,
   isYamlLanguageRef,
   SupportedLanguage,
-  UnformattedMessagePayload
+  UnformattedMessagePayload,
+  FormattedMessagePayload
 } from '@/types/codeHighlight'
 
 const registeredLanguages: Set<SupportedLanguage> = new Set()
@@ -74,16 +75,19 @@ const registerLanguage = (lang: SupportedLanguage): void => {
 }
 
 const handleMessage = (message: MessageEvent<UnformattedMessagePayload>): void => {
-  const { text, lang } = message.data
+  const { id, text, lang } = message.data
   const { language, code, illegal, relevance, value } = highlightText(text, lang)
 
-  self.postMessage({
+  const response: FormattedMessagePayload = {
+    id,
     unformatted: code,
     formatted: value,
     illegal,
     relevance,
     language,
-  })
+  }
+
+  self.postMessage(response)
 }
 
 self.onmessage = handleMessage

--- a/src/compositions/useCodeHighlight.ts
+++ b/src/compositions/useCodeHighlight.ts
@@ -1,0 +1,54 @@
+import { marked } from 'marked'
+import { computed, MaybeRefOrGetter, onScopeDispose, Ref, ref, toValue, watchEffect } from 'vue'
+import HighlightWorker from '@/components/CodeHighlight/worker?worker&inline'
+import { FormattedMessagePayload, UnformattedMessagePayload } from '@/types/codeHighlight'
+import { randomId } from '@/utilities'
+
+export type Tokens = marked.TokensList | []
+export type HighlightCallback = (payload: FormattedMessagePayload) => void
+export type UseCodeHighlight = {
+  formatted: Ref<string>,
+  lines: Ref<number>,
+  illegal: Ref<boolean>,
+  relevance: Ref<number>,
+}
+
+const callbacks = new Map<string, HighlightCallback>()
+const worker = new HighlightWorker()
+
+worker.onmessage = (message: MessageEvent<FormattedMessagePayload>) => {
+  const { id } = message.data
+  const callback = callbacks.get(id)
+
+  if (callback) {
+    callback(message.data)
+  }
+}
+
+export function useCodeHighlight(text: MaybeRefOrGetter, language: MaybeRefOrGetter): UseCodeHighlight {
+  const id = randomId()
+  const formatted = ref<string>('')
+  const illegal = ref<boolean>(false)
+  const relevance = ref<number>(0)
+  const lines = computed(() => toValue(text).split('\n').length)
+
+  const highlightCallback = (payload: FormattedMessagePayload): void => {
+    formatted.value = payload.formatted
+    illegal.value = payload.illegal
+    relevance.value = payload.relevance
+  }
+
+  callbacks.set(id, highlightCallback)
+  watchEffect(() => {
+    const message: UnformattedMessagePayload = {
+      id,
+      text: toValue(text),
+      lang: toValue(language),
+    }
+
+    worker.postMessage(message)
+  })
+  onScopeDispose(() => callbacks.delete(id))
+
+  return { formatted, illegal, relevance, lines }
+}

--- a/src/compositions/useCodeHighlight.ts
+++ b/src/compositions/useCodeHighlight.ts
@@ -1,10 +1,8 @@
-import { marked } from 'marked'
 import { computed, MaybeRefOrGetter, onScopeDispose, Ref, ref, toValue, watchEffect } from 'vue'
 import HighlightWorker from '@/components/CodeHighlight/worker?worker&inline'
 import { FormattedMessagePayload, UnformattedMessagePayload } from '@/types/codeHighlight'
 import { randomId } from '@/utilities'
 
-export type Tokens = marked.TokensList | []
 export type HighlightCallback = (payload: FormattedMessagePayload) => void
 export type UseCodeHighlight = {
   formatted: Ref<string>,

--- a/src/compositions/useMarkdownRenderer.ts
+++ b/src/compositions/useMarkdownRenderer.ts
@@ -1,5 +1,5 @@
 import { marked } from 'marked'
-import { computed, getCurrentScope, MaybeRefOrGetter, onScopeDispose, onUnmounted, Ref, ref, toRef, toValue, watch, watchEffect } from 'vue'
+import { MaybeRefOrGetter, onScopeDispose, Ref, ref, toValue, watchEffect } from 'vue'
 import MarkdownTokenWorker from '@/components/MarkdownRenderer/worker?worker&inline'
 import { ParseMessagePayload } from '@/types/markdownRenderer'
 import { randomId } from '@/utilities'

--- a/src/types/codeHighlight.ts
+++ b/src/types/codeHighlight.ts
@@ -29,16 +29,18 @@ export function isSupportedLanguage(lang: unknown): lang is SupportedLanguage {
 }
 
 export type UnformattedMessagePayload = {
+  id: string,
   text: string,
   lang: SupportedLanguage,
 }
 
 export type FormattedMessagePayload = {
-  unformatted: string,
+  id: string,
+  unformatted?: string | undefined,
   formatted: string,
   illegal: boolean,
   relevance: number,
-  language: string,
+  language?: string | undefined,
 }
 
 export function isJavascriptLanguageRef(lang: SupportedLanguage): lang is typeof JavascriptLanguageRefs[number] {


### PR DESCRIPTION
This PR moves worker logic out of the `PCodeHighlight` component and into a composition that uses a singleton worker. Similar to #1145, functionality remains identical but memory usage should be drastically more efficient when mounting many of these components at the same time and highlight latency should also be improved. 