### PR TITLE
Use an indeterminate checkbox pattern for p-table select all.

### DIFF
--- a/src/components/Table/PTable.vue
+++ b/src/components/Table/PTable.vue
@@ -7,7 +7,12 @@
             <PTableRow>
               <template v-if="showMultiselect">
                 <PTableData class="p-table__checkbox-cell">
-                  <p-checkbox v-model="allSelected" />
+                  <p-tooltip :text="selectAllModel ? 'Deselect all' : 'Select all'">
+                    <p-checkbox
+                      v-model="selectAllModel"
+                      :indeterminate="internalSelectedRows.length && internalSelectedRows.length < selectableRows.length"
+                    />
+                  </p-tooltip>
                 </PTableData>
               </template>
 
@@ -96,9 +101,9 @@
     },
   })
 
-  const allSelected = computed({
+  const selectAllModel = computed({
     get() {
-      return internalSelectedRows.value.length === selectableRows.value.length
+      return internalSelectedRows.value.length > 0
     },
     set(value) {
       internalSelectedRows.value = value ? selectableRows.value : []


### PR DESCRIPTION
This PR changes the `<p-table />` component to use an indeterminate checkbox for the multiselect permutation's (de)select-all box. 

Of note, aside from just the visual change of utilizing the indeterminate state, this pattern slightly changes the _behavior_ as well. The checkbox is now considered "checked" if _any_ row is selected so that clicking the checkbox now _deselects_ all selected rows when _any_ is selected. Compare this to previous behavior where checking when not all rows are selected will _select_ all. 

This change was done to be more inline with the visual appearance of the indeterminate state (which has a minus sign so when some, but not all rows are selected, the behavior will _remove_ selections)