### PR TITLE
Add p-select-all-checkbox

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,8 @@
   "globals": {
     "defineProps": "readonly",
     "defineEmits": "readonly",
-    "defineExpose": "readonly"
+    "defineExpose": "readonly",
+    "defineModel": "readonly"
   },
   "settings": {
     "import/resolver": {

--- a/demo/sections/components/Checkbox.vue
+++ b/demo/sections/components/Checkbox.vue
@@ -4,7 +4,7 @@
     :demos="[
       { title: 'Checkbox' },
       { title: 'Multiple', description: 'For multiple checkboxes, the v-model value can be an array to be shared across all checkboxes. See also: p-checkbox-group' },
-      { title: 'Indeterminate', description: 'A checkbox can either be on or off, but there is a third, visual-only state called indeterminate. This is used to indicate that a checkbox is in a mixed state, for example, when a parent checkbox is checked, but not all of its children are - e.g. a `Select All` checkbox.' },
+      { title: 'Indeterminate', description: 'A checkbox can either be on or off, but there is a third, visual-only state called indeterminate. This is used to indicate that a checkbox is in a mixed state, for example, when a parent checkbox is checked, but not all of its children are. As a common pattern, see `<p-select-all-checkbox />`.' },
       { title: 'Label Slot', description: 'In addition to the label prop, there is a slot available for label content.' },
     ]"
   >

--- a/demo/sections/components/Checkbox.vue
+++ b/demo/sections/components/Checkbox.vue
@@ -4,7 +4,7 @@
     :demos="[
       { title: 'Checkbox' },
       { title: 'Multiple', description: 'For multiple checkboxes, the v-model value can be an array to be shared across all checkboxes. See also: p-checkbox-group' },
-      { title: 'Indeterminate', description: 'A checkbox can either be on or off, but there is a third, visual-only state called indeterminate. This is used to indicate that a checkbox is in a mixed state, for example, when a parent checkbox is checked, but not all of its children are. As a common pattern, see `<p-select-all-checkbox />`.' },
+      { title: 'Indeterminate', description: 'A checkbox can either be on or off, but there is a third, visual-only state called indeterminate. This is used to indicate that a checkbox is in a mixed state, for example, when a parent checkbox is checked, but not all of its children are. See also: p-select-all-checkbox' },
       { title: 'Label Slot', description: 'In addition to the label prop, there is a slot available for label content.' },
     ]"
   >

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
       },
       "peerDependencies": {
         "@prefecthq/vue-compositions": "^1.11.0",
-        "vue": "^3.3.4",
+        "vue": "^3.4.4",
         "vue-router": "^4.1.6"
       }
     },
@@ -601,9 +601,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
@@ -1440,53 +1440,53 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
-      "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.4.tgz",
+      "integrity": "sha512-U5AdCN+6skzh2bSJrkMj2KZsVkUpgK8/XlxjSRYQZhNPcvt9/kmgIMpFEiTyK+Dz5E1J+8o8//BEIX+bakgVSw==",
       "peer": true,
       "dependencies": {
-        "@babel/parser": "^7.21.3",
-        "@vue/shared": "3.3.4",
+        "@babel/parser": "^7.23.6",
+        "@vue/shared": "3.4.4",
+        "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.0.2"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
-      "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.4.tgz",
+      "integrity": "sha512-iSwkdDULCN+Vr8z6uwdlL044GJ/nUmECxP9vu7MzEs4Qma0FwDLYvnvRcyO0ZITuu3Os4FptGUDnhi1kOLSaGw==",
       "peer": true,
       "dependencies": {
-        "@vue/compiler-core": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-core": "3.4.4",
+        "@vue/shared": "3.4.4"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz",
-      "integrity": "sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.4.tgz",
+      "integrity": "sha512-OTFcU6vUxUNHBcarzkp4g6d25nvcmDvFDzPRvSrIsByFFPRYN+y3b+j9HxYwt6nlWvGyFCe0roeJdJlfYxbCBg==",
       "peer": true,
       "dependencies": {
-        "@babel/parser": "^7.20.15",
-        "@vue/compiler-core": "3.3.4",
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/compiler-ssr": "3.3.4",
-        "@vue/reactivity-transform": "3.3.4",
-        "@vue/shared": "3.3.4",
+        "@babel/parser": "^7.23.6",
+        "@vue/compiler-core": "3.4.4",
+        "@vue/compiler-dom": "3.4.4",
+        "@vue/compiler-ssr": "3.4.4",
+        "@vue/shared": "3.4.4",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.0",
-        "postcss": "^8.1.10",
+        "magic-string": "^0.30.5",
+        "postcss": "^8.4.32",
         "source-map-js": "^1.0.2"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz",
-      "integrity": "sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.4.tgz",
+      "integrity": "sha512-1DU9DflSSQlx/M61GEBN+NbT/anUki2ooDo9IXfTckCeKA/2IKNhY8KbG3x6zkd3KGrxzteC7de6QL88vEb41Q==",
       "peer": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-dom": "3.4.4",
+        "@vue/shared": "3.4.4"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -1596,65 +1596,52 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.4.tgz",
-      "integrity": "sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.4.tgz",
+      "integrity": "sha512-DFsuJBf6sfhd5SYzJmcBTUG9+EKqjF31Gsk1NJtnpJm9liSZ806XwGJUeNBVQIanax7ODV7Lmk/k17BgxXNuTg==",
       "peer": true,
       "dependencies": {
-        "@vue/shared": "3.3.4"
-      }
-    },
-    "node_modules/@vue/reactivity-transform": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz",
-      "integrity": "sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==",
-      "peer": true,
-      "dependencies": {
-        "@babel/parser": "^7.20.15",
-        "@vue/compiler-core": "3.3.4",
-        "@vue/shared": "3.3.4",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.0"
+        "@vue/shared": "3.4.4"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.4.tgz",
-      "integrity": "sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.4.tgz",
+      "integrity": "sha512-zWWwNQAj5JdxrmOA1xegJm+c4VtyIbDEKgQjSb4va5v7gGTCh0ZjvLI+htGFdVXaO9bs2J3C81p5p+6jrPK8Bw==",
       "peer": true,
       "dependencies": {
-        "@vue/reactivity": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/reactivity": "3.4.4",
+        "@vue/shared": "3.4.4"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.4.tgz",
-      "integrity": "sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.4.tgz",
+      "integrity": "sha512-Nlh2ap1J/eJQ6R0g+AIRyGNwpTJQACN0dk8I8FRLH8Ev11DSvfcPOpn4+Kbg5xAMcuq0cHB8zFYxVrOgETrrvg==",
       "peer": true,
       "dependencies": {
-        "@vue/runtime-core": "3.3.4",
-        "@vue/shared": "3.3.4",
-        "csstype": "^3.1.1"
+        "@vue/runtime-core": "3.4.4",
+        "@vue/shared": "3.4.4",
+        "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.4.tgz",
-      "integrity": "sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.4.tgz",
+      "integrity": "sha512-+AjoiKcC41k7SMJBYkDO9xs79/Of8DiThS9mH5l2MK+EY0to3psI0k+sElvVqQvsoZTjHMEuMz0AEgvm2T+CwA==",
       "peer": true,
       "dependencies": {
-        "@vue/compiler-ssr": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-ssr": "3.4.4",
+        "@vue/shared": "3.4.4"
       },
       "peerDependencies": {
-        "vue": "3.3.4"
+        "vue": "3.4.4"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
-      "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.4.tgz",
+      "integrity": "sha512-abSgiVRhfjfl3JALR/cSuBl74hGJ3SePgf1mKzodf1eMWLwHZbfEGxT2cNJSsNiw44jEgrO7bNkhchaWA7RwNw==",
       "peer": true
     },
     "node_modules/acorn": {
@@ -2260,9 +2247,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "peer": true
     },
     "node_modules/data-urls": {
@@ -4067,12 +4054,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
-      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+      "version": "0.30.8",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
+      "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
       "peer": true,
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       },
       "engines": {
         "node": ">=12"
@@ -5724,16 +5711,24 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
-      "integrity": "sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.4.tgz",
+      "integrity": "sha512-suZXgDVT8lRNhKmxdkwOsR0oyUi8is7mtqI18qW97JLoyorEbE9B2Sb4Ws/mR/+0AgA/JUtsv1ytlRSH3/pDIA==",
       "peer": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/compiler-sfc": "3.3.4",
-        "@vue/runtime-dom": "3.3.4",
-        "@vue/server-renderer": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-dom": "3.4.4",
+        "@vue/compiler-sfc": "3.4.4",
+        "@vue/runtime-dom": "3.4.4",
+        "@vue/server-renderer": "3.4.4",
+        "@vue/shared": "3.4.4"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/vue-eslint-parser": {
@@ -6313,9 +6308,9 @@
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
+      "version": "1.4.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.9",
@@ -6853,53 +6848,53 @@
       }
     },
     "@vue/compiler-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.3.4.tgz",
-      "integrity": "sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.4.tgz",
+      "integrity": "sha512-U5AdCN+6skzh2bSJrkMj2KZsVkUpgK8/XlxjSRYQZhNPcvt9/kmgIMpFEiTyK+Dz5E1J+8o8//BEIX+bakgVSw==",
       "peer": true,
       "requires": {
-        "@babel/parser": "^7.21.3",
-        "@vue/shared": "3.3.4",
+        "@babel/parser": "^7.23.6",
+        "@vue/shared": "3.4.4",
+        "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.0.2"
       }
     },
     "@vue/compiler-dom": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.3.4.tgz",
-      "integrity": "sha512-wyM+OjOVpuUukIq6p5+nwHYtj9cFroz9cwkfmP9O1nzH68BenTTv0u7/ndggT8cIQlnBeOo6sUT/gvHcIkLA5w==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.4.tgz",
+      "integrity": "sha512-iSwkdDULCN+Vr8z6uwdlL044GJ/nUmECxP9vu7MzEs4Qma0FwDLYvnvRcyO0ZITuu3Os4FptGUDnhi1kOLSaGw==",
       "peer": true,
       "requires": {
-        "@vue/compiler-core": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-core": "3.4.4",
+        "@vue/shared": "3.4.4"
       }
     },
     "@vue/compiler-sfc": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.3.4.tgz",
-      "integrity": "sha512-6y/d8uw+5TkCuzBkgLS0v3lSM3hJDntFEiUORM11pQ/hKvkhSKZrXW6i69UyXlJQisJxuUEJKAWEqWbWsLeNKQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.4.tgz",
+      "integrity": "sha512-OTFcU6vUxUNHBcarzkp4g6d25nvcmDvFDzPRvSrIsByFFPRYN+y3b+j9HxYwt6nlWvGyFCe0roeJdJlfYxbCBg==",
       "peer": true,
       "requires": {
-        "@babel/parser": "^7.20.15",
-        "@vue/compiler-core": "3.3.4",
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/compiler-ssr": "3.3.4",
-        "@vue/reactivity-transform": "3.3.4",
-        "@vue/shared": "3.3.4",
+        "@babel/parser": "^7.23.6",
+        "@vue/compiler-core": "3.4.4",
+        "@vue/compiler-dom": "3.4.4",
+        "@vue/compiler-ssr": "3.4.4",
+        "@vue/shared": "3.4.4",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.0",
-        "postcss": "^8.1.10",
+        "magic-string": "^0.30.5",
+        "postcss": "^8.4.32",
         "source-map-js": "^1.0.2"
       }
     },
     "@vue/compiler-ssr": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.3.4.tgz",
-      "integrity": "sha512-m0v6oKpup2nMSehwA6Uuu+j+wEwcy7QmwMkVNVfrV9P2qE5KshC6RwOCq8fjGS/Eak/uNb8AaWekfiXxbBB6gQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.4.tgz",
+      "integrity": "sha512-1DU9DflSSQlx/M61GEBN+NbT/anUki2ooDo9IXfTckCeKA/2IKNhY8KbG3x6zkd3KGrxzteC7de6QL88vEb41Q==",
       "peer": true,
       "requires": {
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-dom": "3.4.4",
+        "@vue/shared": "3.4.4"
       }
     },
     "@vue/devtools-api": {
@@ -6984,62 +6979,49 @@
       }
     },
     "@vue/reactivity": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.3.4.tgz",
-      "integrity": "sha512-kLTDLwd0B1jG08NBF3R5rqULtv/f8x3rOFByTDz4J53ttIQEDmALqKqXY0J+XQeN0aV2FBxY8nJDf88yvOPAqQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.4.tgz",
+      "integrity": "sha512-DFsuJBf6sfhd5SYzJmcBTUG9+EKqjF31Gsk1NJtnpJm9liSZ806XwGJUeNBVQIanax7ODV7Lmk/k17BgxXNuTg==",
       "peer": true,
       "requires": {
-        "@vue/shared": "3.3.4"
-      }
-    },
-    "@vue/reactivity-transform": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.3.4.tgz",
-      "integrity": "sha512-MXgwjako4nu5WFLAjpBnCj/ieqcjE2aJBINUNQzkZQfzIZA4xn+0fV1tIYBJvvva3N3OvKGofRLvQIwEQPpaXw==",
-      "peer": true,
-      "requires": {
-        "@babel/parser": "^7.20.15",
-        "@vue/compiler-core": "3.3.4",
-        "@vue/shared": "3.3.4",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.0"
+        "@vue/shared": "3.4.4"
       }
     },
     "@vue/runtime-core": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.3.4.tgz",
-      "integrity": "sha512-R+bqxMN6pWO7zGI4OMlmvePOdP2c93GsHFM/siJI7O2nxFRzj55pLwkpCedEY+bTMgp5miZ8CxfIZo3S+gFqvA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.4.tgz",
+      "integrity": "sha512-zWWwNQAj5JdxrmOA1xegJm+c4VtyIbDEKgQjSb4va5v7gGTCh0ZjvLI+htGFdVXaO9bs2J3C81p5p+6jrPK8Bw==",
       "peer": true,
       "requires": {
-        "@vue/reactivity": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/reactivity": "3.4.4",
+        "@vue/shared": "3.4.4"
       }
     },
     "@vue/runtime-dom": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.3.4.tgz",
-      "integrity": "sha512-Aj5bTJ3u5sFsUckRghsNjVTtxZQ1OyMWCr5dZRAPijF/0Vy4xEoRCwLyHXcj4D0UFbJ4lbx3gPTgg06K/GnPnQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.4.tgz",
+      "integrity": "sha512-Nlh2ap1J/eJQ6R0g+AIRyGNwpTJQACN0dk8I8FRLH8Ev11DSvfcPOpn4+Kbg5xAMcuq0cHB8zFYxVrOgETrrvg==",
       "peer": true,
       "requires": {
-        "@vue/runtime-core": "3.3.4",
-        "@vue/shared": "3.3.4",
-        "csstype": "^3.1.1"
+        "@vue/runtime-core": "3.4.4",
+        "@vue/shared": "3.4.4",
+        "csstype": "^3.1.3"
       }
     },
     "@vue/server-renderer": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.3.4.tgz",
-      "integrity": "sha512-Q6jDDzR23ViIb67v+vM1Dqntu+HUexQcsWKhhQa4ARVzxOY2HbC7QRW/ggkDBd5BU+uM1sV6XOAP0b216o34JQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.4.tgz",
+      "integrity": "sha512-+AjoiKcC41k7SMJBYkDO9xs79/Of8DiThS9mH5l2MK+EY0to3psI0k+sElvVqQvsoZTjHMEuMz0AEgvm2T+CwA==",
       "peer": true,
       "requires": {
-        "@vue/compiler-ssr": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-ssr": "3.4.4",
+        "@vue/shared": "3.4.4"
       }
     },
     "@vue/shared": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.4.tgz",
-      "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.4.tgz",
+      "integrity": "sha512-abSgiVRhfjfl3JALR/cSuBl74hGJ3SePgf1mKzodf1eMWLwHZbfEGxT2cNJSsNiw44jEgrO7bNkhchaWA7RwNw==",
       "peer": true
     },
     "acorn": {
@@ -7450,9 +7432,9 @@
       }
     },
     "csstype": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
-      "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "peer": true
     },
     "data-urls": {
@@ -8782,12 +8764,12 @@
       }
     },
     "magic-string": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
-      "integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
+      "version": "0.30.8",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.8.tgz",
+      "integrity": "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==",
       "peer": true,
       "requires": {
-        "@jridgewell/sourcemap-codec": "^1.4.13"
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       }
     },
     "make-error": {
@@ -9907,16 +9889,16 @@
       }
     },
     "vue": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
-      "integrity": "sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.4.tgz",
+      "integrity": "sha512-suZXgDVT8lRNhKmxdkwOsR0oyUi8is7mtqI18qW97JLoyorEbE9B2Sb4Ws/mR/+0AgA/JUtsv1ytlRSH3/pDIA==",
       "peer": true,
       "requires": {
-        "@vue/compiler-dom": "3.3.4",
-        "@vue/compiler-sfc": "3.3.4",
-        "@vue/runtime-dom": "3.3.4",
-        "@vue/server-renderer": "3.3.4",
-        "@vue/shared": "3.3.4"
+        "@vue/compiler-dom": "3.4.4",
+        "@vue/compiler-sfc": "3.4.4",
+        "@vue/runtime-dom": "3.4.4",
+        "@vue/server-renderer": "3.4.4",
+        "@vue/shared": "3.4.4"
       }
     },
     "vue-eslint-parser": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "peerDependencies": {
     "@prefecthq/vue-compositions": "^1.11.0",
-    "vue": "^3.3.4",
+    "vue": "^3.4.4",
     "vue-router": "^4.1.6"
   },
   "dependencies": {

--- a/src/components/SelectAllCheckbox/PSelectAllCheckbox.vue
+++ b/src/components/SelectAllCheckbox/PSelectAllCheckbox.vue
@@ -3,9 +3,13 @@
     <p-checkbox
       v-model="checkboxModel"
       :indeterminate="selectedModel.length && selectedModel.length < selectable.length"
-      :aria-label="checkboxModel ? `Deselect all ${selectedModel.length} ${toPluralString(itemName, selectedModel.length)}` : `Select all ${selectable.length} ${toPluralString(itemName, selectable.length)}`"
+      :aria-label="label"
       v-bind="attrs"
-    />
+    >
+      <template v-if="$slots.label" #label>
+        <slot name="label" :label="label" />
+      </template>
+    </p-checkbox>
   </p-tooltip>
 </template>
 
@@ -31,4 +35,8 @@
       }
     },
   })
+
+  const label = computed(() => checkboxModel.value
+    ? `Deselect all ${selectedModel.value.length} ${toPluralString(props.itemName, selectedModel.value.length)}`
+    : `Select all ${props.selectable.length} ${toPluralString(props.itemName, props.selectable.length)}`)
 </script>

--- a/src/components/SelectAllCheckbox/PSelectAllCheckbox.vue
+++ b/src/components/SelectAllCheckbox/PSelectAllCheckbox.vue
@@ -1,0 +1,34 @@
+<template>
+  <p-tooltip :text="checkboxModel ? 'Deselect all' : 'Select all'">
+    <p-checkbox
+      v-model="checkboxModel"
+      :indeterminate="selectedModel.length && selectedModel.length < selectable.length"
+      :aria-label="checkboxModel ? `Deselect all ${selectedModel.length} ${toPluralString(itemName, selectedModel.length)}` : `Select all ${selectable.length} ${toPluralString(itemName, selectable.length)}`"
+      v-bind="attrs"
+    />
+  </p-tooltip>
+</template>
+
+<script setup lang="ts" generic="T">
+  import { computed, useAttrs } from 'vue'
+  import { toPluralString } from '@/utilities'
+
+  const selectedModel = defineModel<T[]>({ required: true })
+  const props = withDefaults(defineProps<{
+    selectable: T[],
+    itemName?: string,
+  }>(), { itemName: 'item' })
+
+  const attrs = useAttrs()
+
+  const checkboxModel = computed({
+    get: () => selectedModel.value.length > 0,
+    set: (value: boolean) => {
+      if (value) {
+        selectedModel.value = props.selectable
+      } else {
+        selectedModel.value = []
+      }
+    },
+  })
+</script>

--- a/src/components/SelectAllCheckbox/index.ts
+++ b/src/components/SelectAllCheckbox/index.ts
@@ -1,0 +1,8 @@
+import { App } from 'vue'
+import PSelectAllCheckbox from '@/components/SelectAllCheckbox/PSelectAllCheckbox.vue'
+
+const install = (app: App): void => {
+  app.component('PSelectAllCheckbox', PSelectAllCheckbox)
+}
+
+export { PSelectAllCheckbox, install }

--- a/src/components/Table/PTable.vue
+++ b/src/components/Table/PTable.vue
@@ -7,12 +7,7 @@
             <PTableRow>
               <template v-if="showMultiselect">
                 <PTableData class="p-table__checkbox-cell">
-                  <p-tooltip :text="selectAllModel ? 'Deselect all' : 'Select all'">
-                    <p-checkbox
-                      v-model="selectAllModel"
-                      :indeterminate="internalSelectedRows.length && internalSelectedRows.length < selectableRows.length"
-                    />
-                  </p-tooltip>
+                  <PSelectAllCheckbox v-model="internalSelectedRows" :selectable="selectableRows" />
                 </PTableData>
               </template>
 
@@ -64,6 +59,7 @@
 
 <script lang="ts" generic="const TData extends TableData, const TColumn extends TableColumn<TData>" setup>
   import { computed, StyleValue, useSlots } from 'vue'
+  import PSelectAllCheckbox from '@/components/SelectAllCheckbox/PSelectAllCheckbox.vue'
   import PTableBody from '@/components/Table/PTableBody.vue'
   import PTableData from '@/components/Table/PTableData.vue'
   import PTableFoot from '@/components/Table/PTableFoot.vue'
@@ -98,15 +94,6 @@
     },
     set(value) {
       emit('update:selected', value)
-    },
-  })
-
-  const selectAllModel = computed({
-    get() {
-      return internalSelectedRows.value.length > 0
-    },
-    set(value) {
-      internalSelectedRows.value = value ? selectableRows.value : []
     },
   })
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -64,6 +64,7 @@ import { PRadio, install as installPRadio } from '@/components/Radio'
 import { PRadioGroup, install as installPRadioGroup } from '@/components/RadioGroup'
 import { PSanitizeHtml, install as installPSanitizeHtml } from '@/components/SanitizeHtml'
 import { PSelect, install as installPSelect } from '@/components/Select'
+import { PSelectAllCheckbox, install as installPSelectAllCheckbox } from '@/components/SelectAllCheckbox'
 import { PSelectOption, install as installPSelectOption } from '@/components/SelectOption'
 import { PSelectOptionGroup, install as installPSelectOptionGroup } from '@/components/SelectOptionGroup'
 import { PStepper, install as installPStepper } from '@/components/Stepper'
@@ -157,6 +158,7 @@ export {
   PRadioGroup,
   PSanitizeHtml,
   PSelect,
+  PSelectAllCheckbox,
   PSelectOption,
   PSelectOptionGroup,
   PStepper,
@@ -261,6 +263,7 @@ export const installs = [
   installPRadioGroup,
   installPSanitizeHtml,
   installPSelect,
+  installPSelectAllCheckbox,
   installPSelectOption,
   installPSelectOptionGroup,
   installPStepper,


### PR DESCRIPTION
This PR adds a new component `<p-select-all-checkbox />`. It wraps a `p-checkbox` to implement the following pattern:
- when nothing is selected, the checkbox is unchecked
- when some-but-not-all are selected, the checkbox is checked and visually appears in an indeterminate state
- when all selectable items are selected, the checkbox is checked and visually appears in a checked state

- on check, all items should be selected
- on uncheck, all items should be deselected.

The component contains a tooltip along with a sr-friendly label.


This PR updates `<p-table />` to use `<p-select-all-checkbox />` in-place of its prior `<p-checkbox />`