### PR TITLE
Bugfix: Markdown absolute links being treated as relative

### DIFF
--- a/src/components/MarkdownRenderer/parser.ts
+++ b/src/components/MarkdownRenderer/parser.ts
@@ -149,10 +149,6 @@ const getVNode = (token: Token, options: ParserOptions): VNode | VNode[] => {
     const { href, title } = token
     const classList = [`${baseClass}__link`]
     const composedHref = normalizeHref(href)
-    console.log({
-      href,
-      composedHref,
-    })
     return h(PLink, { to: composedHref, title, class: classList, rel: 'noopener' }, { default: () => token.text })
   }
 

--- a/src/utilities/router.ts
+++ b/src/utilities/router.ts
@@ -29,3 +29,17 @@ export function isRouteExternal(route: RouteLocationRaw): boolean {
     return false
   }
 }
+
+export function isRouteRelative(route: string): boolean {
+  return route.startsWith('/')
+}
+
+export function stripBaseUrl(href: string): string {
+  try {
+    const strippedBaseUrl = new URL(href).pathname
+    return strippedBaseUrl
+  } catch {
+    // fail silently
+    return href
+  }
+}


### PR DESCRIPTION
This PR addresses an issue where markdown links whose base urls matched the current route were being treated as relative.

To test this, paste the following in the `Interactive` tab of the [markdown renderer demo](https://prefect-design.netlify.app/components/markdown-renderer):
```md
[accordion-demo-relative-link](/components/accordion)
[accordion-demo-absolute-link](https://prefect-design.netlify.app/components/accordion)
```
the results should be that the first link works and correctly navigates to the accordion demo and the second fails because it attempts to construct a link that looks like `https://prefect-design.netlify.app/components/markdown-renderer/https://prefect-design.netlify.app/components/accordion`

Trying the same in the PR preview (with a modified base URL) should demonstrate the fixed behavior:
```md
[accordion-demo-relative-link](/components/accordion)
[accordion-demo-absolute-link](https://deploy-preview-1163--prefect-design.netlify.app/components/accordion)
```

This is a result of `PLink` testing the passed `to` prop, determining that the base urls match, rendering a `router-link` component, and vue-router treating string `to` props as relative to whatever `baseUrl` is passed to the router constructor. 