### PR TITLE
Enhancement: Lower tooltip font size

### DIFF
--- a/src/components/Tooltip/PTooltip.vue
+++ b/src/components/Tooltip/PTooltip.vue
@@ -96,6 +96,7 @@
 .p-tooltip__tooltip { @apply
   p-1
   max-w-xs
+  text-xs
 }
 
 .p-tooltip__content { @apply


### PR DESCRIPTION
These were way too big for tooltips before since they were using the base font size. 

Before:

![Screenshot 2024-03-19 at 2 06 51 PM](https://github.com/PrefectHQ/prefect-design/assets/27291717/ea8d5080-82c8-495f-8134-e3a9a8ee8ff0)
![Screenshot 2024-03-19 at 2 06 46 PM](https://github.com/PrefectHQ/prefect-design/assets/27291717/a5db2c5b-ab4d-4555-b831-60b76cc0dcbc)

After:

![Screenshot 2024-03-19 at 2 06 58 PM](https://github.com/PrefectHQ/prefect-design/assets/27291717/dee3ec53-a27f-4ad0-b015-1efcd64b6593)
![Screenshot 2024-03-19 at 2 06 55 PM](https://github.com/PrefectHQ/prefect-design/assets/27291717/c018499d-9b4f-40c5-9377-a3be7653fd1d)
