### PR TITLE
Update multiselect checkbox styling to better handle both wide(r) tables and tall(er) rows.

### DIFF
--- a/src/components/Table/PTable.vue
+++ b/src/components/Table/PTable.vue
@@ -6,9 +6,9 @@
           <slot name="header">
             <PTableRow>
               <template v-if="showMultiselect">
-                <PTableData class="p-table__checkbox-cell">
+                <PTableHeader class="p-table__checkbox-cell">
                   <PSelectAllCheckbox v-model="internalSelectedRows" :selectable="selectableRows" />
-                </PTableData>
+                </PTableHeader>
               </template>
 
               <template v-for="column in visibleColumns" :key="column">
@@ -186,10 +186,6 @@
 }
 
 .p-table__checkbox-cell { @apply
-  flex
-  justify-center
-  items-center
-  pl-2
-  pr-0
+  w-5
 }
 </style>


### PR DESCRIPTION
So it seems like (_almost_) none of our tables that have selection functionality actually use `<p-table>`'s underlying multiselect. Instead, their overridden/manually-handled and when I switched over, I noticed some styling issues so the changes I've made should bring the base `<p-table>` styling to parity with what's overloaded and used in-app. 

In particular, notice 2 changes here:
- The width of the checkbox column should stay small even as the table grows wider
- As row heights increase, the checkboxes should stay vertically centered

|          | 📸  |
| ---- | ---- |
| Before | ![image](https://github.com/PrefectHQ/prefect-design/assets/22418768/39a71920-a236-437a-85da-e069b71cddc6) | 
| After | ![image](https://github.com/PrefectHQ/prefect-design/assets/22418768/6858b50b-5eeb-4135-936b-1ee5ad3ea7aa) |
