### PR TITLE
Enhancement: Add `break-words` to tooltip content

### DIFF
--- a/src/components/LoadingIcon/PLoadingIcon.vue
+++ b/src/components/LoadingIcon/PLoadingIcon.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script setup lang="ts">
-  import { computed, defineProps } from 'vue'
+  import { computed } from 'vue'
 
   const props = withDefaults(defineProps<{
     size?: 'small' | 'default' | 'large',

--- a/src/components/SelectOptionGroup/PSelectOptionGroup.vue
+++ b/src/components/SelectOptionGroup/PSelectOptionGroup.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { defineProps, computed } from 'vue'
+  import { computed } from 'vue'
   import { SelectOptionGroupNormalized } from '@/types'
 
   const props = defineProps<{

--- a/src/components/Tooltip/PTooltip.vue
+++ b/src/components/Tooltip/PTooltip.vue
@@ -107,5 +107,6 @@
   shadow
   dark:shadow-md
   max-w-xs
+  break-words
 }
 </style>


### PR DESCRIPTION
# Description
Makes sure that tooltip content wraps even if its a single unbroken word. Closes https://github.com/PrefectHQ/prefect-design/issues/1179

Before
<img width="605" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6200442/ee3bbba3-1bb7-41c6-b6ad-c747a8271d32">

After
<img width="421" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/6200442/f57365ad-3474-42f0-a38c-464cfe49c8f0">
