### PR TITLE
[p-select] Fix multi select keyboard selection

### DIFF
--- a/demo/sections/components/Combobox.vue
+++ b/demo/sections/components/Combobox.vue
@@ -106,11 +106,9 @@
 </script>
 
 <style>
-  .combobox__demo {
-    @apply
-    h-80
-    flex
-    flex-col
-    gap-4
-  }
+.combobox__demo { @apply
+  flex
+  flex-col
+  gap-4
+}
 </style>

--- a/src/components/Select/PSelectOptions.vue
+++ b/src/components/Select/PSelectOptions.vue
@@ -114,7 +114,7 @@
 
   function toggleValue(newValue: SelectModelValue): void {
     if (Array.isArray(internalValue.value)) {
-      toggleArrayValue(internalValue.value, newValue)
+      internalValue.value = toggleArrayValue(internalValue.value, newValue)
       return
     }
 
@@ -144,6 +144,7 @@
         break
       case keys.space:
       case keys.enter:
+        debugger
         if (isUnselected(highlightedValue.value)) {
           return
         }

--- a/src/components/Select/PSelectOptions.vue
+++ b/src/components/Select/PSelectOptions.vue
@@ -144,7 +144,6 @@
         break
       case keys.space:
       case keys.enter:
-        debugger
         if (isUnselected(highlightedValue.value)) {
           return
         }


### PR DESCRIPTION
`<p-select multiple ... />` components and others that build on top if it (i.e. comboboxes) have a bug when attempting to select options via keyboard. Pressing <kbd>Enter</kbd> doesn't do anything like it should once an option is highlighted. 


### Steps to reproduce:
1. Go to the demo (on main) https://prefect-design.netlify.app/components/select#multi-select
2. Pop it open
3. Press down arrows to navigate to an option
4. Press <kbd>Enter</kbd> but nothing happens