### PR TITLE
Bugfix: Don't bind panel to slot

### DIFF
--- a/demo/components/cascade/BasicDemo.vue
+++ b/demo/components/cascade/BasicDemo.vue
@@ -12,10 +12,10 @@
       <Level1 />
     </template>
 
-    <template #level-2="{ close }">
+    <template #level-2>
       No component for level-2 but we can still access the panel state
 
-      <p-button small @click="close">
+      <p-button small @click="closePanelById('level-2')">
         Close
       </p-button>
     </template>
@@ -43,5 +43,5 @@
     },
   ]
 
-  const { toggle } = useCascadePanels(panels)
+  const { toggle, closePanelById } = useCascadePanels(panels)
 </script>

--- a/src/components/CascadeMenu/PCascadePanel.vue
+++ b/src/components/CascadeMenu/PCascadePanel.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="p-cascade-panel">
-    <slot v-bind="panel" />
+    <slot />
   </div>
 </template>
 
@@ -11,7 +11,7 @@
     panelId: CascadePanelId,
   }>()
 
-  const panel = useCascadePanel(() => props.panelId)
+  useCascadePanel(() => props.panelId)
 </script>
 
 <style>

--- a/src/components/CascadeMenu/PCascadePanels.vue
+++ b/src/components/CascadeMenu/PCascadePanels.vue
@@ -4,11 +4,9 @@
       <template v-for="{ id } in panels" :key="id">
         <transition-group :name="panelTransitionName">
           <PCascadePanel v-show="getPanelIsOpenById(id)" :key="id" :panel-id="id" class="p-cascade-panels__panel">
-            <template #default="panel">
-              <slot :name="`${getBaseSlotName(id)}`" v-bind="panel">
-                {{ getBaseSlotName(id) }}
-              </slot>
-            </template>
+            <slot :name="`${getBaseSlotName(id)}`">
+              {{ getBaseSlotName(id) }}
+            </slot>
           </PCascadePanel>
         </transition-group>
       </template>


### PR DESCRIPTION
I'm not quite sure why this is necessary but after spending all evening chasing down an HMR-only recursion issue the culprit seems to be the fact that I'm binding the `panel` prop in both the `PCascadePanel` component and again in the named slot in `PCascadePanels` loop. 

Note: This caused me to change an earlier demo a bit - instead of accessing the panel through the binding it's calling `closePanelById` - downstream components are fine because they can still access the panel via the `usePanel` composition, which is preferred anyway.