### PR TITLE
Enhancement: Add slot for tag wrapper

### DIFF
--- a/src/components/TagWrapper/PTagWrapper.vue
+++ b/src/components/TagWrapper/PTagWrapper.vue
@@ -12,13 +12,15 @@
 
 
     <div ref="overflowTag" class="p-tag-wrapper__tag-overflow" :class="classes.overflowTag">
-      <PTooltip :text="hiddenText">
-        <slot name="overflow-tags" :overflowed-children="overflowCount">
-          <PTag>
-            +{{ overflowCount }}
-          </PTag>
-        </slot>
-      </PTooltip>
+      <slot name="overflow" v-bind="{ hiddenText, overflowCount }">
+        <PTooltip :text="hiddenText">
+          <slot name="overflow-tags" :overflowed-children="overflowCount">
+            <PTag>
+              +{{ overflowCount }}
+            </PTag>
+          </slot>
+        </PTooltip>
+      </slot>
     </div>
   </div>
 </template>


### PR DESCRIPTION
This will allow callers to override the `PTooltip` and regular slot content, either displaying nothing at all or displaying something custom. The `overflowCount` should also allow re-creating any hidden tags since indices should remain consistent when hiding tags