### PR TITLE
BugFix: PTagWrapper key causing flickering in PSelect and PComboBox

### DIFF
--- a/src/components/TagWrapper/PTagWrapper.vue
+++ b/src/components/TagWrapper/PTagWrapper.vue
@@ -1,7 +1,7 @@
 <template>
   <div ref="container" class="p-tag-wrapper" :class="classes.tagContainer">
     <slot>
-      <template v-for="tag in tags" :key="tag">
+      <template v-for="tag in tags" :key="tag.value">
         <div class="p-tag-wrapper__tag" :class="classes.tag">
           <slot name="tag" :tag="tag">
             <PTag :value="tag" />


### PR DESCRIPTION
# Description
PTagWrapper has a v-for with a key that is the current tag. However since tag is an object its very easy for that object to not be `===` even though the values are the same. 

This effected PSelect which flattens/normalizes its values which produces a new object each time. Causing the slot content to be remounted/rendered each time the value changed. 