### PR TITLE
Bugfix: `PTagWrapper` with async data

### DIFF
--- a/demo/sections/components/Tags.vue
+++ b/demo/sections/components/Tags.vue
@@ -87,7 +87,7 @@
 
         <p-tag-wrapper>
           <template v-for="tag in asyncTags" :key="tag.id">
-            <p-tag :class="tag.tailwindClass">
+            <p-tag class="tags__async-tag" :class="tag.tailwindClass">
               {{ tag.label }}
             </p-tag>
           </template>
@@ -124,11 +124,11 @@
     { className: 'tag--scheduled', name: 'Scheduled' },
   ]
 
-  type AsyncTag = { id: string, label: string, tailwindClass: string }
+  type AsyncTag = { id: string, label: string, tailwindClass?: string }
 
-  const tailwindClasses = ['bg-blue-500', 'bg-red-500', 'bg-yellow-500', 'bg-green-500', 'bg-gray-500', 'bg-purple-500', 'bg-pink-500', 'bg-indigo-500']
+  const tailwindClasses = ['!bg-blue-500', '!bg-red-500', '!bg-yellow-500', '!bg-green-500', '!bg-gray-500', '!bg-purple-500', '!bg-pink-500', '!bg-indigo-500']
   function getAsyncTags(length: number = 50): AsyncTag[] {
-    return Array.from({ length: length }, () => ({ id: randomId(), label: '', tailwindClass: tailwindClasses[Math.floor(Math.random() * tailwindClasses.length)] }))
+    return Array.from({ length: length }, () => ({ id: randomId(), label: '' }))
   }
   const asyncTags = ref<AsyncTag[]>(getAsyncTags())
   const loading = ref(false)
@@ -145,7 +145,9 @@
     return new Promise((resolve) => {
       asyncTags.value.forEach((tag, index) => {
         const timeout = setTimeout(() => {
-          asyncTags.value[index].label = numberArr[Math.floor(Math.random() * numberArr.length)]
+          const tailwindClass = tailwindClasses[Math.floor(Math.random() * tailwindClasses.length)]
+          asyncTags.value[index].label = tailwindClass.slice(4, -4)
+          asyncTags.value[index].tailwindClass = tailwindClass
           if (index === asyncTags.value.length - 1) {
             resolve()
           }

--- a/demo/sections/components/Tags.vue
+++ b/demo/sections/components/Tags.vue
@@ -83,12 +83,19 @@
           </p-button>
         </div>
 
-        <p-tag-wrapper :tags="asyncTagsNormalized" justify="right" inline />
+        <p-tag-wrapper :tags="asyncTagsNormalized" justify="left" />
 
-        <p-tag-wrapper>
+        <p-tag-wrapper justify="right" inline>
           <template v-for="tag in asyncTags" :key="tag.id">
             <p-tag class="tags__async-tag" :class="tag.tailwindClass">
-              {{ tag.label }}
+              <template v-if="tag.label.length === 0">
+                ...
+                <p-loading-icon />
+                ...
+              </template>
+              <template v-else>
+                {{ tag.label }}
+              </template>
             </p-tag>
           </template>
         </p-tag-wrapper>


### PR DESCRIPTION
This PR adds a mutation observer to better track overflow when down-DOM updates occur, specifically in cases of asynchronously-loaded data.

Before:

https://github.com/PrefectHQ/prefect-design/assets/27291717/49f637a2-ab04-4c6c-b1ba-6bd7ae9cb15c

After:

https://github.com/PrefectHQ/prefect-design/assets/27291717/7edd2178-fd82-4b14-9db6-1cd5c748a16b



