### PR TITLE
Enhancement: Add a footer slot to the wizard component

### DIFF
--- a/src/components/Wizard/PWizard.vue
+++ b/src/components/Wizard/PWizard.vue
@@ -21,7 +21,7 @@
 
       <slot name="after-steps" />
 
-      <div class="p-wizard__footer">
+      <div class="p-wizard__actions">
         <slot name="actions" :next-button-text="nextButtonText" :handle-next-button-click="handleNextButtonClick">
           <template v-if="showCancel">
             <p-button @click="emit('cancel')">
@@ -36,6 +36,7 @@
           </p-button>
         </slot>
       </div>
+      <slot name="footer" />
     </PCard>
   </div>
 </template>
@@ -134,7 +135,7 @@
   pb-6
 }
 
-.p-wizard__footer { @apply
+.p-wizard__actions { @apply
   flex
   flex-wrap
   gap-2

--- a/src/components/Wizard/PWizard.vue
+++ b/src/components/Wizard/PWizard.vue
@@ -61,6 +61,7 @@
 
   const emit = defineEmits<{
     (event: 'cancel' | 'next' | 'previous' | 'submit'): void,
+    (event: 'step', currentStepIndex: WizardStep | undefined): void,
   }>()
 
   const {
@@ -101,6 +102,7 @@
     const { success } = await previous()
 
     if (success) {
+      emit('step', currentStep.value)
       emit('previous')
     }
   }
@@ -110,9 +112,11 @@
     const { success } = await next()
 
     if (success) {
+      emit('step', currentStep.value)
       emit('next')
 
       if (last) {
+        emit('step', currentStep.value)
         emit('submit')
       }
     }


### PR DESCRIPTION
We want to add the mini event feed to the bottom of the trigger step in the automation wizard.  This PR adds a footer slot after the actions slot in the wizard to facilitate that.  It also adds an emit of the current step so that we can easily identify which step the wizard is on and conditionally show a footer. 

<img width="1251" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/40272060/162c59dc-b3af-48c0-8cf2-0643b0f1415e">
