### PR TITLE
Style Scrollbar to `thin`

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -22,6 +22,7 @@
     --p-spacing-focus-ring-offset: 1px;
 
     --p-radius-default: 6px;
+    --p-scrollbar-width: 12px;
   }
 
   .dark {
@@ -398,16 +399,15 @@ body {
 
 @supports selector(::-webkit-scrollbar) {
   /* If the browser supports the ::-webkit-scrollbar pseudo-element, we can style the scrollbar */
-  /* The border-radius should be at least half the width of the scrollbar thumb */
   ::-webkit-scrollbar {
-    width: 12px;
+    width: var(--p-scrollbar-width);
   }
   ::-webkit-scrollbar-track {
     background: var(--p-color-bg-0);
   }
   ::-webkit-scrollbar-thumb {
     background: var(--p-color-scrollbar-thumb);
-    border-radius: 6px; 
+    border-radius: calc(var(--p-scrollbar-width) / 2);
     border: 3px solid var(--p-color-bg-0);
   }
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -16,23 +16,6 @@
   color-scheme: light;
 }
 
-@layer utilities {
-  ::-webkit-scrollbar {
-    width: 12px;
-    height: 20px;
-  }
-
-  ::-webkit-scrollbar-track {
-    background: var(--p-color-bg-0);
-  }
-
-  ::-webkit-scrollbar-thumb {
-    background: var(--p-color-scrollbar-thumb);
-    border-radius: 100vh;
-    border: 3px solid var(--p-color-bg-0);
-  }
-}
-
 @layer base {
   :root {
     --p-spacing-focus-ring: 2px;
@@ -396,11 +379,36 @@ html {
 html,
 body {
   background-color: var(--p-color-bg-0);
-  color: var(--p-color-text-default)
+  color: var(--p-color-text-default);
+  scrollbar-width: thin;
 }
 
 *::selection {
   background-color: var(--p-color-selection-highlight);
+  
+}
+
+@supports (scrollbar-color: auto) {
+  /* If the browser supports the scrollbar-color property, we can set the color of the scrollbar thumb */
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: var(--p-color-scrollbar-thumb) transparent
+  }
+}
+
+@supports selector(::-webkit-scrollbar) {
+  /* If the browser supports the ::-webkit-scrollbar pseudo-element, we can style the scrollbar */
+  ::-webkit-scrollbar {
+    width: 12px;
+  }
+  ::-webkit-scrollbar-track {
+    background: var(--p-color-bg-0);
+  }
+  ::-webkit-scrollbar-thumb {
+    background: var(--p-color-scrollbar-thumb);
+    border-radius: 100vh;
+    border: 3px solid var(--p-color-bg-0);
+  }
 }
 
 .p-background {

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -398,6 +398,7 @@ body {
 
 @supports selector(::-webkit-scrollbar) {
   /* If the browser supports the ::-webkit-scrollbar pseudo-element, we can style the scrollbar */
+  /* The border-radius should be at least half the width of the scrollbar thumb */
   ::-webkit-scrollbar {
     width: 12px;
   }
@@ -406,7 +407,7 @@ body {
   }
   ::-webkit-scrollbar-thumb {
     background: var(--p-color-scrollbar-thumb);
-    border-radius: 100vh;
+    border-radius: 6px; 
     border: 3px solid var(--p-color-bg-0);
   }
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -16,6 +16,23 @@
   color-scheme: light;
 }
 
+@layer utilities {
+  ::-webkit-scrollbar {
+    width: 12px;
+    height: 20px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: var(--p-color-bg-0);
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: var(--p-color-scrollbar-thumb);
+    border-radius: 100vh;
+    border: 3px solid var(--p-color-bg-0);
+  }
+}
+
 @layer base {
   :root {
     --p-spacing-focus-ring: 2px;
@@ -41,7 +58,7 @@
     --p-color-divider: #51525C;
     --p-color-divider-subdued: #51525C;
     --p-color-selection-highlight: rgba(69, 156, 255, 0.4);
-
+    --p-color-scrollbar-thumb: #636467;
     --p-color-selected: rgba(104, 125, 155, 0.4);
     --p-color-selectable-hover: rgba(104, 125, 155, 0.24);
     --p-color-focus-ring: #276EE7;
@@ -213,7 +230,7 @@
     --p-color-divider: #BFBFCC;
     --p-color-divider-subdued: #f3f4f6;
     --p-color-selection-highlight: rgba(69, 156, 255, 0.4);
-
+    --p-color-scrollbar-thumb: #9e9ea0;
     --p-color-selected: rgba(107, 116, 152, 0.24);
     --p-color-selectable-hover: rgba(107, 116, 152, 0.16);
     --p-color-focus-ring: #1470EF;
@@ -369,6 +386,8 @@
     --p-color-tag-text: var(--p-color-text-default);
   }
 }
+
+
 
 html {
   transition: inherit;


### PR DESCRIPTION
Scrollbar-width is now supported on chrome, edge, and Firefox (complementing Safari's -webkit-scrollbar-*). This PR adds the default scrollbar width to `thin`, adds a color token for the scroll thumb, and makes the scroll track transparent. 

before (thick) and after (thin)

 
<img width="266" alt="Screenshot 2024-04-13 at 10 40 47 PM" src="https://github.com/PrefectHQ/prefect-design/assets/33043305/73b9f194-5001-44d6-b90d-06b989e4803d">
<img width="266" alt="Screenshot 2024-04-13 at 10 40 38 PM" src="https://github.com/PrefectHQ/prefect-design/assets/33043305/ad3936f0-b4b9-45cc-9d46-28a2f0c61ef5">
