### PR TITLE
Hide PModal footer when no actions are passed

### DIFF
--- a/src/components/Modal/PModal.vue
+++ b/src/components/Modal/PModal.vue
@@ -32,7 +32,7 @@
               <slot v-bind="modalScope" />
             </div>
 
-            <div class="p-modal__footer">
+            <div v-if="$slots.actions" class="p-modal__footer">
               <slot name="actions" v-bind="modalScope" />
               <slot name="cancel" v-bind="modalScope">
                 <p-button class="p-modal__close-button" @click="modalScope.close">


### PR DESCRIPTION
Currently our Modal component creates a "Cancel" action by default even if no actions are passed. Since action-less modals are used for previews, there's no action to cancel. Users instead can use the default top-right "X" to dismiss. 