### PR TITLE
Standardize Background Tokens with color-mix

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -46,7 +46,7 @@
     /* In dark mode, we first go dark then incrementally lighten nested cards. */
     --p-color-bg-1: color-mix(in hsl, hsl(var(--p-background)) 75%, black);
     --p-color-bg-2: hsl(var(--p-background));
-    --p-color-bg-3: color-mix(in hsl, hsl(var(--p-background)) 75%, white);
+    --p-color-bg-3: color-mix(in hsl, hsl(var(--p-background)) 94%, white);
     --p-color-bg-floating: hsl(var(--p-popover-foreground));
     --p-color-bg-floating-sticky: hsl(var(--p-popover-foreground) / 90%);
     

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -202,7 +202,7 @@
     /* In dark mode, we first go light then incrementally darken nested cards. */
     --p-color-bg-1: color-mix(in hsl, hsl(var(--p-background)) 25%, white);
     --p-color-bg-2: hsl(var(--p-background));
-    --p-color-bg-3: color-mix(in hsl, hsl(var(--p-background)) 75%, black);
+    --p-color-bg-3: color-mix(in hsl, hsl(var(--p-background)) 94%, black);
     --p-color-bg-floating: hsl(var(--p-popover-foreground));
     --p-color-bg-floating-sticky: hsl(var(--p-popover-foreground) / 90%);
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -42,6 +42,8 @@
     --p-popover-foreground: 228 6% 22%;
     
     --p-color-bg-0: hsl(var(--p-background));
+
+    /* In dark mode, we first go dark then incrementally lighten nested cards. */
     --p-color-bg-1: color-mix(in hsl, hsl(var(--p-background)) 75%, black);
     --p-color-bg-2: hsl(var(--p-background));
     --p-color-bg-3: color-mix(in hsl, hsl(var(--p-background)) 75%, white);
@@ -196,6 +198,8 @@
     --p-popover-foreground: 0 0% 98%;
 
     --p-color-bg-0: hsl(var(--p-background));
+
+    /* In dark mode, we first go light then incrementally darken nested cards. */
     --p-color-bg-1: color-mix(in hsl, hsl(var(--p-background)) 25%, white);
     --p-color-bg-2: hsl(var(--p-background));
     --p-color-bg-3: color-mix(in hsl, hsl(var(--p-background)) 75%, black);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -38,12 +38,16 @@
     color-scheme: dark;
 
     /* Background */
-    --p-color-bg-0: #26272B;
-    --p-color-bg-1: #1C1D20;
-    --p-color-bg-2: var(--p-color-bg-0);
-    --p-color-bg-3: #303237;
-    --p-color-bg-floating: #35363C;
-    --p-color-bg-floating-sticky: rgba(28, 29, 32, 0.9);
+    --p-background: 228 6% 16%;
+    --p-popover-foreground: 228 6% 22%;
+    
+    --p-color-bg-0: hsl(var(--p-background));
+    --p-color-bg-1: color-mix(in hsl, hsl(var(--p-background)) 75%, black);
+    --p-color-bg-2: hsl(var(--p-background));
+    --p-color-bg-3: color-mix(in hsl, hsl(var(--p-background)) 75%, white);
+    --p-color-bg-floating: hsl(var(--p-popover-foreground));
+    --p-color-bg-floating-sticky: hsl(var(--p-popover-foreground) / 90%);
+    
     --p-color-bg-code: #121317;
     --p-color-bg-overlay: rgba(0, 0, 0, 0.5);
 
@@ -188,15 +192,16 @@
   .light {
     color-scheme: light;
 
-    
+    --p-background: 0 0% 96%; 
+    --p-popover-foreground: 0 0% 98%;
 
-    /* Background */
-    --p-color-bg-0: #EFEFF0;
-    --p-color-bg-1: #FFFFFF;
-    --p-color-bg-2: #F5F5F5;
-    --p-color-bg-3: #EAEAEA;
-    --p-color-bg-floating: #FAFAFA;
-    --p-color-bg-floating-sticky: rgba(255, 255, 255, 0.8);
+    --p-color-bg-0: hsl(var(--p-background));
+    --p-color-bg-1: color-mix(in hsl, hsl(var(--p-background)) 25%, white);
+    --p-color-bg-2: hsl(var(--p-background));
+    --p-color-bg-3: color-mix(in hsl, hsl(var(--p-background)) 75%, black);
+    --p-color-bg-floating: hsl(var(--p-popover-foreground));
+    --p-color-bg-floating-sticky: hsl(var(--p-popover-foreground) / 90%);
+
     --p-color-bg-code: #DEDEE3;
     --p-color-bg-overlay: rgba(0, 0, 0, 0.5);
 


### PR DESCRIPTION
This PR standardizes our background palette to be a single line in HSL space, e.g. "there's a base hue/saturation and other shades are just white/black mixins with it". Previously our color palette were more or less small perturbations around an HSL line. This doesn't change our application visually, yet -- but sets us up to do so much more easily. 

Note this makes use of the CSS function color-mix, which is supported in all major browsers since March 2023. 

<img width="1054" alt="Screenshot 2024-04-18 at 5 26 07 PM" src="https://github.com/PrefectHQ/prefect-design/assets/33043305/b2007140-07c4-4797-a905-d6cd2d27927b">
<img width="1041" alt="Screenshot 2024-04-18 at 5 26 46 PM" src="https://github.com/PrefectHQ/prefect-design/assets/33043305/7ce85233-e052-40da-b4f5-8e86f23e1d37">
<img width="1046" alt="Screenshot 2024-04-18 at 5 30 22 PM" src="https://github.com/PrefectHQ/prefect-design/assets/33043305/56259b65-ae1b-419d-be07-9c147f865b8e">
<img width="1055" alt="Screenshot 2024-04-18 at 5 29 52 PM" src="https://github.com/PrefectHQ/prefect-design/assets/33043305/d9ba4bd1-62eb-4b04-97f9-9835dd99f659">
