### PR TITLE
Standardize primary hue across design system

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -25,7 +25,7 @@
 
     --p-destructive: 4 74% 49%;
     --p-positive: 142 71% 45%;
-    --p-neutral: 240 5% 46%;
+    --p-neutral: 228 5% 46%;
     --p-warning: 40 92% 50%;
 
     --p-color-sentiment-positive: hsl(var(--p-positive));
@@ -38,43 +38,43 @@
     color-scheme: dark;
 
     /* Background */
-    --p-color-bg-0: hsl(228.0, 6.17%, 15.88%);
-    --p-color-bg-1: hsl(225.0, 6.67%, 11.76%);
+    --p-color-bg-0: hsl(228, 6.17%, 15.88%);
+    --p-color-bg-1: hsl(228, 6.67%, 11.76%);
     --p-color-bg-2: var(--p-color-bg-0);
-    --p-color-bg-3: hsl(222.9, 6.8%, 20.2%);
-    --p-color-bg-floating: hsl(231.4, 6.19%, 22.16%);
-    --p-color-bg-floating-sticky: hsl(225.0 6.67% 11.76% / 0.9);
-    --p-color-bg-code: hsl(228.0, 12.2%, 8.04%);
+    --p-color-bg-3: hsl(228, 6.8%, 20.2%);
+    --p-color-bg-floating: hsl(228, 6.19%, 22.16%);
+    --p-color-bg-floating-sticky: hsl(228 6.67% 11.76% / 0.9);
+    --p-color-bg-code: hsl(228, 12.2%, 8.04%);
     --p-color-bg-overlay: hsl(0.0 0.0% 0.0% / 0.5);
 
     /* Root Tokens */
-    --p-color-divider: hsl(234.5, 6.36%, 33.92%);
-    --p-color-divider-subdued: hsl(234.5, 6.36%, 33.92%);
-    --p-color-selection-highlight: hsl(211.9 100.0% 63.53% / 0.4);
-    --p-color-scrollbar-thumb: hsl(225.0, 1.98%, 39.61%);
-    --p-color-selected: hsl(215.3 20.32% 50.78% / 0.4);
-    --p-color-selectable-hover: hsl(215.3 20.32% 50.78% / 0.24);
-    --p-color-focus-ring: hsl(217.8, 80.0%, 52.94%);
+    --p-color-divider: hsl(228, 6.36%, 33.92%);
+    --p-color-divider-subdued: hsl(228, 6.36%, 33.92%);
+    --p-color-selection-highlight: hsl(228 100.0% 63.53% / 0.4);
+    --p-color-scrollbar-thumb: hsl(228, 1.98%, 39.61%);
+    --p-color-selected: hsl(228 20.32% 50.78% / 0.4);
+    --p-color-selectable-hover: hsl(228 20.32% 50.78% / 0.24);
+    --p-color-focus-ring: hsl(228, 80.0%, 52.94%);
     --p-color-focus-ring-offset: var(--p-color-bg-0);
 
-    --p-color-live: hsl(233.9, 100.0%, 69.22%);
+    --p-color-live: hsl(228, 100.0%, 69.22%);
 
     /* Text */
     --p-color-text-default: hsl(0.0, 0.0%, 100.0%);
     --p-color-text-subdued: hsl(0.0, 0.0%, 67.84%);
     --p-color-text-inverse: hsl(0.0, 0.0%, 9.02%);
     --p-color-text-link: hsl(206.8, 97.7%, 65.88%);
-    --p-color-text-code: hsl(226.2, 11.71%, 78.24%);
+    --p-color-text-code: hsl(228, 11.71%, 78.24%);
     --p-color-text-invalid: var(--p-color-sentiment-negative);
     --p-color-text-selected: hsl(195.0, 52.38%, 50.59%);
 
     /* Syntax Highlighting */
-    --p-color-syntax-comment: hsl(226.4, 9.57%, 45.1%);
+    --p-color-syntax-comment: hsl(228, 9.57%, 45.1%);
     --p-color-syntax-selector: hsl(356.6, 69.31%, 60.39%);
     --p-color-syntax-parameter: hsl(36.1, 73.21%, 59.02%);
     --p-color-syntax-attribute: hsl(21.7, 69.05%, 50.59%);
     --p-color-syntax-symbol: hsl(159.9, 82.27%, 39.8%);
-    --p-color-syntax-title: hsl(226.3, 100.0%, 67.45%);
+    --p-color-syntax-title: hsl(228, 100.0%, 67.45%);
     --p-color-syntax-keyword: hsl(313.3, 69.31%, 60.39%);
 
     /* Input */
@@ -90,7 +90,7 @@
     --p-color-input-border-invalid: var(--p-color-sentiment-negative);
     --p-color-input-text-invalid-icon: var(--p-color-sentiment-negative);
 
-    --p-color-input-checked-bg: hsl(218.0, 80.34%, 45.88%);
+    --p-color-input-checked-bg: hsl(228, 80.34%, 45.88%);
     --p-color-input-checked-border: var(--p-color-selected);
     --p-color-input-checked-text: var(--p-color-text-default);
 
@@ -108,17 +108,17 @@
     --p-color-button-default-bg-hover: var(--p-color-button-default-bg);
     --p-color-button-default-border-hover: var(--p-color-text-subdued);
     --p-color-button-default-text-hover: var(--p-color-button-default-text);
-    --p-color-button-default-bg-active: hsl(220.0, 6.98%, 8.43%);
+    --p-color-button-default-bg-active: hsl(228, 6.98%, 8.43%);
     --p-color-button-default-border-active: var(--p-color-button-default-border-hover);
     --p-color-button-default-text-active: var(--p-color-button-default-text-hover);
 
-    --p-color-button-primary-bg: hsl(218.0, 80.34%, 45.88%);
+    --p-color-button-primary-bg: hsl(228, 80.34%, 45.88%);
     --p-color-button-primary-border: transparent;
     --p-color-button-primary-text: var(--p-color-text-default);
-    --p-color-button-primary-bg-hover: hsl(217.9, 89.92%, 53.33%);
+    --p-color-button-primary-bg-hover: hsl(228, 89.92%, 53.33%);
     --p-color-button-primary-border-hover: var(--p-color-button-primary-border);
     --p-color-button-primary-text-hover: var(--p-color-button-primary-text);
-    --p-color-button-primary-bg-active: hsl(217.8, 89.8%, 38.43%);
+    --p-color-button-primary-bg-active: hsl(228, 89.8%, 38.43%);
     --p-color-button-primary-border-active: var(--p-color-button-primary-border-hover);
     --p-color-button-primary-text-active: var(--p-color-button-primary-text-hover);
 
@@ -145,10 +145,10 @@
     --p-color-button-flat-bg: transparent;
     --p-color-button-flat-border: transparent;
     --p-color-button-flat-text: var(--p-color-text-default);
-    --p-color-button-flat-bg-hover: hsl(240.0 4.68% 46.08% / 0.4);
+    --p-color-button-flat-bg-hover: hsl(228 4.68% 46.08% / 0.4);
     --p-color-button-flat-border-hover: var(--p-color-button-flat-border);
     --p-color-button-flat-text-hover: var(--p-color-button-flat-text);
-    --p-color-button-flat-bg-active: hsl(240.0 4.68% 46.08% / 0.8);
+    --p-color-button-flat-bg-active: hsl(228 4.68% 46.08% / 0.8);
     --p-color-button-flat-border-active: var(--p-color-button-flat-border-hover);
     --p-color-button-flat-text-active: var(--p-color-button-flat-text-hover);
 
@@ -167,7 +167,7 @@
     --p-color-button-selected-text: var(--p-color-text-default);
 
     /* Message */
-    --p-color-message-info-bg: hsl(217.7, 42.17%, 32.55%);
+    --p-color-message-info-bg: hsl(228, 42.17%, 32.55%);
     --p-color-message-info-text: var(--p-color-text-default);
 
     --p-color-message-warning-bg: var(--p-color-sentiment-warning);
@@ -191,43 +191,43 @@
     
 
     /* Background */
-    --p-color-bg-0: hsl(240.0, 3.23%, 93.92%);
-    --p-color-bg-1: hsl(0.0, 0.0%, 100.0%);
-    --p-color-bg-2: hsl(0.0, 0.0%, 96.08%);
-    --p-color-bg-3: hsl(0.0, 0.0%, 91.76%);
-    --p-color-bg-floating: hsl(0.0, 0.0%, 98.04%);
-    --p-color-bg-floating-sticky: hsl(0.0 0.0% 100.0% / 0.8);
-    --p-color-bg-code: hsl(240.0, 8.2%, 88.04%);
+    --p-color-bg-0: hsl(228, 3.23%, 93.92%);
+    --p-color-bg-1: hsl(228, 0.0%, 100.0%);
+    --p-color-bg-2: hsl(228, 0.0%, 96.08%);
+    --p-color-bg-3: hsl(228, 0.0%, 91.76%);
+    --p-color-bg-floating: hsl(228, 0.0%, 98.04%);
+    --p-color-bg-floating-sticky: hsl(228 0.0% 100.0% / 0.8);
+    --p-color-bg-code: hsl(228, 8.2%, 88.04%);
     --p-color-bg-overlay: hsl(0.0 0.0% 0.0% / 0.5);
 
     /* Root Tokens */
-    --p-color-divider: hsl(240.0, 11.3%, 77.45%);
-    --p-color-divider-subdued: hsl(220.0, 14.29%, 95.88%);
-    --p-color-selection-highlight: hsl(211.9 100.0% 63.53% / 0.4);
-    --p-color-scrollbar-thumb: hsl(240.0, 1.04%, 62.35%);
-    --p-color-selected: hsl(228.0 17.93% 50.78% / 0.24);
-    --p-color-selectable-hover: hsl(228.0 17.93% 50.78% / 0.16);
-    --p-color-focus-ring: hsl(214.8, 87.25%, 50.78%);
+    --p-color-divider: hsl(228, 11.3%, 77.45%);
+    --p-color-divider-subdued: hsl(228, 14.29%, 95.88%);
+    --p-color-selection-highlight: hsl(228 100.0% 63.53% / 0.4);
+    --p-color-scrollbar-thumb: hsl(228, 1.04%, 62.35%);
+    --p-color-selected: hsl(228 17.93% 50.78% / 0.24);
+    --p-color-selectable-hover: hsl(228 17.93% 50.78% / 0.16);
+    --p-color-focus-ring: hsl(228, 87.25%, 50.78%);
     --p-color-focus-ring-offset: var(--p-color-bg-1);
 
-    --p-color-live: hsl(234.3, 100.0%, 64.71%);
+    --p-color-live: hsl(228, 100.0%, 64.71%);
 
     /* Text */
     --p-color-text-default: hsl(0.0, 0.0%, 9.02%);
-    --p-color-text-subdued: hsl(240.0, 4.68%, 46.08%);
+    --p-color-text-subdued: hsl(228, 4.68%, 46.08%);
     --p-color-text-inverse: hsl(0.0, 0.0%, 100.0%);
-    --p-color-text-link: hsl(214.8, 87.25%, 50.78%);
+    --p-color-text-link: hsl(228, 87.25%, 50.78%);
     --p-color-text-code: hsl(0.0, 0.0%, 23.92%);
     --p-color-text-invalid: var(--p-color-sentiment-negative);
     --p-color-text-selected: hsl(195.1, 58.38%, 38.63%);
 
     /* Syntax Highlighting */
-    --p-color-syntax-comment: hsl(226.4, 9.57%, 45.1%);
+    --p-color-syntax-comment: hsl(228, 9.57%, 45.1%);
     --p-color-syntax-selector: hsl(356.7, 81.22%, 51.96%);
     --p-color-syntax-parameter: hsl(36.1, 100.0%, 39.8%);
     --p-color-syntax-attribute: hsl(21.8, 100.0%, 43.73%);
     --p-color-syntax-symbol: hsl(159.7, 77.38%, 32.94%);
-    --p-color-syntax-title: hsl(226.3, 100.0%, 67.45%);
+    --p-color-syntax-title: hsl(228, 100.0%, 67.45%);
     --p-color-syntax-keyword: hsl(313.3, 69.31%, 60.39%);
 
     /* Input */
@@ -243,7 +243,7 @@
     --p-color-input-border-invalid: var(--p-color-sentiment-negative);
     --p-color-input-text-invalid-icon: var(--p-color-sentiment-negative);
 
-    --p-color-input-checked-bg: hsl(211.3, 96.24%, 58.24%);
+    --p-color-input-checked-bg: hsl(228, 96.24%, 58.24%);
     --p-color-input-checked-border: var(--p-color-selected);
     --p-color-input-checked-text: var(--p-color-text-default);
 
@@ -262,17 +262,17 @@
     --p-color-button-default-bg-hover: var(--p-color-button-default-bg);
     --p-color-button-default-border-hover: var(--p-color-text-subdued);
     --p-color-button-default-text-hover: var(--p-color-button-default-text);
-    --p-color-button-default-bg-active: hsl(240.0, 11.63%, 91.57%);
+    --p-color-button-default-bg-active: hsl(228, 11.63%, 91.57%);
     --p-color-button-default-border-active: var(--p-color-button-default-border-hover);
     --p-color-button-default-text-active: var(--p-color-button-default-text-hover);
 
-    --p-color-button-primary-bg: hsl(218.0, 80.34%, 45.88%);
+    --p-color-button-primary-bg: hsl(228, 80.34%, 45.88%);
     --p-color-button-primary-border: transparent;
     --p-color-button-primary-text: var(--p-color-text-inverse);
-    --p-color-button-primary-bg-hover: hsl(217.9, 89.92%, 53.33%);
+    --p-color-button-primary-bg-hover: hsl(228, 89.92%, 53.33%);
     --p-color-button-primary-border-hover: var(--p-color-button-primary-border);
     --p-color-button-primary-text-hover: var(--p-color-button-primary-text);
-    --p-color-button-primary-bg-active: hsl(217.8, 89.8%, 38.43%);
+    --p-color-button-primary-bg-active: hsl(228, 89.8%, 38.43%);
     --p-color-button-primary-border-active: var(--p-color-button-primary-border-hover);
     --p-color-button-primary-text-active: var(--p-color-button-primary-text-hover);
 
@@ -299,10 +299,10 @@
     --p-color-button-flat-bg: transparent;
     --p-color-button-flat-border: transparent;
     --p-color-button-flat-text: var(--p-color-text-default);
-    --p-color-button-flat-bg-hover: hsla(240, 4.7%, 46.1%, 0.4);
+    --p-color-button-flat-bg-hover: hsla(228, 4.7%, 46.1%, 0.4);
     --p-color-button-flat-border-hover: var(--p-color-button-flat-border);
     --p-color-button-flat-text-hover: var(--p-color-button-flat-text);
-    --p-color-button-flat-bg-active: hsl(240.0 4.68% 46.08% / 0.8);
+    --p-color-button-flat-bg-active: hsl(228 4.68% 46.08% / 0.8);
     --p-color-button-flat-border-active: var(--p-color-button-flat-border-hover);
     --p-color-button-flat-text-active: var(--p-color-button-flat-text-hover);
 
@@ -321,7 +321,7 @@
     --p-color-button-selected-text: var(--p-color-text-default);
 
     /* Message */
-    --p-color-message-info-bg: hsl(218.1, 100.0%, 85.49%);
+    --p-color-message-info-bg: hsl(228, 100.0%, 85.49%);
     --p-color-message-info-text: var(--p-color-text-default);
 
     --p-color-message-warning-bg: var(--p-color-sentiment-warning);
@@ -334,7 +334,7 @@
     --p-color-message-success-text: var(--p-color-text-inverse);
 
     /* Tag */
-    --p-color-tag-bg: hsl(240.0, 13.43%, 86.86%);
+    --p-color-tag-bg: hsl(228, 13.43%, 86.86%);
     --p-color-tag-border: transparent;
     --p-color-tag-text: var(--p-color-text-default);
   }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -23,9 +23,12 @@
     --p-radius-default: 6px;
     --p-scrollbar-width: 12px;
 
+    --p-primary-hue: 228;
+    --p-primary-saturation: 6%;
+
     --p-destructive: 4 74% 49%;
     --p-positive: 142 71% 45%;
-    --p-neutral: 228 5% 46%;
+    --p-neutral: var(--p-primary-hue) 5% 46%;
     --p-warning: 40 92% 50%;
 
     --p-color-sentiment-positive: hsl(var(--p-positive));
@@ -38,43 +41,43 @@
     color-scheme: dark;
 
     /* Background */
-    --p-color-bg-0: hsl(228, 6.17%, 15.88%);
-    --p-color-bg-1: hsl(228, 6.67%, 11.76%);
+    --p-color-bg-0: hsl(var(--p-primary-hue), var(--p-primary-saturation), 15.88%);
+    --p-color-bg-1: hsl(var(--p-primary-hue), var(--p-primary-saturation), 11.76%);
     --p-color-bg-2: var(--p-color-bg-0);
-    --p-color-bg-3: hsl(228, 6.8%, 20.2%);
-    --p-color-bg-floating: hsl(228, 6.19%, 22.16%);
-    --p-color-bg-floating-sticky: hsl(228 6.67% 11.76% / 0.9);
-    --p-color-bg-code: hsl(228, 12.2%, 8.04%);
+    --p-color-bg-3: hsl(var(--p-primary-hue), var(--p-primary-saturation), 20.2%);
+    --p-color-bg-floating: hsl(var(--p-primary-hue), var(--p-primary-saturation), 22.16%);
+    --p-color-bg-floating-sticky: hsl(var(--p-primary-hue) 6.67% 11.76% / 0.9);
+    --p-color-bg-code: hsl(var(--p-primary-hue), 12.2%, 8.04%);
     --p-color-bg-overlay: hsl(0.0 0.0% 0.0% / 0.5);
 
     /* Root Tokens */
-    --p-color-divider: hsl(228, 6.36%, 33.92%);
-    --p-color-divider-subdued: hsl(228, 6.36%, 33.92%);
-    --p-color-selection-highlight: hsl(228 100.0% 63.53% / 0.4);
-    --p-color-scrollbar-thumb: hsl(228, 1.98%, 39.61%);
-    --p-color-selected: hsl(228 20.32% 50.78% / 0.4);
-    --p-color-selectable-hover: hsl(228 20.32% 50.78% / 0.24);
-    --p-color-focus-ring: hsl(228, 80.0%, 52.94%);
+    --p-color-divider: hsl(var(--p-primary-hue), var(--p-primary-saturation), 33.92%);
+    --p-color-divider-subdued: hsl(var(--p-primary-hue), var(--p-primary-saturation), 33.92%);
+    --p-color-selection-highlight: hsl(var(--p-primary-hue) 100.0% 63.53% / 0.4);
+    --p-color-scrollbar-thumb: hsl(var(--p-primary-hue), 1.98%, 39.61%);
+    --p-color-selected: hsl(var(--p-primary-hue) 20.32% 50.78% / 0.4);
+    --p-color-selectable-hover: hsl(var(--p-primary-hue) 20.32% 50.78% / 0.24);
+    --p-color-focus-ring: hsl(var(--p-primary-hue), 80.0%, 52.94%);
     --p-color-focus-ring-offset: var(--p-color-bg-0);
 
-    --p-color-live: hsl(228, 100.0%, 69.22%);
+    --p-color-live: hsl(var(--p-primary-hue), 100.0%, 69.22%);
 
     /* Text */
     --p-color-text-default: hsl(0.0, 0.0%, 100.0%);
     --p-color-text-subdued: hsl(0.0, 0.0%, 67.84%);
     --p-color-text-inverse: hsl(0.0, 0.0%, 9.02%);
     --p-color-text-link: hsl(206.8, 97.7%, 65.88%);
-    --p-color-text-code: hsl(228, 11.71%, 78.24%);
+    --p-color-text-code: hsl(var(--p-primary-hue), 11.71%, 78.24%);
     --p-color-text-invalid: var(--p-color-sentiment-negative);
     --p-color-text-selected: hsl(195.0, 52.38%, 50.59%);
 
     /* Syntax Highlighting */
-    --p-color-syntax-comment: hsl(228, 9.57%, 45.1%);
+    --p-color-syntax-comment: hsl(var(--p-primary-hue), 9.57%, 45.1%);
     --p-color-syntax-selector: hsl(356.6, 69.31%, 60.39%);
     --p-color-syntax-parameter: hsl(36.1, 73.21%, 59.02%);
     --p-color-syntax-attribute: hsl(21.7, 69.05%, 50.59%);
     --p-color-syntax-symbol: hsl(159.9, 82.27%, 39.8%);
-    --p-color-syntax-title: hsl(228, 100.0%, 67.45%);
+    --p-color-syntax-title: hsl(var(--p-primary-hue), 100.0%, 67.45%);
     --p-color-syntax-keyword: hsl(313.3, 69.31%, 60.39%);
 
     /* Input */
@@ -90,7 +93,7 @@
     --p-color-input-border-invalid: var(--p-color-sentiment-negative);
     --p-color-input-text-invalid-icon: var(--p-color-sentiment-negative);
 
-    --p-color-input-checked-bg: hsl(228, 80.34%, 45.88%);
+    --p-color-input-checked-bg: hsl(var(--p-primary-hue), 80.34%, 45.88%);
     --p-color-input-checked-border: var(--p-color-selected);
     --p-color-input-checked-text: var(--p-color-text-default);
 
@@ -108,17 +111,17 @@
     --p-color-button-default-bg-hover: var(--p-color-button-default-bg);
     --p-color-button-default-border-hover: var(--p-color-text-subdued);
     --p-color-button-default-text-hover: var(--p-color-button-default-text);
-    --p-color-button-default-bg-active: hsl(228, 6.98%, 8.43%);
+    --p-color-button-default-bg-active: hsl(var(--p-primary-hue), var(--p-primary-saturation), 8.43%);
     --p-color-button-default-border-active: var(--p-color-button-default-border-hover);
     --p-color-button-default-text-active: var(--p-color-button-default-text-hover);
 
-    --p-color-button-primary-bg: hsl(228, 80.34%, 45.88%);
+    --p-color-button-primary-bg: hsl(var(--p-primary-hue), 80.34%, 45.88%);
     --p-color-button-primary-border: transparent;
     --p-color-button-primary-text: var(--p-color-text-default);
-    --p-color-button-primary-bg-hover: hsl(228, 89.92%, 53.33%);
+    --p-color-button-primary-bg-hover: hsl(var(--p-primary-hue), 89.92%, 53.33%);
     --p-color-button-primary-border-hover: var(--p-color-button-primary-border);
     --p-color-button-primary-text-hover: var(--p-color-button-primary-text);
-    --p-color-button-primary-bg-active: hsl(228, 89.8%, 38.43%);
+    --p-color-button-primary-bg-active: hsl(var(--p-primary-hue), 89.8%, 38.43%);
     --p-color-button-primary-border-active: var(--p-color-button-primary-border-hover);
     --p-color-button-primary-text-active: var(--p-color-button-primary-text-hover);
 
@@ -145,10 +148,10 @@
     --p-color-button-flat-bg: transparent;
     --p-color-button-flat-border: transparent;
     --p-color-button-flat-text: var(--p-color-text-default);
-    --p-color-button-flat-bg-hover: hsl(228 4.68% 46.08% / 0.4);
+    --p-color-button-flat-bg-hover: hsl(var(--p-primary-hue) 4.68% 46.08% / 0.4);
     --p-color-button-flat-border-hover: var(--p-color-button-flat-border);
     --p-color-button-flat-text-hover: var(--p-color-button-flat-text);
-    --p-color-button-flat-bg-active: hsl(228 4.68% 46.08% / 0.8);
+    --p-color-button-flat-bg-active: hsl(var(--p-primary-hue) 4.68% 46.08% / 0.8);
     --p-color-button-flat-border-active: var(--p-color-button-flat-border-hover);
     --p-color-button-flat-text-active: var(--p-color-button-flat-text-hover);
 
@@ -167,7 +170,7 @@
     --p-color-button-selected-text: var(--p-color-text-default);
 
     /* Message */
-    --p-color-message-info-bg: hsl(228, 42.17%, 32.55%);
+    --p-color-message-info-bg: hsl(var(--p-primary-hue), 42.17%, 32.55%);
     --p-color-message-info-text: var(--p-color-text-default);
 
     --p-color-message-warning-bg: var(--p-color-sentiment-warning);
@@ -191,43 +194,43 @@
     
 
     /* Background */
-    --p-color-bg-0: hsl(228, 3.23%, 93.92%);
-    --p-color-bg-1: hsl(228, 0.0%, 100.0%);
-    --p-color-bg-2: hsl(228, 0.0%, 96.08%);
-    --p-color-bg-3: hsl(228, 0.0%, 91.76%);
-    --p-color-bg-floating: hsl(228, 0.0%, 98.04%);
-    --p-color-bg-floating-sticky: hsl(228 0.0% 100.0% / 0.8);
-    --p-color-bg-code: hsl(228, 8.2%, 88.04%);
+    --p-color-bg-0: hsl(var(--p-primary-hue), 3.23%, 93.92%);
+    --p-color-bg-1: hsl(var(--p-primary-hue), 0.0%, 100.0%);
+    --p-color-bg-2: hsl(var(--p-primary-hue), 0.0%, 96.08%);
+    --p-color-bg-3: hsl(var(--p-primary-hue), 0.0%, 91.76%);
+    --p-color-bg-floating: hsl(var(--p-primary-hue), 0.0%, 98.04%);
+    --p-color-bg-floating-sticky: hsl(var(--p-primary-hue) 0.0% 100.0% / 0.8);
+    --p-color-bg-code: hsl(var(--p-primary-hue), 8.2%, 88.04%);
     --p-color-bg-overlay: hsl(0.0 0.0% 0.0% / 0.5);
 
     /* Root Tokens */
-    --p-color-divider: hsl(228, 11.3%, 77.45%);
-    --p-color-divider-subdued: hsl(228, 14.29%, 95.88%);
-    --p-color-selection-highlight: hsl(228 100.0% 63.53% / 0.4);
-    --p-color-scrollbar-thumb: hsl(228, 1.04%, 62.35%);
-    --p-color-selected: hsl(228 17.93% 50.78% / 0.24);
-    --p-color-selectable-hover: hsl(228 17.93% 50.78% / 0.16);
-    --p-color-focus-ring: hsl(228, 87.25%, 50.78%);
+    --p-color-divider: hsl(var(--p-primary-hue), 11.3%, 77.45%);
+    --p-color-divider-subdued: hsl(var(--p-primary-hue), 14.29%, 95.88%);
+    --p-color-selection-highlight: hsl(var(--p-primary-hue) 100.0% 63.53% / 0.4);
+    --p-color-scrollbar-thumb: hsl(var(--p-primary-hue), 1.04%, 62.35%);
+    --p-color-selected: hsl(var(--p-primary-hue) 17.93% 50.78% / 0.24);
+    --p-color-selectable-hover: hsl(var(--p-primary-hue) 17.93% 50.78% / 0.16);
+    --p-color-focus-ring: hsl(var(--p-primary-hue), 87.25%, 50.78%);
     --p-color-focus-ring-offset: var(--p-color-bg-1);
 
-    --p-color-live: hsl(228, 100.0%, 64.71%);
+    --p-color-live: hsl(var(--p-primary-hue), 100.0%, 64.71%);
 
     /* Text */
     --p-color-text-default: hsl(0.0, 0.0%, 9.02%);
-    --p-color-text-subdued: hsl(228, 4.68%, 46.08%);
+    --p-color-text-subdued: hsl(var(--p-primary-hue), var(--p-primary-saturation), 46.08%);
     --p-color-text-inverse: hsl(0.0, 0.0%, 100.0%);
-    --p-color-text-link: hsl(228, 87.25%, 50.78%);
+    --p-color-text-link: hsl(var(--p-primary-hue), 87.25%, 50.78%);
     --p-color-text-code: hsl(0.0, 0.0%, 23.92%);
     --p-color-text-invalid: var(--p-color-sentiment-negative);
     --p-color-text-selected: hsl(195.1, 58.38%, 38.63%);
 
     /* Syntax Highlighting */
-    --p-color-syntax-comment: hsl(228, 9.57%, 45.1%);
+    --p-color-syntax-comment: hsl(var(--p-primary-hue), 9.57%, 45.1%);
     --p-color-syntax-selector: hsl(356.7, 81.22%, 51.96%);
     --p-color-syntax-parameter: hsl(36.1, 100.0%, 39.8%);
     --p-color-syntax-attribute: hsl(21.8, 100.0%, 43.73%);
     --p-color-syntax-symbol: hsl(159.7, 77.38%, 32.94%);
-    --p-color-syntax-title: hsl(228, 100.0%, 67.45%);
+    --p-color-syntax-title: hsl(var(--p-primary-hue), 100.0%, 67.45%);
     --p-color-syntax-keyword: hsl(313.3, 69.31%, 60.39%);
 
     /* Input */
@@ -243,7 +246,7 @@
     --p-color-input-border-invalid: var(--p-color-sentiment-negative);
     --p-color-input-text-invalid-icon: var(--p-color-sentiment-negative);
 
-    --p-color-input-checked-bg: hsl(228, 96.24%, 58.24%);
+    --p-color-input-checked-bg: hsl(var(--p-primary-hue), 96.24%, 58.24%);
     --p-color-input-checked-border: var(--p-color-selected);
     --p-color-input-checked-text: var(--p-color-text-default);
 
@@ -262,17 +265,17 @@
     --p-color-button-default-bg-hover: var(--p-color-button-default-bg);
     --p-color-button-default-border-hover: var(--p-color-text-subdued);
     --p-color-button-default-text-hover: var(--p-color-button-default-text);
-    --p-color-button-default-bg-active: hsl(228, 11.63%, 91.57%);
+    --p-color-button-default-bg-active: hsl(var(--p-primary-hue), 11.63%, 91.57%);
     --p-color-button-default-border-active: var(--p-color-button-default-border-hover);
     --p-color-button-default-text-active: var(--p-color-button-default-text-hover);
 
-    --p-color-button-primary-bg: hsl(228, 80.34%, 45.88%);
+    --p-color-button-primary-bg: hsl(var(--p-primary-hue), 80.34%, 45.88%);
     --p-color-button-primary-border: transparent;
     --p-color-button-primary-text: var(--p-color-text-inverse);
-    --p-color-button-primary-bg-hover: hsl(228, 89.92%, 53.33%);
+    --p-color-button-primary-bg-hover: hsl(var(--p-primary-hue), 89.92%, 53.33%);
     --p-color-button-primary-border-hover: var(--p-color-button-primary-border);
     --p-color-button-primary-text-hover: var(--p-color-button-primary-text);
-    --p-color-button-primary-bg-active: hsl(228, 89.8%, 38.43%);
+    --p-color-button-primary-bg-active: hsl(var(--p-primary-hue), 89.8%, 38.43%);
     --p-color-button-primary-border-active: var(--p-color-button-primary-border-hover);
     --p-color-button-primary-text-active: var(--p-color-button-primary-text-hover);
 
@@ -299,10 +302,10 @@
     --p-color-button-flat-bg: transparent;
     --p-color-button-flat-border: transparent;
     --p-color-button-flat-text: var(--p-color-text-default);
-    --p-color-button-flat-bg-hover: hsla(228, 4.7%, 46.1%, 0.4);
+    --p-color-button-flat-bg-hover: hsla(var(--p-primary-hue), var(--p-primary-saturation), 46.1%, 0.4);
     --p-color-button-flat-border-hover: var(--p-color-button-flat-border);
     --p-color-button-flat-text-hover: var(--p-color-button-flat-text);
-    --p-color-button-flat-bg-active: hsl(228 4.68% 46.08% / 0.8);
+    --p-color-button-flat-bg-active: hsl(var(--p-primary-hue) 4.68% 46.08% / 0.8);
     --p-color-button-flat-border-active: var(--p-color-button-flat-border-hover);
     --p-color-button-flat-text-active: var(--p-color-button-flat-text-hover);
 
@@ -321,7 +324,7 @@
     --p-color-button-selected-text: var(--p-color-text-default);
 
     /* Message */
-    --p-color-message-info-bg: hsl(228, 100.0%, 85.49%);
+    --p-color-message-info-bg: hsl(var(--p-primary-hue), 100.0%, 85.49%);
     --p-color-message-info-text: var(--p-color-text-default);
 
     --p-color-message-warning-bg: var(--p-color-sentiment-warning);
@@ -334,7 +337,7 @@
     --p-color-message-success-text: var(--p-color-text-inverse);
 
     /* Tag */
-    --p-color-tag-bg: hsl(228, 13.43%, 86.86%);
+    --p-color-tag-bg: hsl(var(--p-primary-hue), 13.43%, 86.86%);
     --p-color-tag-border: transparent;
     --p-color-tag-text: var(--p-color-text-default);
   }


### PR DESCRIPTION
Prefect uses hsl(228+-, 6+-, lightness) to parameterize a family of blues to create depth throughout its UI. 

This PR collapses the small variations in hue and saturation to create a better-practice family of background depths. 

The thirteen or so primary color variations are collapsed to the single one in red:

![image](https://github.com/PrefectHQ/prefect-design/assets/33043305/92b05da2-2adf-4285-944d-728a75e04e1b)
 
This has little-to-no visual distinction in the UI, but sets us up for a better devex against this smaller surface area of colors. 