### PR TITLE
Cast lightness palette to a 4% grid

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -23,7 +23,7 @@
     --p-radius-default: 6px;
     --p-scrollbar-width: 12px;
 
-    /* Prefect Blue is 218, 100, 50  */
+    /* Prefect Blue is 219, 100, 50  */
     --p-primary-hue: 228;
 
     --p-destructive: 4 74% 49%;
@@ -41,43 +41,44 @@
     color-scheme: dark;
 
     /* Background */
-    --p-color-bg-0: hsl(var(--p-primary-hue), 6%, 15.88%);
-    --p-color-bg-1: hsl(var(--p-primary-hue), 6%, 11.76%);
-    --p-color-bg-2: var(--p-color-bg-0);
-    --p-color-bg-3: hsl(var(--p-primary-hue), 6%, 20.2%);
-    --p-color-bg-floating: hsl(var(--p-primary-hue), 6%, 22.16%);
-    --p-color-bg-floating-sticky: hsl(var(--p-primary-hue) 6.67% 11.76% / 0.9);
-    --p-color-bg-code: hsl(var(--p-primary-hue), 12.2%, 8.04%);
+    --p-color-bg-0: hsl(var(--p-primary-hue), 6%, 16%);
+    --p-color-bg-1: hsl(var(--p-primary-hue), 6%, 12%);
+    --p-color-bg-2: hsl(var(--p-primary-hue), 6%, 16%);
+    --p-color-bg-3: hsl(var(--p-primary-hue), 6%, 20%);
+
+    --p-color-bg-floating: hsl(var(--p-primary-hue), 6%, 24%);
+    --p-color-bg-floating-sticky: hsl(var(--p-primary-hue) 6% 12% / 0.9);
+    --p-color-bg-code: hsl(var(--p-primary-hue), 6%, 8%);
     --p-color-bg-overlay: hsl(0.0 0.0% 0.0% / 0.5);
 
     /* Root Tokens */
-    --p-color-divider: hsl(var(--p-primary-hue), 6%, 33.92%);
-    --p-color-divider-subdued: hsl(var(--p-primary-hue), 6%, 33.92%);
-    --p-color-selection-highlight: hsl(var(--p-primary-hue) 100.0% 63.53% / 0.4);
-    --p-color-scrollbar-thumb: hsl(var(--p-primary-hue), 1.98%, 39.61%);
-    --p-color-selected: hsl(var(--p-primary-hue) 20.32% 50.78% / 0.4);
-    --p-color-selectable-hover: hsl(var(--p-primary-hue) 20.32% 50.78% / 0.24);
-    --p-color-focus-ring: hsl(var(--p-primary-hue), 80.0%, 52.94%);
+    --p-color-divider: hsl(var(--p-primary-hue), 6%, 32%);
+    --p-color-divider-subdued: hsl(var(--p-primary-hue), 6%, 32%);
+    --p-color-selection-highlight: hsl(var(--p-primary-hue) 100.0% 64% / 0.4);
+    --p-color-scrollbar-thumb: hsl(var(--p-primary-hue), 1.98%, 36%);
+    --p-color-selected: hsl(var(--p-primary-hue) 20.32% 52% / 0.4);
+    --p-color-selectable-hover: hsl(var(--p-primary-hue) 20.32% 52% / 0.24);
+    --p-color-focus-ring: hsl(var(--p-primary-hue), 80.0%, 52%);
     --p-color-focus-ring-offset: var(--p-color-bg-0);
 
-    --p-color-live: hsl(var(--p-primary-hue), 100.0%, 69.22%);
+    --p-color-live: hsl(var(--p-primary-hue), 100.0%, 68%);
 
     /* Text */
     --p-color-text-default: hsl(0.0, 0.0%, 100.0%);
     --p-color-text-subdued: hsl(0.0, 0.0%, 67.84%);
     --p-color-text-inverse: hsl(0.0, 0.0%, 9.02%);
     --p-color-text-link: hsl(206.8, 97.7%, 65.88%);
-    --p-color-text-code: hsl(var(--p-primary-hue), 11.71%, 78.24%);
+    --p-color-text-code: hsl(var(--p-primary-hue), 11.71%, 78%);
     --p-color-text-invalid: var(--p-color-sentiment-negative);
     --p-color-text-selected: hsl(195.0, 52.38%, 50.59%);
 
     /* Syntax Highlighting */
-    --p-color-syntax-comment: hsl(var(--p-primary-hue), 9.57%, 45.1%);
+    --p-color-syntax-comment: hsl(var(--p-primary-hue), 9.57%, 44%);
     --p-color-syntax-selector: hsl(356.6, 69.31%, 60.39%);
     --p-color-syntax-parameter: hsl(36.1, 73.21%, 59.02%);
     --p-color-syntax-attribute: hsl(21.7, 69.05%, 50.59%);
     --p-color-syntax-symbol: hsl(159.9, 82.27%, 39.8%);
-    --p-color-syntax-title: hsl(var(--p-primary-hue), 100.0%, 67.45%);
+    --p-color-syntax-title: hsl(var(--p-primary-hue), 100.0%, 68%);
     --p-color-syntax-keyword: hsl(313.3, 69.31%, 60.39%);
 
     /* Input */
@@ -93,7 +94,7 @@
     --p-color-input-border-invalid: var(--p-color-sentiment-negative);
     --p-color-input-text-invalid-icon: var(--p-color-sentiment-negative);
 
-    --p-color-input-checked-bg: hsl(var(--p-primary-hue), 80.34%, 45.88%);
+    --p-color-input-checked-bg: hsl(var(--p-primary-hue), 80.34%, 44%);
     --p-color-input-checked-border: var(--p-color-selected);
     --p-color-input-checked-text: var(--p-color-text-default);
 
@@ -111,17 +112,17 @@
     --p-color-button-default-bg-hover: var(--p-color-button-default-bg);
     --p-color-button-default-border-hover: var(--p-color-text-subdued);
     --p-color-button-default-text-hover: var(--p-color-button-default-text);
-    --p-color-button-default-bg-active: hsl(var(--p-primary-hue), 6%, 8.43%);
+    --p-color-button-default-bg-active: hsl(var(--p-primary-hue), 6%, 8%);
     --p-color-button-default-border-active: var(--p-color-button-default-border-hover);
     --p-color-button-default-text-active: var(--p-color-button-default-text-hover);
 
-    --p-color-button-primary-bg: hsl(var(--p-primary-hue), 80.34%, 45.88%);
+    --p-color-button-primary-bg: hsl(var(--p-primary-hue), 80.34%, 44%);
     --p-color-button-primary-border: transparent;
     --p-color-button-primary-text: var(--p-color-text-default);
-    --p-color-button-primary-bg-hover: hsl(var(--p-primary-hue), 89.92%, 53.33%);
+    --p-color-button-primary-bg-hover: hsl(var(--p-primary-hue), 89.92%, 52%);
     --p-color-button-primary-border-hover: var(--p-color-button-primary-border);
     --p-color-button-primary-text-hover: var(--p-color-button-primary-text);
-    --p-color-button-primary-bg-active: hsl(var(--p-primary-hue), 89.8%, 38.43%);
+    --p-color-button-primary-bg-active: hsl(var(--p-primary-hue), 89.8%, 40%);
     --p-color-button-primary-border-active: var(--p-color-button-primary-border-hover);
     --p-color-button-primary-text-active: var(--p-color-button-primary-text-hover);
 
@@ -148,10 +149,10 @@
     --p-color-button-flat-bg: transparent;
     --p-color-button-flat-border: transparent;
     --p-color-button-flat-text: var(--p-color-text-default);
-    --p-color-button-flat-bg-hover: hsl(var(--p-primary-hue) 4.68% 46.08% / 0.4);
+    --p-color-button-flat-bg-hover: hsl(var(--p-primary-hue) 4.68% 44% / 0.4);
     --p-color-button-flat-border-hover: var(--p-color-button-flat-border);
     --p-color-button-flat-text-hover: var(--p-color-button-flat-text);
-    --p-color-button-flat-bg-active: hsl(var(--p-primary-hue) 4.68% 46.08% / 0.8);
+    --p-color-button-flat-bg-active: hsl(var(--p-primary-hue) 4.68% 48% / 0.8);
     --p-color-button-flat-border-active: var(--p-color-button-flat-border-hover);
     --p-color-button-flat-text-active: var(--p-color-button-flat-text-hover);
 
@@ -170,7 +171,7 @@
     --p-color-button-selected-text: var(--p-color-text-default);
 
     /* Message */
-    --p-color-message-info-bg: hsl(var(--p-primary-hue), 42.17%, 32.55%);
+    --p-color-message-info-bg: hsl(var(--p-primary-hue), 42.17%, 32%);
     --p-color-message-info-text: var(--p-color-text-default);
 
     --p-color-message-warning-bg: var(--p-color-sentiment-warning);
@@ -194,43 +195,43 @@
     
 
     /* Background */
-    --p-color-bg-0: hsl(var(--p-primary-hue), 3.23%, 93.92%);
+    --p-color-bg-0: hsl(var(--p-primary-hue), 3.23%, 92%);
     --p-color-bg-1: hsl(var(--p-primary-hue), 0.0%, 100.0%);
-    --p-color-bg-2: hsl(var(--p-primary-hue), 0.0%, 96.08%);
-    --p-color-bg-3: hsl(var(--p-primary-hue), 0.0%, 91.76%);
-    --p-color-bg-floating: hsl(var(--p-primary-hue), 0.0%, 98.04%);
+    --p-color-bg-2: hsl(var(--p-primary-hue), 0.0%, 96%);
+    --p-color-bg-3: hsl(var(--p-primary-hue), 0.0%, 92%);
+    --p-color-bg-floating: hsl(var(--p-primary-hue), 0.0%, 100%);
     --p-color-bg-floating-sticky: hsl(var(--p-primary-hue) 0.0% 100.0% / 0.8);
-    --p-color-bg-code: hsl(var(--p-primary-hue), 8.2%, 88.04%);
+    --p-color-bg-code: hsl(var(--p-primary-hue), 8.2%, 88%);
     --p-color-bg-overlay: hsl(0.0 0.0% 0.0% / 0.5);
 
     /* Root Tokens */
-    --p-color-divider: hsl(var(--p-primary-hue), 11.3%, 77.45%);
-    --p-color-divider-subdued: hsl(var(--p-primary-hue), 14.29%, 95.88%);
-    --p-color-selection-highlight: hsl(var(--p-primary-hue) 100.0% 63.53% / 0.4);
-    --p-color-scrollbar-thumb: hsl(var(--p-primary-hue), 1.04%, 62.35%);
+    --p-color-divider: hsl(var(--p-primary-hue), 11.3%, 76%);
+    --p-color-divider-subdued: hsl(var(--p-primary-hue), 14.29%, 96%);
+    --p-color-selection-highlight: hsl(var(--p-primary-hue) 100.0% 64% / 0.4);
+    --p-color-scrollbar-thumb: hsl(var(--p-primary-hue), 1.04%, 64%);
     --p-color-selected: hsl(var(--p-primary-hue) 17.93% 50.78% / 0.24);
-    --p-color-selectable-hover: hsl(var(--p-primary-hue) 17.93% 50.78% / 0.16);
-    --p-color-focus-ring: hsl(var(--p-primary-hue), 87.25%, 50.78%);
+    --p-color-selectable-hover: hsl(var(--p-primary-hue) 17.93% 52% / 0.16);
+    --p-color-focus-ring: hsl(var(--p-primary-hue), 87.25%, 52%);
     --p-color-focus-ring-offset: var(--p-color-bg-1);
 
-    --p-color-live: hsl(var(--p-primary-hue), 100.0%, 64.71%);
+    --p-color-live: hsl(var(--p-primary-hue), 100.0%, 64%);
 
     /* Text */
     --p-color-text-default: hsl(0.0, 0.0%, 9.02%);
-    --p-color-text-subdued: hsl(var(--p-primary-hue), 6%, 46.08%);
+    --p-color-text-subdued: hsl(var(--p-primary-hue), 6%, 48%);
     --p-color-text-inverse: hsl(0.0, 0.0%, 100.0%);
-    --p-color-text-link: hsl(var(--p-primary-hue), 87.25%, 50.78%);
+    --p-color-text-link: hsl(var(--p-primary-hue), 87.25%, 52%);
     --p-color-text-code: hsl(0.0, 0.0%, 23.92%);
     --p-color-text-invalid: var(--p-color-sentiment-negative);
     --p-color-text-selected: hsl(195.1, 58.38%, 38.63%);
 
     /* Syntax Highlighting */
-    --p-color-syntax-comment: hsl(var(--p-primary-hue), 9.57%, 45.1%);
+    --p-color-syntax-comment: hsl(var(--p-primary-hue), 9.57%, 44%);
     --p-color-syntax-selector: hsl(356.7, 81.22%, 51.96%);
     --p-color-syntax-parameter: hsl(36.1, 100.0%, 39.8%);
     --p-color-syntax-attribute: hsl(21.8, 100.0%, 43.73%);
     --p-color-syntax-symbol: hsl(159.7, 77.38%, 32.94%);
-    --p-color-syntax-title: hsl(var(--p-primary-hue), 100.0%, 67.45%);
+    --p-color-syntax-title: hsl(var(--p-primary-hue), 100.0%, 68%);
     --p-color-syntax-keyword: hsl(313.3, 69.31%, 60.39%);
 
     /* Input */
@@ -246,7 +247,7 @@
     --p-color-input-border-invalid: var(--p-color-sentiment-negative);
     --p-color-input-text-invalid-icon: var(--p-color-sentiment-negative);
 
-    --p-color-input-checked-bg: hsl(var(--p-primary-hue), 96.24%, 58.24%);
+    --p-color-input-checked-bg: hsl(var(--p-primary-hue), 96.24%, 60%);
     --p-color-input-checked-border: var(--p-color-selected);
     --p-color-input-checked-text: var(--p-color-text-default);
 
@@ -265,17 +266,17 @@
     --p-color-button-default-bg-hover: var(--p-color-button-default-bg);
     --p-color-button-default-border-hover: var(--p-color-text-subdued);
     --p-color-button-default-text-hover: var(--p-color-button-default-text);
-    --p-color-button-default-bg-active: hsl(var(--p-primary-hue), 11.63%, 91.57%);
+    --p-color-button-default-bg-active: hsl(var(--p-primary-hue), 11.63%, 92%);
     --p-color-button-default-border-active: var(--p-color-button-default-border-hover);
     --p-color-button-default-text-active: var(--p-color-button-default-text-hover);
 
-    --p-color-button-primary-bg: hsl(var(--p-primary-hue), 80.34%, 45.88%);
+    --p-color-button-primary-bg: hsl(var(--p-primary-hue), 80.34%, 44%);
     --p-color-button-primary-border: transparent;
     --p-color-button-primary-text: var(--p-color-text-inverse);
-    --p-color-button-primary-bg-hover: hsl(var(--p-primary-hue), 89.92%, 53.33%);
+    --p-color-button-primary-bg-hover: hsl(var(--p-primary-hue), 89.92%, 52%);
     --p-color-button-primary-border-hover: var(--p-color-button-primary-border);
     --p-color-button-primary-text-hover: var(--p-color-button-primary-text);
-    --p-color-button-primary-bg-active: hsl(var(--p-primary-hue), 89.8%, 38.43%);
+    --p-color-button-primary-bg-active: hsl(var(--p-primary-hue), 89.8%, 40%);
     --p-color-button-primary-border-active: var(--p-color-button-primary-border-hover);
     --p-color-button-primary-text-active: var(--p-color-button-primary-text-hover);
 
@@ -302,10 +303,10 @@
     --p-color-button-flat-bg: transparent;
     --p-color-button-flat-border: transparent;
     --p-color-button-flat-text: var(--p-color-text-default);
-    --p-color-button-flat-bg-hover: hsla(var(--p-primary-hue), 6%, 46.1%, 0.4);
+    --p-color-button-flat-bg-hover: hsla(var(--p-primary-hue), 6%, 48%, 0.4);
     --p-color-button-flat-border-hover: var(--p-color-button-flat-border);
     --p-color-button-flat-text-hover: var(--p-color-button-flat-text);
-    --p-color-button-flat-bg-active: hsl(var(--p-primary-hue) 4.68% 46.08% / 0.8);
+    --p-color-button-flat-bg-active: hsl(var(--p-primary-hue) 4.68% 48% / 0.8);
     --p-color-button-flat-border-active: var(--p-color-button-flat-border-hover);
     --p-color-button-flat-text-active: var(--p-color-button-flat-text-hover);
 
@@ -324,7 +325,7 @@
     --p-color-button-selected-text: var(--p-color-text-default);
 
     /* Message */
-    --p-color-message-info-bg: hsl(var(--p-primary-hue), 100.0%, 85.49%);
+    --p-color-message-info-bg: hsl(var(--p-primary-hue), 100.0%, 84%);
     --p-color-message-info-text: var(--p-color-text-default);
 
     --p-color-message-warning-bg: var(--p-color-sentiment-warning);
@@ -337,7 +338,7 @@
     --p-color-message-success-text: var(--p-color-text-inverse);
 
     /* Tag */
-    --p-color-tag-bg: hsl(var(--p-primary-hue), 13.43%, 86.86%);
+    --p-color-tag-bg: hsl(var(--p-primary-hue), 13.43%, 88%);
     --p-color-tag-border: transparent;
     --p-color-tag-text: var(--p-color-text-default);
   }


### PR DESCRIPTION
Our design system samples lightness values more or less randomly clustered around increments of 4%. 

This PR casts our `lightness` values to a 4% grid. 

```css
    --p-color-bg-0: hsl(var(--p-primary-hue), 6%, 15.88%);
    --p-color-bg-1: hsl(var(--p-primary-hue), 6%, 11.76%);
    --p-color-bg-2: var(--p-color-bg-0);
    --p-color-bg-3: hsl(var(--p-primary-hue), 6%, 20.2%);
    --p-color-bg-floating: hsl(var(--p-primary-hue), 6%, 22.16%);
    --p-color-bg-floating-sticky: hsl(var(--p-primary-hue) 6.67% 11.76% / 0.9);
    --p-color-bg-code: hsl(var(--p-primary-hue), 12.2%, 8.04%);
    --p-color-bg-overlay: hsl(0.0 0.0% 0.0% / 0.5);
```

becomes

```css
    --p-color-bg-0: hsl(var(--p-primary-hue), 6%, 16%);
    --p-color-bg-1: hsl(var(--p-primary-hue), 6%, 12%);
    --p-color-bg-2: hsl(var(--p-primary-hue), 6%, 16%);
    --p-color-bg-3: hsl(var(--p-primary-hue), 6%, 20%);
    --p-color-bg-floating: hsl(var(--p-primary-hue), 6%, 24%);
    --p-color-bg-floating-sticky: hsl(var(--p-primary-hue) 6% 12% / 0.9);
    --p-color-bg-code: hsl(var(--p-primary-hue), 6%, 8%);
    --p-color-bg-overlay: hsl(0.0 0.0% 0.0% / 0.5);
```

The color changes here are more-or-less imperceptible, and shouldn't have noticeable changes to users. This is more of a form-over-function PR. 