### PR TITLE
Spike/Automated releases using shell script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,14 @@
 name: Release
 
 on:
-  push:
-    paths: 
-      - package.json
-    branches:
-      - main
-      
-jobs:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Type of release to perform'
+        required: true
+        default: 'patch'
 
+jobs:
   build-and-publish:
     name: Build & Publish Release
     runs-on: ubuntu-latest
@@ -16,6 +16,28 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      # Checkout branch, bump version, push, merge, create release
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: ".nvmrc"
+      
+      - name: Bump Package Version
+        id: bump_version
+        run: | 
+          npm version patch
+          echo "RELEASE_VERSION=$(cat package.json | jq .version)" >> $GITHUB_ENV
+
+      - name: Bump Version and Create Release
+        run: |
+          git checkout -b $RELEASE_VERSION
+          git commit -am "Bump version to $RELEASE_VERSION"
+          git push --set-upstream origin release
+          gh pr create --base main -f
+          gh pr merge --squash
+        env:
+          GITHUB_TOKEN: ${{ secrets.PREFECT_CONTENTS_PR_RW }}
 
       - uses: prefecthq/actions-release-ui-components@main
         id: release-ui-components

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
+      - name: Configure git user
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
       # Checkout branch, bump version, push, merge, create release
       - name: Setup Node
         uses: actions/setup-node@v3
@@ -27,12 +33,11 @@ jobs:
         id: bump_version
         run: | 
           npm version ${{ inputs.release_type }}
-          echo "RELEASE_VERSION=$(cat package.json | jq .version)" >> $GITHUB_ENV
+          echo "RELEASE_VERSION=$(cat package.json | jq .version | tr -d '"')" >> $GITHUB_ENV
 
       - name: Bump Version and Create Release
         run: |
           git checkout -b $RELEASE_VERSION
-          git commit -am "Bump version to $RELEASE_VERSION"
           git push --set-upstream origin $RELEASE_VERSION
           gh pr create --base main -f
           gh pr merge --squash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Checkout branch, bump version, push, merge, create releases
+      # Checkout branch, bump version, push, merge, create release
       - name: Setup Node
         uses: actions/setup-node@v3
         with:
@@ -33,11 +33,15 @@ jobs:
         run: |
           git checkout -b $RELEASE_VERSION
           git commit -am "Bump version to $RELEASE_VERSION"
-          git push --set-upstream origin release
+          git push --set-upstream origin $RELEASE_VERSION
           gh pr create --base main -f
           gh pr merge --squash
         env:
           GITHUB_TOKEN: ${{ secrets.PREFECT_CONTENTS_PR_RW }}
+      
+      - uses: actions/checkout@v4
+        with:
+          ref: main
 
       - uses: prefecthq/actions-release-ui-components@main
         id: release-ui-components

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Checkout branch, bump version, push, merge, create release
+      # Checkout branch, bump version, push, merge, create releases
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Bump Package Version
         id: bump_version
         run: | 
-          npm version patch
+          npm version ${{ inputs.release_type }}
           echo "RELEASE_VERSION=$(cat package.json | jq .version)" >> $GITHUB_ENV
 
       - name: Bump Version and Create Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       release_type:
-        description: 'Type of release to perform'
+        description: Type of release to perform
         required: true
-        default: 'patch'
+        default: patch
 
 jobs:
   build-and-publish:

--- a/prefect-design-release
+++ b/prefect-design-release
@@ -1,0 +1,7 @@
+#!/bin/bash
+echo "Is the release a major, minor, or patch release?"
+read release_type
+gh workflow run release.yaml \
+--repo=prefecthq/prefect-design \
+--ref=main \
+-f release_type=$release_type


### PR DESCRIPTION
- Relates: https://github.com/PrefectHQ/platform/issues/6509
- Migrates to a workflow_dispatch release workflow vs a main merge workflow
- Uses an inputed release type (i.e patch, minor, major, etc) to then automatically bump the version using npm version <release_type>
- Create a simple bash script to allow for the release pipeline to be triggered from a local machine