### PR TITLE
Add PrimaryForeground and Input Tokens

### DIFF
--- a/public/tailwindPlugin.js
+++ b/public/tailwindPlugin.js
@@ -9,6 +9,8 @@ const borderRadius = {
 }
 
 const colors = {
+  'input': 'hsl(var(--p-color-input) / <alpha-value>)',
+  'primary-foreground': 'hsl(var(--p-color-primary-foreground) / <alpha-value>)',
   divider: 'var(--p-color-divider)',
   'selectable-hover': 'var(--p-color-selectable-hover)',
   'focus-ring': 'var(--p-color-focus-ring)',

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -52,7 +52,7 @@
     --p-color-bg-overlay: hsl(0.0 0.0% 0.0% / 0.5);
 
     /* Root Tokens */
-    --p-input: var(--p-primary-hue) 6% 32%
+    --p-input: var(--p-primary-hue) 6% 32%;
     --p-color-divider: hsl(var(--p-input));
     --p-color-divider-subdued: hsl(var(--p-primary-hue), 6%, 32%);
     --p-color-selection-highlight: hsl(var(--p-primary-hue) 100.0% 64% / 0.4);
@@ -207,7 +207,7 @@
     --p-color-bg-overlay: hsl(0.0 0.0% 0.0% / 0.5);
 
     /* Root Tokens */
-    --p-input: var(--p-primary-hue) 11.3% 76%
+    --p-input: var(--p-primary-hue) 11.3% 76%;
     --p-color-divider: hsl(var(--p-input));
     --p-color-divider-subdued: hsl(var(--p-primary-hue), 14.29%, 96%);
     --p-color-selection-highlight: hsl(var(--p-primary-hue) 100.0% 64% / 0.4);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -52,7 +52,8 @@
     --p-color-bg-overlay: hsl(0.0 0.0% 0.0% / 0.5);
 
     /* Root Tokens */
-    --p-color-divider: hsl(var(--p-primary-hue), 6%, 32%);
+    --p-input: var(--p-primary-hue) 6% 32%
+    --p-color-divider: hsl(var(--p-input));
     --p-color-divider-subdued: hsl(var(--p-primary-hue), 6%, 32%);
     --p-color-selection-highlight: hsl(var(--p-primary-hue) 100.0% 64% / 0.4);
     --p-color-scrollbar-thumb: hsl(var(--p-primary-hue), 1.98%, 36%);
@@ -64,7 +65,8 @@
     --p-color-live: hsl(var(--p-primary-hue), 100.0%, 68%);
 
     /* Text */
-    --p-color-text-default: hsl(0.0, 0.0%, 100.0%);
+    --p-primary-foreground: 0.0 0.0% 100.0%;
+    --p-color-text-default: hsl(var(--p-primary-foreground));
     --p-color-text-subdued: hsl(0.0, 0.0%, 67.84%);
     --p-color-text-inverse: hsl(0.0, 0.0%, 9.02%);
     --p-color-text-link: hsl(206.8, 97.7%, 65.88%);
@@ -205,7 +207,8 @@
     --p-color-bg-overlay: hsl(0.0 0.0% 0.0% / 0.5);
 
     /* Root Tokens */
-    --p-color-divider: hsl(var(--p-primary-hue), 11.3%, 76%);
+    --p-input: var(--p-primary-hue) 11.3% 76%
+    --p-color-divider: hsl(var(--p-input));
     --p-color-divider-subdued: hsl(var(--p-primary-hue), 14.29%, 96%);
     --p-color-selection-highlight: hsl(var(--p-primary-hue) 100.0% 64% / 0.4);
     --p-color-scrollbar-thumb: hsl(var(--p-primary-hue), 1.04%, 64%);
@@ -217,7 +220,8 @@
     --p-color-live: hsl(var(--p-primary-hue), 100.0%, 64%);
 
     /* Text */
-    --p-color-text-default: hsl(0.0, 0.0%, 9.02%);
+    --p-primary-foreground: 0.0 0.0% 9.02%;
+    --p-color-text-default: hsl(var(--p-primary-foreground));
     --p-color-text-subdued: hsl(var(--p-primary-hue), 6%, 48%);
     --p-color-text-inverse: hsl(0.0, 0.0%, 100.0%);
     --p-color-text-link: hsl(var(--p-primary-hue), 87.25%, 52%);


### PR DESCRIPTION
This PR separates out the HSL array tokens from the actual use of them as a color. 

This, in particular, plays better with tailwind opacity filters. 

This introduces an ugly-haircut phase of design token name-changing, by having --p-input and --p-primary-foreground which are more or less duplicative of --p-divider and --p-text-default, respectively. 

will get worse before it gets better!