### PR TITLE
Simplify PButton styling

### DIFF
--- a/public/tailwindPlugin.js
+++ b/public/tailwindPlugin.js
@@ -9,8 +9,8 @@ const borderRadius = {
 }
 
 const colors = {
-  'input': 'hsl(var(--p-color-input) / <alpha-value>)',
-  'primary-foreground': 'hsl(var(--p-color-primary-foreground) / <alpha-value>)',
+  'input': 'hsl(var(--p-input) / <alpha-value>)',
+  'primary-foreground': 'hsl(var(--p-primary-foreground) / <alpha-value>)',
   divider: 'var(--p-color-divider)',
   'selectable-hover': 'var(--p-color-selectable-hover)',
   'focus-ring': 'var(--p-color-focus-ring)',

--- a/src/components/Button/PButton.vue
+++ b/src/components/Button/PButton.vue
@@ -107,10 +107,10 @@
   focus:ring-spacing-focus-ring
   focus:ring-focus-ring
   focus:ring-offset-focus-ring
-  focus:ring-offset-focus-ring-offset;
-  background-color: var(--p-color-button-default-bg);
-  border-color: var(--p-color-button-default-border);
-  color: var(--p-color-button-default-text);
+  focus:ring-offset-focus-ring-offset
+  bg-transparent
+  border-input
+  text-primary-foreground;
 }
 
 .p-button:focus:not(:focus-visible) { @apply


### PR DESCRIPTION
Part of a series of PRs to simplify styling for PButton. 

This series of PRs is trying to do two things:

- reduce the surface area of our design tokens for better maintenance. Right now we have things like --p-color-default-button-bg that is a pointer to 'transparent' and is used in exactly one place. 
- make adding or changing button variants easier. I'd like to make a more uniform interface to our components around sizes (we have small: bool or size: string inconsistently), but our specific styling of PButton and other components makes it incredibly hard to change variants since they create a polynomial number of orthogonal BEM classes to maintain. 

wish me luck!