### PR TITLE
Enhancement: `PTable` 

### DIFF
--- a/demo/sections/components/Table.vue
+++ b/demo/sections/components/Table.vue
@@ -145,12 +145,14 @@
   const columns = computed<TableColumn<Data>[]>(() => [
     {
       property: 'first_name',
-      label: 'First Name',
+      label: 'First Name (or given name)',
+      minWidth: 'min-content',
       width: '120px',
+      maxWidth: '400px',
     },
     {
       property: 'last_name',
-      label: 'Last Name',
+      label: 'Last Name (or family name)',
       width: '120px',
     },
     {

--- a/src/components/Table/PTable.vue
+++ b/src/components/Table/PTable.vue
@@ -31,7 +31,7 @@
               </template>
 
               <template v-for="(column, columnIndex) in visibleColumns" :key="column">
-                <PTableData :class="getColumnClasses(column, getValue(row, column.property), columnIndex, row, rowIndex)">
+                <PTableData :class="getColumnClasses(column, getValue(row, column.property), columnIndex, row, rowIndex)" :title="getValue(row, column.property)">
                   <slot :name="kebabCase(column.label)" :value="getValue(row, column.property)" v-bind="{ column, row }">
                     {{ getValue(row, column.property) }}
                   </slot>
@@ -118,12 +118,10 @@
   const visibleColumns = computed<TColumn[]>(() => columns.value.filter(column => column.visible ?? true))
 
   function getColumnStyle(column: TColumn): StyleValue {
-    if (column.width === undefined) {
-      return ''
-    }
-
     return {
       width: column.width,
+      minWidth: column.minWidth ?? column.width ?? 0,
+      maxWidth: column.maxWidth ?? column.width,
     }
   }
 

--- a/src/components/Table/PTable.vue
+++ b/src/components/Table/PTable.vue
@@ -177,6 +177,8 @@
   overflow-hidden
   overflow-x-auto
   rounded-default
+  border
+  border-divider
 }
 
 .p-table__table { @apply

--- a/src/components/Table/PTable.vue
+++ b/src/components/Table/PTable.vue
@@ -12,7 +12,7 @@
               </template>
 
               <template v-for="column in visibleColumns" :key="column">
-                <PTableHeader :style="getColumnStyle(column)">
+                <PTableHeader :style="getColumnStyle(column)" :title="column.label">
                   <slot :name="`${kebabCase(column.label)}-heading`" v-bind="{ column }">
                     {{ column.label }}
                   </slot>

--- a/src/components/Table/PTableData.vue
+++ b/src/components/Table/PTableData.vue
@@ -8,7 +8,8 @@
 .p-table-data { @apply
   whitespace-nowrap
   px-3
-  py-4
+  py-3
   text-sm
+  truncate
 }
 </style>

--- a/src/components/Table/PTableHead.vue
+++ b/src/components/Table/PTableHead.vue
@@ -1,5 +1,5 @@
 <template>
-  <thead class="p-table-head p-background">
+  <thead class="p-table-head">
     <slot>
       <PTableRow>
         <slot name="row" />

--- a/src/components/Table/PTableHeader.vue
+++ b/src/components/Table/PTableHeader.vue
@@ -7,10 +7,11 @@
 <style>
 .p-table-header { @apply
   px-3
-  py-3.5
+  py-3
   text-sm
-  font-semibold
+  font-bold
   whitespace-nowrap
+  truncate
   text-left
 }
 </style>

--- a/src/types/tables.ts
+++ b/src/types/tables.ts
@@ -6,6 +6,8 @@ export type TableData = Record<string, any>
 export type TableColumn<T extends TableData = Record<never, never>> = {
   label: string,
   property?: T extends T ? keyof T : never,
+  maxWidth?: string,
+  minWidth?: string,
   width?: string,
   visible?: boolean,
   disabled?: boolean,


### PR DESCRIPTION
This PR makes several improvements to `PTable`, including:
- adding a border to that matches the row divider
- removing the `p-background` class from `PTableHead`
- tightening row and header vertical padding
- expanding column definitions to include min and max attributes; these help us better enforce column width definitions and prevent table blowouts
- truncating headers and cells
- adding title attributes to headers and cells
- swapping `font-semibold` for `font-bold` in header labels (semibold text doesn't provide a very clear distinction between headers and content)

Before:
<img width="1206" alt="Screenshot 2024-04-24 at 12 09 48 PM" src="https://github.com/PrefectHQ/prefect-design/assets/27291717/1d08a74e-dbe0-45e7-a1c8-2e469f7b623c">


After:
<img width="1206" alt="Screenshot 2024-04-24 at 12 09 45 PM" src="https://github.com/PrefectHQ/prefect-design/assets/27291717/c5413a7a-f7ae-44fc-9f8a-2cac06871997">


