### PR TITLE
Fix date range select displaying negative values for ranges in the past

### DIFF
--- a/src/components/DateRangeSelect/utilities.ts
+++ b/src/components/DateRangeSelect/utilities.ts
@@ -36,7 +36,7 @@ function getDateSpanLabel({ seconds }: DateRangeSelectSpanValue): string {
   const now = new Date()
   const duration = intervalToDuration({
     start: now,
-    end: addSeconds(now, seconds),
+    end: addSeconds(now, Math.abs(seconds)),
   })
 
   const reduced = Object.entries(duration).reduce<string[]>((durations, [key, value]) => {


### PR DESCRIPTION
# Description
Since date-fns was updated to 3.x in https://github.com/PrefectHQ/prefect-design/pull/1212 PDateRangeSelect has been displaying negative values for date ranges in the past. Displaying labels like `Past -7 days` rather than `Past 7 days`. This was because `intervalToDuration` now respects negative/inverted date ranges. 

Since we always want a positive duration I've added `Math.abs` around the value we're creating the duration from which forces it to always return a positive duration. 