### PR TITLE
Quick Fix: Aria-Selected on PButtonGroup

### DIFF
--- a/src/components/ButtonGroup/PButtonGroup.vue
+++ b/src/components/ButtonGroup/PButtonGroup.vue
@@ -7,6 +7,7 @@
         class="p-button-group__button"
         :selected="button.value === modelValue"
         :icon="button.icon"
+        :aria-selected="button.value === modelValue"
         @click="select(button.value)"
       >
         <template v-if="button.label || $slots.default" #default>


### PR DESCRIPTION
PButtonGroup passes down a selected prop to it's button children, rather than setting aria-selected. This PR fixes that, but does not yet deprecate the passed down prop.