### PR TITLE
Remove sidebar section dividers

### DIFF
--- a/src/components/ContextSidebar/PContextSidebar.vue
+++ b/src/components/ContextSidebar/PContextSidebar.vue
@@ -47,8 +47,6 @@
 }
 
 .p-context-sidebar__header { @apply
-  border-b
-  border-divider
   flex-shrink-0
 }
 
@@ -60,8 +58,6 @@
 
 .p-context-sidebar__footer { @apply
   mt-auto
-  border-t
   flex-shrink-0
-  border-divider
 }
 </style>

--- a/src/components/NavigationBar/PNavigationBar.vue
+++ b/src/components/NavigationBar/PNavigationBar.vue
@@ -80,8 +80,6 @@
 }
 
 .p-navigation-bar__content { @apply
-  border-t
-  border-b
   border-divider
   self-stretch
   py-2


### PR DESCRIPTION
This PR removes the borders between sections in the sidebar. Some of these may come back in a future PR but right now they're a bit of an eyesore and don't jive well with the padding structure of the sidebar