### PR TITLE
Bugfix: Package files, bump vue peer-dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,11 +47,11 @@
         "vite": "5.2.11",
         "vite-plugin-vue-devtools": "^7.1.3",
         "vite-svg-loader": "5.1.0",
-        "vue-tsc": "2.0.17"
+        "vue-tsc": "^2.0.17"
       },
       "peerDependencies": {
         "@prefecthq/vue-compositions": "^1.11.0",
-        "vue": "^3.4.4",
+        "vue": "^3.4.27",
         "vue-router": "^4.1.6"
       }
     },
@@ -2245,36 +2245,36 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.4.24",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.24.tgz",
-      "integrity": "sha512-vbW/tgbwJYj62N/Ww99x0zhFTkZDTcGh3uwJEuadZ/nF9/xuFMC4693P9r+3sxGXISABpDKvffY5ApH9pmdd1A==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.27.tgz",
+      "integrity": "sha512-E+RyqY24KnyDXsCuQrI+mlcdW3ALND6U7Gqa/+bVwbcpcR3BRRIckFoz7Qyd4TTlnugtwuI7YgjbvsLmxb+yvg==",
       "dependencies": {
         "@babel/parser": "^7.24.4",
-        "@vue/shared": "3.4.24",
+        "@vue/shared": "3.4.27",
         "entities": "^4.5.0",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.0"
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.4.24",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.24.tgz",
-      "integrity": "sha512-4XgABML/4cNndVsQndG6BbGN7+EoisDwi3oXNovqL/4jdNhwvP8/rfRMTb6FxkxIxUUtg6AI1/qZvwfSjxJiWA==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.27.tgz",
+      "integrity": "sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==",
       "dependencies": {
-        "@vue/compiler-core": "3.4.24",
-        "@vue/shared": "3.4.24"
+        "@vue/compiler-core": "3.4.27",
+        "@vue/shared": "3.4.27"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.4.24",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.24.tgz",
-      "integrity": "sha512-nRAlJUK02FTWfA2nuvNBAqsDZuERGFgxZ8sGH62XgFSvMxO2URblzulExsmj4gFZ8e+VAyDooU9oAoXfEDNxTA==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.27.tgz",
+      "integrity": "sha512-nDwntUEADssW8e0rrmE0+OrONwmRlegDA1pD6QhVeXxjIytV03yDqTey9SBDiALsvAd5U4ZrEKbMyVXhX6mCGA==",
       "dependencies": {
         "@babel/parser": "^7.24.4",
-        "@vue/compiler-core": "3.4.24",
-        "@vue/compiler-dom": "3.4.24",
-        "@vue/compiler-ssr": "3.4.24",
-        "@vue/shared": "3.4.24",
+        "@vue/compiler-core": "3.4.27",
+        "@vue/compiler-dom": "3.4.27",
+        "@vue/compiler-ssr": "3.4.27",
+        "@vue/shared": "3.4.27",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.10",
         "postcss": "^8.4.38",
@@ -2282,12 +2282,12 @@
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.4.24",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.24.tgz",
-      "integrity": "sha512-ZsAtr4fhaUFnVcDqwW3bYCSDwq+9Gk69q2r/7dAHDrOMw41kylaMgOP4zRnn6GIEJkQznKgrMOGPMFnLB52RbQ==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.27.tgz",
+      "integrity": "sha512-CVRzSJIltzMG5FcidsW0jKNQnNRYC8bT21VegyMMtHmhW3UOI7knmUehzswXLrExDLE6lQCZdrhD4ogI7c+vuw==",
       "dependencies": {
-        "@vue/compiler-dom": "3.4.24",
-        "@vue/shared": "3.4.24"
+        "@vue/compiler-dom": "3.4.27",
+        "@vue/shared": "3.4.27"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -2383,52 +2383,52 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.4.24",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.24.tgz",
-      "integrity": "sha512-nup3fSYg4i4LtNvu9slF/HF/0dkMQYfepUdORBcMSsankzRPzE7ypAFurpwyRBfU1i7Dn1kcwpYsE1wETSh91g==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.27.tgz",
+      "integrity": "sha512-kK0g4NknW6JX2yySLpsm2jlunZJl2/RJGZ0H9ddHdfBVHcNzxmQ0sS0b09ipmBoQpY8JM2KmUw+a6sO8Zo+zIA==",
       "peer": true,
       "dependencies": {
-        "@vue/shared": "3.4.24"
+        "@vue/shared": "3.4.27"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.4.24",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.24.tgz",
-      "integrity": "sha512-c7iMfj6cJMeAG3s5yOn9Rc5D9e2/wIuaozmGf/ICGCY3KV5H7mbTVdvEkd4ZshTq7RUZqj2k7LMJWVx+EBiY1g==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.27.tgz",
+      "integrity": "sha512-7aYA9GEbOOdviqVvcuweTLe5Za4qBZkUY7SvET6vE8kyypxVgaT1ixHLg4urtOlrApdgcdgHoTZCUuTGap/5WA==",
       "peer": true,
       "dependencies": {
-        "@vue/reactivity": "3.4.24",
-        "@vue/shared": "3.4.24"
+        "@vue/reactivity": "3.4.27",
+        "@vue/shared": "3.4.27"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.4.24",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.24.tgz",
-      "integrity": "sha512-uXKzuh/Emfad2Y7Qm0ABsLZZV6H3mAJ5ZVqmAOlrNQRf+T5mxpPGZBfec1hkP41t6h6FwF6RSGCs/gd8WbuySQ==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.27.tgz",
+      "integrity": "sha512-ScOmP70/3NPM+TW9hvVAz6VWWtZJqkbdf7w6ySsws+EsqtHvkhxaWLecrTorFxsawelM5Ys9FnDEMt6BPBDS0Q==",
       "peer": true,
       "dependencies": {
-        "@vue/runtime-core": "3.4.24",
-        "@vue/shared": "3.4.24",
+        "@vue/runtime-core": "3.4.27",
+        "@vue/shared": "3.4.27",
         "csstype": "^3.1.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.4.24",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.24.tgz",
-      "integrity": "sha512-H+DLK4sQF6sRgzKyofmlEVBIV/9KrQU6HIV7nt6yIwSGGKvSwlV8pqJlebUKLpbXaNHugdSfAbP6YmXF69lxow==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.27.tgz",
+      "integrity": "sha512-dlAMEuvmeA3rJsOMJ2J1kXU7o7pOxgsNHVr9K8hB3ImIkSuBrIdy0vF66h8gf8Tuinf1TK3mPAz2+2sqyf3KzA==",
       "peer": true,
       "dependencies": {
-        "@vue/compiler-ssr": "3.4.24",
-        "@vue/shared": "3.4.24"
+        "@vue/compiler-ssr": "3.4.27",
+        "@vue/shared": "3.4.27"
       },
       "peerDependencies": {
-        "vue": "3.4.24"
+        "vue": "3.4.27"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.4.24",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.24.tgz",
-      "integrity": "sha512-BW4tajrJBM9AGAknnyEw5tO2xTmnqgup0VTnDAMcxYmqOX0RG0b9aSUGAbEKolD91tdwpA6oCwbltoJoNzpItw=="
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.27.tgz",
+      "integrity": "sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA=="
     },
     "node_modules/@vueuse/core": {
       "version": "10.9.0",
@@ -7688,16 +7688,16 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.4.24",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.24.tgz",
-      "integrity": "sha512-NPdx7dLGyHmKHGRRU5bMRYVE+rechR+KDU5R2tSTNG36PuMwbfAJ+amEvOAw7BPfZp5sQulNELSLm5YUkau+Sg==",
+      "version": "3.4.27",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.27.tgz",
+      "integrity": "sha512-8s/56uK6r01r1icG/aEOHqyMVxd1bkYcSe9j8HcKtr/xTOFWvnzIVTehNW+5Yt89f+DLBe4A569pnZLS5HzAMA==",
       "peer": true,
       "dependencies": {
-        "@vue/compiler-dom": "3.4.24",
-        "@vue/compiler-sfc": "3.4.24",
-        "@vue/runtime-dom": "3.4.24",
-        "@vue/server-renderer": "3.4.24",
-        "@vue/shared": "3.4.24"
+        "@vue/compiler-dom": "3.4.27",
+        "@vue/compiler-sfc": "3.4.27",
+        "@vue/runtime-dom": "3.4.27",
+        "@vue/server-renderer": "3.4.27",
+        "@vue/shared": "3.4.27"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     }
   },
   "files": [
-    "."
+    "dist",
+    "src"
   ],
   "types": "./dist/types/src/index.d.ts",
   "devDependencies": {
@@ -58,11 +59,11 @@
     "vite": "5.2.11",
     "vite-plugin-vue-devtools": "^7.1.3",
     "vite-svg-loader": "5.1.0",
-    "vue-tsc": "2.0.17"
+    "vue-tsc": "^2.0.17"
   },
   "peerDependencies": {
     "@prefecthq/vue-compositions": "^1.11.0",
-    "vue": "^3.4.4",
+    "vue": "^3.4.27",
     "vue-router": "^4.1.6"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     ".": {
       "import": "./dist/prefect-design.mjs",
       "require": "./dist/prefect-design.umd.js"
-    }
+    },
+    "./tailwind.config.ts": "./src/tailwind.config.ts"
   },
   "files": [
     "dist",
@@ -59,7 +60,7 @@
     "vite": "5.2.11",
     "vite-plugin-vue-devtools": "^7.1.3",
     "vite-svg-loader": "5.1.0",
-    "vue-tsc": "^2.0.17"
+    "vue-tsc": "2.0.17"
   },
   "peerDependencies": {
     "@prefecthq/vue-compositions": "^1.11.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,5 +39,9 @@
     "**/*.mts",
     "postcss.config.cjs",
     "vite.config.mts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,9 +39,5 @@
     "**/*.mts",
     "postcss.config.cjs",
     "vite.config.mts"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist"
   ]
 }


### PR DESCRIPTION
This PR fixes a change introduced in #1273 to `package.json` that used a relative file path for the files key instead of passing the directories themselves which causes downstream importers to be unable to properly resolve imports. Also bumps the vue peer dep cause that was causing some downstream type issues. 