### PR TITLE
Enhancement: `PTable` `row-after` slot

### DIFF
--- a/demo/sections/components/Table.vue
+++ b/demo/sections/components/Table.vue
@@ -97,8 +97,8 @@
 
         <template #row-after="{ row }">
           <PTableRow v-if="isExpanded(row)">
-            <PTableData :colspan="columns.length">
-              <p-code-highlight :text="JSON.stringify(row, null, 2)" lang="json" class="w-full grow" />
+            <PTableData :colspan="columns.length" class="!p-0">
+              <p-code-highlight :text="JSON.stringify(row, null, 2)" lang="json" class="!rounded-none !p-4" />
             </PTableData>
           </PTableRow>
         </template>

--- a/demo/sections/components/Table.vue
+++ b/demo/sections/components/Table.vue
@@ -7,6 +7,7 @@
       { title: 'With Multiselect' },
       { title: 'Using Columns' },
       { title: 'Custom Slots' },
+      { title: 'Expandable Rows' },
       { title: 'Empty States' },
     ]"
   >
@@ -82,6 +83,28 @@
       </p-table>
     </template>
 
+    <template #expandable-rows>
+      <p-table :data="data" :columns="columns">
+        <template #action-heading>
+          <span />
+        </template>
+
+        <template #action="{ row }">
+          <div class="w-full flex justify-end">
+            <p-button class="ml-auto" small :icon="isExpanded(row) ? 'ChevronUpIcon' : 'ChevronDownIcon'" @click="expandRow(row)" />
+          </div>
+        </template>
+
+        <template #row-after="{ row }">
+          <PTableRow v-if="isExpanded(row)">
+            <PTableData :colspan="columns.length">
+              <p-code-highlight :text="JSON.stringify(row, null, 2)" lang="json" class="w-full grow" />
+            </PTableData>
+          </PTableRow>
+        </template>
+      </p-table>
+    </template>
+
     <template #empty-states>
       <p-table :data="emptyDate" :columns="columns">
         <template #empty-state>
@@ -153,7 +176,6 @@
     {
       property: 'last_name',
       label: 'Last Name (or family name)',
-      width: '120px',
     },
     {
       property: 'email',
@@ -180,6 +202,17 @@
       'custom-column-class': column.label === 'Last Name',
       'custom-column-class--index': index === 3,
     }
+  }
+
+
+  const expandedRows = ref<Map<number, boolean>>(new Map())
+
+  function isExpanded(row: Data): boolean {
+    return expandedRows.value.get(row.id) ?? false
+  }
+
+  function expandRow(row: Data): void {
+    expandedRows.value.set(row.id, !isExpanded(row))
   }
 </script>
 

--- a/src/components/Table/PTable.vue
+++ b/src/components/Table/PTable.vue
@@ -38,6 +38,10 @@
                 </PTableData>
               </template>
             </PTableRow>
+
+            <template v-if="$slots['row-after']">
+              <slot name="row-after" v-bind="{ row, rowIndex }" />
+            </template>
           </template>
           <template v-if="slots['empty-state'] && data.length === 0">
             <PTableRow>

--- a/src/components/Table/PTableBody.vue
+++ b/src/components/Table/PTableBody.vue
@@ -13,6 +13,10 @@
             </template>
           </slot>
         </PTableRow>
+
+        <template v-if="$slots['row-after']">
+          <slot name="row-after" v-bind="{ row, index }" />
+        </template>
       </template>
     </slot>
   </tbody>


### PR DESCRIPTION
This PR adds a new slot, `row-after` that allows callers to specify any sort of additional content below the content of a row. 

Demo of this in action:

https://github.com/PrefectHQ/prefect-design/assets/27291717/4c0ba1de-a1fb-46a7-aa4a-c2cee8365528

