### PR TITLE
[p-timeline] center content of p timeline to better account for content with 1 line of text

### DIFF
--- a/src/components/Timeline/PTimelineItem.vue
+++ b/src/components/Timeline/PTimelineItem.vue
@@ -158,6 +158,10 @@
   text-left
 }
 
+.p-timeline-item__content { @apply
+  self-center
+}
+
 .p-timeline-item__content--date-left { @apply
   text-left
 }


### PR DESCRIPTION
This PR adjust p-timeline _content_ (not the date nor the point) to `align-self: center` with the intended result of nicely centering single lines of text. This works well under the assumption that the _content_ is what primarily drives the height of a p-timeline-item. If say, the date slot were to be larger, then this change would result in the content then being centered within a larger box rather than floating to the top (which imo is desirable in the context of a single line of content text). 🤷  - I considered making this change _only_ for the artifact timeline but that assumption that the content primarily drives the height made sense to me.


| **Before** | **After** |
| ---- | ---- |
| <img width="929" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/22418768/dd496729-fd59-4ced-990d-ef7d0bd50afc"> | <img width="924" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/22418768/a38f9540-25d5-4efa-9c19-3f66d9970825"> |
