### PR TITLE
[p-table] Remove built-in titles on p-table data cells.

### DIFF
--- a/src/components/Table/PTable.vue
+++ b/src/components/Table/PTable.vue
@@ -31,7 +31,7 @@
               </template>
 
               <template v-for="(column, columnIndex) in visibleColumns" :key="column">
-                <PTableData :class="getColumnClasses(column, getValue(row, column.property), columnIndex, row, rowIndex)" :title="getValue(row, column.property)">
+                <PTableData :class="getColumnClasses(column, getValue(row, column.property), columnIndex, row, rowIndex)">
                   <slot :name="kebabCase(column.label)" :value="getValue(row, column.property)" v-bind="{ column, row }">
                     {{ getValue(row, column.property) }}
                   </slot>


### PR DESCRIPTION
Not sure that these titles add much. If anything, non-primitive values take a hit here

<img width="544" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/22418768/58d4fd3b-df59-42f4-bc72-b90f456c4bb5">
