### PR TITLE
Chore: Font dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "./demo"
       ],
       "dependencies": {
+        "@fontsource/inconsolata": "^5.0.18",
+        "@fontsource/inter": "^5.0.18",
         "@heroicons/vue": "2.0.17",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.0",
@@ -28,8 +30,6 @@
         "tailwindcss-animate": "^1.0.7"
       },
       "devDependencies": {
-        "@fontsource/inconsolata": "^4.5.7",
-        "@fontsource/inter": "^4.5.12",
         "@prefecthq/eslint-config": "1.0.32",
         "@types/dompurify": "^3.0.1",
         "@types/marked": "^4.0.8",
@@ -1268,16 +1268,14 @@
       }
     },
     "node_modules/@fontsource/inconsolata": {
-      "version": "4.5.10",
-      "resolved": "https://registry.npmjs.org/@fontsource/inconsolata/-/inconsolata-4.5.10.tgz",
-      "integrity": "sha512-kShpiWE3RD4LH4YlZPbyE4VMt826DA7Ugw1jNJt54mxpP7nUsI9gflQOLWSJ9AMLkqPLpjza9iZkKRmU8Q7MOQ==",
-      "dev": true
+      "version": "5.0.18",
+      "resolved": "https://registry.npmjs.org/@fontsource/inconsolata/-/inconsolata-5.0.18.tgz",
+      "integrity": "sha512-VVG5RWMfYEmWRKv3sh8M1n3Ux3vs7v8978vYZ205lBQPlff3e7H67f7TRfswj2ybnX53+QxWylySvcv8ACCvWw=="
     },
     "node_modules/@fontsource/inter": {
-      "version": "4.5.15",
-      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-4.5.15.tgz",
-      "integrity": "sha512-FzleM9AxZQK2nqsTDtBiY0PMEVWvnKnuu2i09+p6DHvrHsuucoV2j0tmw+kAT3L4hvsLdAIDv6MdGehsPIdT+Q==",
-      "dev": true
+      "version": "5.0.18",
+      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.0.18.tgz",
+      "integrity": "sha512-YCsoYPTcs713sI7tLtxaPrIhXAXvEetGg5Ry02ivA8qUOb3fQHojbK/X9HLD5OOKvFUNR2Ynkwb1kR1hVKQHpw=="
     },
     "node_modules/@heroicons/vue": {
       "version": "2.0.17",

--- a/package.json
+++ b/package.json
@@ -42,8 +42,6 @@
   ],
   "types": "./dist/types/src/index.d.ts",
   "devDependencies": {
-    "@fontsource/inconsolata": "^4.5.7",
-    "@fontsource/inter": "^4.5.12",
     "@prefecthq/eslint-config": "1.0.32",
     "@types/dompurify": "^3.0.1",
     "@types/marked": "^4.0.8",
@@ -69,6 +67,8 @@
     "vue-router": "^4.1.6"
   },
   "dependencies": {
+    "@fontsource/inconsolata": "^5.0.18",
+    "@fontsource/inter": "^5.0.18",
     "@heroicons/vue": "2.0.17",
     "@tailwindcss/aspect-ratio": "^0.4.0",
     "@tailwindcss/forms": "^0.5.0",

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,5 +1,5 @@
-@import "@fontsource/inconsolata/variable.css";
-@import "@fontsource/inter/variable.css";
+@import "@fontsource/inconsolata";
+@import "@fontsource/inter";
 @import "./scrollbar.css";
 
 @tailwind base;

--- a/src/tailwind.config.ts
+++ b/src/tailwind.config.ts
@@ -120,11 +120,7 @@ const plugins = [
 ]
 
 export default {
-  content: [
-    './src/**/*.{vue,js,ts}',
-    './demo/index.html',
-    './demo/**/*.vue',
-  ],
+  content: ['./src/**/*.{vue}'],
   darkMode,
   plugins,
   theme: {


### PR DESCRIPTION
This PR updates the fontsource packages and makes them dependencies instead of dev-dependencies. I'm hoping this change will let us compile stylesheets from source in downstream packages, since the blocker at the moment is the missing dependency.