### PR TITLE
[p-date-range-select] Use PSelect instead of PNativeSelect.

### DIFF
--- a/src/components/DateRangeSelect/PDateRangeDurationInput.vue
+++ b/src/components/DateRangeSelect/PDateRangeDurationInput.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="p-date-range-duration-input">
     <PNumberInput v-model="quantity" prepend="±" />
-    <!-- <PNativeSelect v-model="unit" :options="units" /> -->
     <PSelect v-model="unit" :options="units" />
   </div>
 </template>

--- a/src/components/DateRangeSelect/PDateRangeDurationInput.vue
+++ b/src/components/DateRangeSelect/PDateRangeDurationInput.vue
@@ -1,14 +1,15 @@
 <template>
   <div class="p-date-range-duration-input">
     <PNumberInput v-model="quantity" prepend="±" />
-    <PNativeSelect v-model="unit" :options="units" />
+    <!-- <PNativeSelect v-model="unit" :options="units" /> -->
+    <PSelect v-model="unit" :options="units" />
   </div>
 </template>
 
 <script lang="ts" setup>
   import { computed } from 'vue'
-  import PNativeSelect from '@/components/NativeSelect/PNativeSelect.vue'
-  import { PNumberInput } from '@/components/NumberInput'
+  import PNumberInput from '@/components/NumberInput/PNumberInput.vue'
+  import PSelect from '@/components/Select/PSelect.vue'
   import { DateRangeSelectAroundUnit } from '@/types/dateRange'
   import { SelectOption } from '@/types/selectOption'
 


### PR DESCRIPTION
When choosing "Around a time" with the PDateRangeSelect component, the unit picker uses PNativeSelect which sometimes don't render too good. This PR changes to use PSelect which _fallsback_ to PNativeSelect implicitly.

| **Before** | **After** |
| ---- | ---- |
| <img width="338" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/22418768/3b6aa7ea-eeec-449e-a56a-bf5cf22ea955"> ![image](https://github.com/PrefectHQ/prefect-design/assets/22418768/59113225-87eb-4baa-b544-9efc85b6d732) | <img width="331" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/22418768/4a0c62a8-9f75-4698-a1b2-c93d2399ebef"> |
