### PR TITLE
Chore: Install variable fonts instead of base fonts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
         "./demo"
       ],
       "dependencies": {
-        "@fontsource/inconsolata": "^5.0.18",
-        "@fontsource/inter": "^5.0.18",
+        "@fontsource-variable/inconsolata": "^5.0.18",
+        "@fontsource-variable/inter": "^5.0.18",
         "@heroicons/vue": "2.0.17",
         "@tailwindcss/aspect-ratio": "^0.4.0",
         "@tailwindcss/forms": "^0.5.0",
@@ -1267,15 +1267,15 @@
         }
       }
     },
-    "node_modules/@fontsource/inconsolata": {
+    "node_modules/@fontsource-variable/inconsolata": {
       "version": "5.0.18",
-      "resolved": "https://registry.npmjs.org/@fontsource/inconsolata/-/inconsolata-5.0.18.tgz",
-      "integrity": "sha512-VVG5RWMfYEmWRKv3sh8M1n3Ux3vs7v8978vYZ205lBQPlff3e7H67f7TRfswj2ybnX53+QxWylySvcv8ACCvWw=="
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inconsolata/-/inconsolata-5.0.18.tgz",
+      "integrity": "sha512-tnpqD9NOKGJlYvf9/wjy6CNAZUpiNIf5OCdQnUEd5rHMepPx8Jkv4XzWgNuU88npVoDGn7qHnv05lAcyZ7Qpqw=="
     },
-    "node_modules/@fontsource/inter": {
+    "node_modules/@fontsource-variable/inter": {
       "version": "5.0.18",
-      "resolved": "https://registry.npmjs.org/@fontsource/inter/-/inter-5.0.18.tgz",
-      "integrity": "sha512-YCsoYPTcs713sI7tLtxaPrIhXAXvEetGg5Ry02ivA8qUOb3fQHojbK/X9HLD5OOKvFUNR2Ynkwb1kR1hVKQHpw=="
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/inter/-/inter-5.0.18.tgz",
+      "integrity": "sha512-rJzSrtJ3b7djiGFvRuTe6stDfbYJGhdQSfn2SI2WfXviee7Er0yKAHE5u7FU7OWVQQQ1x3+cxdmx9NdiAkcrcA=="
     },
     "node_modules/@heroicons/vue": {
       "version": "2.0.17",

--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
     "vue-router": "^4.1.6"
   },
   "dependencies": {
-    "@fontsource/inconsolata": "^5.0.18",
-    "@fontsource/inter": "^5.0.18",
+    "@fontsource-variable/inconsolata": "^5.0.18",
+    "@fontsource-variable/inter": "^5.0.18",
     "@heroicons/vue": "2.0.17",
     "@tailwindcss/aspect-ratio": "^0.4.0",
     "@tailwindcss/forms": "^0.5.0",

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,5 +1,5 @@
-@import "@fontsource/inconsolata";
-@import "@fontsource/inter";
+@import "@fontsource-variable/inconsolata";
+@import "@fontsource-variable/inter";
 @import "./scrollbar.css";
 
 @tailwind base;

--- a/src/tailwind.config.ts
+++ b/src/tailwind.config.ts
@@ -55,8 +55,8 @@ const ringOffsetWidth = {
 }
 
 const fontFamily = {
-  sans: ['Inter', ...defaultTheme.fontFamily.sans],
-  mono: ['Inconsolata', ...defaultTheme.fontFamily.mono],
+  sans: ['Inter Variable', ...defaultTheme.fontFamily.sans],
+  mono: ['Inconsolata Variable', ...defaultTheme.fontFamily.mono],
 }
 
 const keyframes = {

--- a/src/tailwind.config.ts
+++ b/src/tailwind.config.ts
@@ -54,9 +54,12 @@ const ringOffsetWidth = {
   'focus-ring': 'var(--p-spacing-focus-ring-offset)',
 }
 
+export const sansFontFamily = 'Inter Variable'
+export const monoFontFamily = 'Inconsolata Variable'
+
 const fontFamily = {
-  sans: ['Inter Variable', ...defaultTheme.fontFamily.sans],
-  mono: ['Inconsolata Variable', ...defaultTheme.fontFamily.mono],
+  sans: [sansFontFamily, ...defaultTheme.fontFamily.sans],
+  mono: [monoFontFamily, ...defaultTheme.fontFamily.mono],
 }
 
 const keyframes = {


### PR DESCRIPTION
Following up from #1308, this installs the variable font sheets instead of just the base ones so we support things like italics and font weights.