### PR TITLE
Fix PDateInput closing when picking a month or year

### DIFF
--- a/src/components/Calendar/PCalendarDatePicker.vue
+++ b/src/components/Calendar/PCalendarDatePicker.vue
@@ -28,7 +28,7 @@
 
 <script lang="ts" setup>
   import { eachDayOfInterval, endOfMonth, endOfWeek, format, isSameDay, isSameMonth, isToday, startOfMonth, startOfWeek } from 'date-fns'
-  import { computed } from 'vue'
+  import { VNode, computed } from 'vue'
   import { ClassValue } from '@/types/attributes'
   import { isDateAfter, isDateBefore, isNotNullish } from '@/utilities'
 
@@ -55,7 +55,7 @@
   }>()
 
   defineSlots<{
-    date: (props: DateSlotScope) => any,
+    date: (props: DateSlotScope) => VNode,
   }>()
 
   const selected = computed({

--- a/src/components/PopOver/PPopOver.vue
+++ b/src/components/PopOver/PPopOver.vue
@@ -23,7 +23,7 @@
   import { useMostVisiblePositionStyles } from '@/compositions/position'
   import { usePopOverGroup } from '@/compositions/usePopOverGroup'
   import { PositionMethod } from '@/types/position'
-  import { randomId } from '@/utilities'
+  import { isDefined, randomId } from '@/utilities'
   import { left, right, bottom, top } from '@/utilities/position'
 
   const props = withDefaults(defineProps<{
@@ -72,11 +72,20 @@
 
   function eventHandler(event: MouseEvent | FocusEvent): void {
     const eventTarget = event.target as Element
+    const isMouseEvent = event instanceof MouseEvent
 
+    /*
+     * isEventInElement checks are backup checks for click events where the
+     * click changes the content of the popover. The element clicked on may
+     * no longer exist in the dom so the element.contains check will fail.
+     * So falling back to checking if the event x,y originated within the element
+     */
     if (
       !props.autoClose
       || target.value?.contains(eventTarget)
+      || isMouseEvent && isEventInElement(event, target.value)
       || content.value?.contains(eventTarget)
+      || isMouseEvent && isEventInElement(event, content.value)
       || eventTarget.closest('.p-pop-over-content') !== null
     ) {
       return
@@ -84,6 +93,26 @@
 
     close()
   }
+
+  function isEventInElement(event: MouseEvent, element: Element | undefined): boolean {
+    if (!element) {
+      return false
+    }
+
+    const rect = element.getBoundingClientRect()
+    const { clientX, clientY } = event
+
+    if (clientX < rect.left || clientX >= rect.right) {
+      return false
+    }
+
+    if (clientY < rect.top || clientY >= rect.bottom) {
+      return false
+    }
+
+    return true
+  }
+
 
   function open(): void {
     setGroupCloseMethod(close)

--- a/src/components/PopOver/PPopOver.vue
+++ b/src/components/PopOver/PPopOver.vue
@@ -23,7 +23,7 @@
   import { useMostVisiblePositionStyles } from '@/compositions/position'
   import { usePopOverGroup } from '@/compositions/usePopOverGroup'
   import { PositionMethod } from '@/types/position'
-  import { isDefined, randomId } from '@/utilities'
+  import { randomId } from '@/utilities'
   import { left, right, bottom, top } from '@/utilities/position'
 
   const props = withDefaults(defineProps<{

--- a/src/components/VirtualScroller/PVirtualScrollerChunk.vue
+++ b/src/components/VirtualScroller/PVirtualScrollerChunk.vue
@@ -16,19 +16,19 @@
   }>()
 
   const styles = computed(() => ({
-    height: visible.value ? undefined : `${height.value ?? props.height}px`,
+    height: visible.value ? undefined : `${internalHeight.value ?? props.height}px`,
   }))
 
   const el = ref<HTMLDivElement>()
   const visible = ref(false)
-  const height = ref<number | null>(null)
+  const internalHeight = ref<number | null>(null)
   const { observe } = useIntersectionObserver(intersect, props.observerOptions)
 
   function setHeight(): void {
     setTimeout(() => {
       const rect = el.value!.getBoundingClientRect()
 
-      height.value = rect.height
+      internalHeight.value = rect.height
     })
   }
 


### PR DESCRIPTION
# Description
When picking a month or year from the date picker the popover would close, preventing the user from actually selecting their desired date. This was happening because the element clicked on was no longer part of the DOM when PPopOver did its check to auto close. 