### PR TITLE
[p-tooltip] Fix extraneous attributes warning - props not properly forwarded.

### DIFF
--- a/src/components/Tooltip/PTooltip.vue
+++ b/src/components/Tooltip/PTooltip.vue
@@ -1,16 +1,14 @@
 <template>
-  <TooltipProvider :v-bind="delegatedProviderProps">
-    <TooltipRoot :v-bind="delegatedRootProps">
+  <TooltipProvider v-bind="delegatedProviderProps">
+    <TooltipRoot v-bind="delegatedRootProps">
       <TooltipTrigger as-child>
         <slot />
 
         <TooltipContent
-          :v-bind="delegatedContentProps"
+          v-bind="delegatedContentProps"
           :as-child="Boolean($slots.tooltip)"
         >
-          <slot
-            name="tooltip"
-          >
+          <slot name="tooltip">
             <slot name="content">
               {{ text }}
             </slot>
@@ -23,32 +21,40 @@
 
 <script setup lang="ts">
   import { type TooltipRootProps, type TooltipProviderProps, type TooltipContentProps } from 'radix-vue'
-  import { defineProps, computed } from 'vue'
+  import { computed } from 'vue'
   import TooltipContent from '@/components/Tooltip/PTooltipContent.vue'
   import TooltipProvider from '@/components/Tooltip/PTooltipProvider.vue'
   import TooltipRoot from '@/components/Tooltip/PTooltipRoot.vue'
   import TooltipTrigger from '@/components/Tooltip/PTooltipTrigger.vue'
 
+  const props = withDefaults(
+    defineProps<TooltipRootProps & TooltipProviderProps & Omit<TooltipContentProps, 'asChild' | 'as'> & { text?: string }>(),
+    {
+      text: undefined,
+      // Mimicking radix-vue's TooltipRoot props. These need to be undefined rather than Vue's default behavior of
+      // coercing boolean props to false so that the default values are respected when forwarded.
+      defaultOpen: false,
+      open: undefined,
+      delayDuration: undefined,
+      disableHoverableContent: undefined,
+      disableClosingTrigger: undefined,
+      disabled: undefined,
+      ignoreNonKeyboardFocus: undefined,
+    })
 
-  // eslint-disable-next-line vue/no-unused-properties
-  const props = defineProps<TooltipRootProps & TooltipProviderProps & TooltipContentProps & { text?: string }>()
 
-
-  const delegatedRootProps = computed(() => {
-    // eslint-disable-next-line id-length, no-unused-vars
+  const delegatedRootProps = computed<TooltipRootProps>(() => {
     const { defaultOpen, open, delayDuration, disableHoverableContent, disableClosingTrigger, disabled, ignoreNonKeyboardFocus } = props
     return { defaultOpen, open, delayDuration, disableHoverableContent, disableClosingTrigger, disabled, ignoreNonKeyboardFocus }
   })
 
-  const delegatedProviderProps = computed(() => {
-    // eslint-disable-next-line id-length, no-unused-vars
-    const { delayDuration, disableHoverableContent, disableClosingTrigger, disabled, ignoreNonKeyboardFocus } = props
-    return { delayDuration, disableHoverableContent, disableClosingTrigger, disabled, ignoreNonKeyboardFocus }
+  const delegatedProviderProps = computed<TooltipProviderProps>(() => {
+    const { delayDuration, disableHoverableContent, disableClosingTrigger, disabled, ignoreNonKeyboardFocus, skipDelayDuration } = props
+    return { delayDuration, disableHoverableContent, disableClosingTrigger, disabled, ignoreNonKeyboardFocus, skipDelayDuration }
   })
 
-  const delegatedContentProps = computed(() => {
-    // eslint-disable-next-line id-length, no-unused-vars
-    const { side, sideOffset, align, avoidCollisions, collisionBoundary, collisionPadding, arrowPadding, sticky, hideWhenDetached } = props
-    return { side, sideOffset, align, avoidCollisions, collisionBoundary, collisionPadding, arrowPadding, sticky, hideWhenDetached }
+  const delegatedContentProps = computed<TooltipContentProps>(() => {
+    const { side, sideOffset, align, avoidCollisions, collisionBoundary, collisionPadding, arrowPadding, sticky, hideWhenDetached, ariaLabel, alignOffset } = props
+    return { side, sideOffset, align, avoidCollisions, collisionBoundary, collisionPadding, arrowPadding, sticky, hideWhenDetached, ariaLabel, alignOffset }
   })
 </script>


### PR DESCRIPTION
This PR fixes this warning in development when using p-tooltip

<img width="465" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/22418768/254f0081-ed7d-4b3b-95c4-6df6adc46f3b">
