### PR TITLE
[p-tooltip] Fix classes on p-tooltip throw warnings.

### DIFF
--- a/src/components/Tooltip/PTooltip.vue
+++ b/src/components/Tooltip/PTooltip.vue
@@ -1,7 +1,7 @@
 <template>
   <TooltipProvider v-bind="delegatedProviderProps">
     <TooltipRoot v-bind="delegatedRootProps">
-      <TooltipTrigger as-child>
+      <TooltipTrigger as-child v-bind="$attrs">
         <slot />
 
         <TooltipContent
@@ -42,6 +42,9 @@
       ignoreNonKeyboardFocus: undefined,
     })
 
+  defineOptions({
+    inheritAttrs: false,
+  })
 
   const delegatedRootProps = computed<TooltipRootProps>(() => {
     const { defaultOpen, open, delayDuration, disableHoverableContent, disableClosingTrigger, disabled, ignoreNonKeyboardFocus } = props


### PR DESCRIPTION
Similar to #1327, recent changes to p-tooltip have resulted in a lot of console warnings in development. This PR fixes another issue where using `<p-tooltip class="some class" ... />` results in warnings like the below:

<img width="373" alt="image" src="https://github.com/PrefectHQ/prefect-design/assets/22418768/64d651b9-b12d-44f3-bd98-36f40643c04c">

The warning is because attrs are falling through to TooltipProvider which doesn't render a single top-level node.