### PR TITLE
Enhancement: Don't explicitly set font size in markdown renderer nodes

### DIFF
--- a/src/components/MarkdownRenderer/PMarkdownRenderer.vue
+++ b/src/components/MarkdownRenderer/PMarkdownRenderer.vue
@@ -21,7 +21,6 @@
 
 <style>
 .markdown-renderer { @apply
-  text-base
   block
   overflow-auto
 }
@@ -45,7 +44,6 @@
 .markdown-renderer__blockquote .markdown-renderer__table,
 .markdown-renderer__blockquote .markdown-renderer__codespan { @apply
   font-normal
-  text-base
   not-italic
 }
 


### PR DESCRIPTION
This just makes it tougher to override these styles and doesn't give us any real benefit.