### PR TITLE
Fix auto close not working on PModal

### DIFF
--- a/src/components/Modal/PModal.vue
+++ b/src/components/Modal/PModal.vue
@@ -107,10 +107,6 @@
     },
   }))
 
-  function close(): void {
-    emit('update:showModal', false)
-  }
-
   function findFirstFocusable(): HTMLElement | undefined {
     const focusable = useFocusableElements(modalBody)
 
@@ -125,13 +121,13 @@
 
   function handleMaskClick(): void {
     if (props.autoClose) {
-      close()
+      modalScope.close()
     }
   }
 
   function closeOnEscape(event: KeyboardEvent): void {
     if (open.value && props.autoClose && isKeyEvent(keys.escape, event)) {
-      close()
+      modalScope.close()
     }
   }
   useGlobalEventListener('keyup', closeOnEscape)

--- a/src/components/Modal/PModal.vue
+++ b/src/components/Modal/PModal.vue
@@ -107,6 +107,10 @@
     },
   }))
 
+  function close(): void {
+    emit('update:showModal', false)
+  }
+
   function findFirstFocusable(): HTMLElement | undefined {
     const focusable = useFocusableElements(modalBody)
 


### PR DESCRIPTION
# Description
No local `close` method existed so it was attempting to call `window.close` which if the browser didn't prevent it would close the whole tab. Using `modalScope.close` fixes this. Looks like `modalScope` use to be destructured and close existed locally. But was lost when the destructure was removed. 