### PR TITLE
Enhancement: `PTabsTrigger` visual clarity

### DIFF
--- a/src/components/Tabs/PTabsTrigger.vue
+++ b/src/components/Tabs/PTabsTrigger.vue
@@ -25,7 +25,7 @@
   px-3
   py-1.5
   text-sm
-  font-medium
+  text-subdued
   ring-offset-background
   transition-all
   focus-visible:outline-none
@@ -36,6 +36,7 @@
   disabled:opacity-50
   data-[state=active]:bg-background
   data-[state=active]:text-foreground
+  data-[state=active]:text-default
   data-[state=active]:shadow-sm;
 }
 </style>


### PR DESCRIPTION
This PR improves the visual clarity of (in particular) the active tab trigger by de-emphasizing inactive tabs and by decreasing the default font-weight. 


| Before | After |
|---|---|
| <img width="397" alt="Screenshot 2024-06-10 at 12 56 58 PM" src="https://github.com/PrefectHQ/prefect-design/assets/27291717/f9fc0853-ab76-4306-a264-a363a5731d74"> | <img width="397" alt="Screenshot 2024-06-10 at 12 56 43 PM" src="https://github.com/PrefectHQ/prefect-design/assets/27291717/017fc6b7-08b1-4789-b21a-4d4af6176075"> |
| <img width="397" alt="Screenshot 2024-06-10 at 12 57 15 PM" src="https://github.com/PrefectHQ/prefect-design/assets/27291717/4f19d0e7-09ed-4148-bd43-17bbbaa6d74d"> | <img width="397" alt="Screenshot 2024-06-10 at 12 57 05 PM" src="https://github.com/PrefectHQ/prefect-design/assets/27291717/b131d375-c50d-49a1-ac56-9d23dfaff056"> |





