### PR TITLE
Enhancement: `PWizard` step header UX

### DIFF
--- a/demo/components/wizard/StepOne.vue
+++ b/demo/components/wizard/StepOne.vue
@@ -2,7 +2,7 @@
   <div class="step-one">
     <p-content>
       <p-form @submit="wizard.next">
-        <p-label label="Favorite Color" :state="state" :message="error">
+        <p-label label="Favorite Color" :state :message="error">
           <p-text-input v-model="internalValue" />
         </p-label>
       </p-form>

--- a/demo/components/wizard/StepOne.vue
+++ b/demo/components/wizard/StepOne.vue
@@ -2,7 +2,7 @@
   <div class="step-one">
     <p-content>
       <p-form @submit="wizard.next">
-        <p-label label="Favorite Color">
+        <p-label label="Favorite Color" :state="state" :message="error">
           <p-text-input v-model="internalValue" />
         </p-label>
       </p-form>
@@ -15,6 +15,7 @@
 
 <script lang="ts" setup>
   import { useWizardStep } from '@/compositions/wizard'
+  import { useValidation } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
 
   const props = defineProps<{
@@ -36,10 +37,20 @@
 
   const { wizard, defineValidate } = useWizardStep()
 
+
+  const { error, state, validate } = useValidation(internalValue, 'Favorite color', (value) => {
+    if (value.length === 0) {
+      return 'Favorite color is required'
+    }
+
+    return true
+  })
+
+
   defineValidate(() => {
     return new Promise(resolve => {
       setTimeout(() => {
-        resolve(internalValue.value.length > 0)
+        resolve(validate())
       }, 2000)
     })
   })

--- a/demo/components/wizard/StepTwo.vue
+++ b/demo/components/wizard/StepTwo.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="step-two">
     <p-form @submit="wizard.next">
-      <p-label label="Here are my terms, agree or perish">
+      <p-label label="Here are my terms, agree or perish" :state :message="error">
         <p-checkbox v-model="internalValue" label="I agree" />
       </p-label>
     </p-form>
@@ -10,6 +10,7 @@
 
 <script lang="ts" setup>
   import { useWizardStep } from '@/compositions/wizard'
+  import { useValidation } from '@prefecthq/vue-compositions'
   import { computed } from 'vue'
 
   const props = defineProps<{
@@ -31,5 +32,14 @@
 
   const { wizard, defineValidate } = useWizardStep()
 
-  defineValidate(() => internalValue.value)
+  const { error, state, validate } = useValidation(internalValue, (value) => {
+    if (!value) {
+      return 'You must accept the terms and conditions to continue.'
+    }
+
+    return true
+  })
+
+
+  defineValidate(validate)
 </script>

--- a/src/components/Wizard/PWizardHeaders.vue
+++ b/src/components/Wizard/PWizardHeaders.vue
@@ -8,6 +8,8 @@
           :current="index === currentStepIndex"
           :loading="loading && index === currentStepIndex"
           :complete="index < wizard.furthestStepIndex.value"
+          class="p-wizard-headers__step-header"
+          :class="classes.stepHeader(index)"
           @click="handleStepHeaderClick(index)"
         >
           <template #default="data">
@@ -51,6 +53,11 @@
     container: {
       'p-wizard-headers--wrapped': wrapped.value,
     },
+    stepHeader: (index: number) => {
+      return {
+        'p-wizard-headers__step-header--interactive': !props.loading && (props.nonlinear || index < wizard.furthestStepIndex.value),
+      }
+    },
   }))
 </script>
 
@@ -66,5 +73,13 @@
 .p-wizard-headers--wrapped { @apply
   justify-start
   flex-col
+}
+
+.p-wizard-headers__step-header { @apply
+  cursor-default
+}
+
+.p-wizard-headers__step-header--interactive { @apply
+  cursor-pointer
 }
 </style>

--- a/src/components/Wizard/PWizardHeaders.vue
+++ b/src/components/Wizard/PWizardHeaders.vue
@@ -9,6 +9,7 @@
           :loading="loading && index === currentStepIndex"
           :complete="index < wizard.furthestStepIndex.value"
           class="p-wizard-headers__step-header"
+          :disabled="stepIsDisabled(index)"
           :class="classes.stepHeader(index)"
           @click="handleStepHeaderClick(index)"
         >
@@ -42,12 +43,19 @@
 
   const wizard = useWizard()
 
+  const stepIsDisabled = (index: number): boolean => {
+    return !props.nonlinear && index > wizard.furthestStepIndex.value
+  }
+
+
   function handleStepHeaderClick(index: number): void {
-    if (!props.nonlinear && index > wizard.furthestStepIndex.value) {
+    if (props.loading || stepIsDisabled(index)) {
       return
     }
+
     wizard.goto(index + 1)
   }
+
 
   const classes = computed(() => ({
     container: {
@@ -55,7 +63,8 @@
     },
     stepHeader: (index: number) => {
       return {
-        'p-wizard-headers__step-header--interactive': !props.loading && (props.nonlinear || index < wizard.furthestStepIndex.value),
+        'p-wizard-headers__step-header--loading': props.loading,
+        'p-wizard-headers__step-header--interactive': !props.loading && !stepIsDisabled(index) && index !== props.currentStepIndex,
       }
     },
   }))
@@ -75,11 +84,11 @@
   flex-col
 }
 
-.p-wizard-headers__step-header { @apply
-  cursor-default
-}
-
 .p-wizard-headers__step-header--interactive { @apply
   cursor-pointer
+}
+
+.p-wizard-headers__step-header--loading { @apply
+  cursor-wait
 }
 </style>

--- a/src/components/Wizard/PWizardStepHeader.vue
+++ b/src/components/Wizard/PWizardStepHeader.vue
@@ -47,6 +47,7 @@
   inline-flex
   items-center
   gap-4
+  cursor-default
   text-subdued
 }
 
@@ -65,5 +66,9 @@
 
 .p-wizard-step-header--current { @apply
   text-selected
+}
+
+.p-wizard-step-header:disabled { @apply
+  cursor-not-allowed
 }
 </style>


### PR DESCRIPTION
This PR removes the step header `cursor: pointer` for non-interactive header elements. When in a linear form this means that future steps won't show the cursor unless the steps before them have passed validation.

Resolves: https://github.com/PrefectHQ/nebula-ui/issues/4800