### PR TITLE
Remove scoped from style block in PTable

### DIFF
--- a/src/components/Table/PTable.vue
+++ b/src/components/Table/PTable.vue
@@ -189,7 +189,7 @@
   }
 </script>
 
-<style scoped>
+<style>
 .p-table { @apply
   overflow-hidden
   overflow-x-auto


### PR DESCRIPTION
# Description
This was never added intentionally. Removing now because its messing with an implementation style. 