### PR TITLE
Downgrade typescript from 5.5 -> 5.4 to fix improper p-table generic typing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "tailwindcss-animate": "^1.0.7",
         "ts-node": "^10.7.0",
         "tsc-alias": "1.8.10",
-        "typescript": "5.5.2",
+        "typescript": "5.4.5",
         "vite": "5.3.2",
         "vite-plugin-vue-devtools": "^7.1.3",
         "vite-svg-loader": "5.1.0",
@@ -7476,9 +7476,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.2.tgz",
-      "integrity": "sha512-NcRtPEOsPFFWjobJEtfihkLCZCXZt/os3zf8nTxjVH3RvTSxjrCamJpbExGvYOF+tFHc3pA65qpdwPbzjohhew==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "tailwindcss-animate": "^1.0.7",
     "ts-node": "^10.7.0",
     "tsc-alias": "1.8.10",
-    "typescript": "5.5.2",
+    "typescript": "5.4.5",
     "vite": "5.3.2",
     "vite-plugin-vue-devtools": "^7.1.3",
     "vite-svg-loader": "5.1.0",


### PR DESCRIPTION
This dependency bump seems to have caused downstream issues with `<p-table />`. Specifically, the generic types around TableData don't seem to be working correctly. Downstream consumption breaks on scoped slot type inference where the `row` _should_ be inferred from the passed in data type, but is instead being picked up as just `TableData`.

Found some potentially related issues in vue-tsc around TS 5.5 and changes related to `@vue/runtime-core`, but neither changing the global TS declaration (for global components) nor updating the tsconfig.json to include
```
"vueCompilerOptions": {
    "lib": "@vue/runtime-core",
},
```

(as mentioned in those issues) seemed to fix the issue. Going to revert this upgrade for now.