### PR TITLE
Remove install step from project specific ci

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,8 +34,5 @@ jobs:
         id: setup
         uses: prefecthq/actions-setup-nodejs@main
 
-      - name: Install dependencies
-        run: npm ci install
-
       - name: Build package
         run: npm run build


### PR DESCRIPTION
# Description
The setup node action already installs packages (and caches them). 

https://github.com/PrefectHQ/actions-setup-nodejs/blob/main/action.yaml#L22