### PR TITLE
BugFix: incorrect css custom property syntax

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -307,7 +307,7 @@
     --p-color-button-default-border-active: var(--p-color-button-default-border-hover);
     --p-color-button-default-text-active: var(--p-color-button-default-text-hover);
 
-    --p-color-button-primary-bg: hsl(--p-primary);
+    --p-color-button-primary-bg: hsl(var(--p-primary));
     --p-color-button-primary-border: transparent;
     --p-color-button-primary-text: var(--p-color-text-inverse);
     --p-color-button-primary-bg-hover: hsl(var(--p-primary-hue), 89.92%, 52%);


### PR DESCRIPTION
Only when using `light` mode, value for `--p-color-button-primary-bg` was set to `hsl(--p-primary)`. I'm guessing this is intended to be using the custom property `p-primary` but is missing the `var()` syntax.