### PR TITLE
Fix module declaration

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -327,7 +327,7 @@ export const installs = [
   installPWizard,
 ]
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface GlobalComponents {
     PAccordion: typeof PAccordion,
     PAutoHeightTransition: typeof PAutoHeightTransition,


### PR DESCRIPTION
# Description
This release replaces declare module `@vue/runtime-core` with declare module `vue` like it's [supposed to be](https://vuejs.org/guide/extras/web-components.html#web-components-and-typescript). 