### PR TITLE
Enhancement: Make tooltip collision avoidance opt-out

### DIFF
--- a/src/components/Tooltip/PTooltip.vue
+++ b/src/components/Tooltip/PTooltip.vue
@@ -7,6 +7,7 @@
         <TooltipContent
           v-bind="delegatedContentProps"
           :as-child="Boolean($slots.tooltip)"
+          :avoid-collisions="!allowCollisions"
         >
           <slot name="tooltip">
             <slot name="content">
@@ -28,7 +29,7 @@
   import TooltipTrigger from '@/components/Tooltip/PTooltipTrigger.vue'
 
   const props = withDefaults(
-    defineProps<TooltipRootProps & TooltipProviderProps & Omit<TooltipContentProps, 'asChild' | 'as'> & { text?: string }>(),
+    defineProps<TooltipRootProps & TooltipProviderProps & Omit<TooltipContentProps, 'asChild' | 'as'> & { text?: string, allowCollisions?: boolean }>(),
     {
       text: undefined,
       // Mimicking radix-vue's TooltipRoot props. These need to be undefined rather than Vue's default behavior of

--- a/src/components/Tooltip/PTooltipContent.vue
+++ b/src/components/Tooltip/PTooltipContent.vue
@@ -36,7 +36,8 @@
   bg-popover
   px-3
   py-1.5
-  text-sm
+  text-xs
+  font-mono
   text-popover-foreground
   shadow-md
   animate-in


### PR DESCRIPTION
This should be the default behavior; also makes the mono xs font the default for content (we were overriding this downstream enough)