### PR TITLE
Bugfix: Light mode accent colors

### DIFF
--- a/src/components/Button/PButton.vue
+++ b/src/components/Button/PButton.vue
@@ -184,40 +184,40 @@
   disabled:opacity-50
   select-none
   aria-selected:bg-[color:var(--p-color-button-selected-bg)]
-  aria-selected:text-[color:var(--p-color-button-selected-test)]
+  aria-selected:text-[color:var(--p-color-button-selected-text)]
   aria-selected:border-[color:var(--p-color-button-selected-border)]
 }
 
-.p-button--default{ @apply
+.p-button--default { @apply
   bg-primary
   text-primary-foreground
   hover:bg-primary/90
   active:bg-primary/80
 }
 
-.p-button--outline{ @apply
+.p-button--outline { @apply
   border
   border-input
   bg-background
   hover:bg-accent
   hover:text-accent-foreground
-  active:bg-accent/90
+  active:bg-accent/60
 }
 
-.p-button--ghost{ @apply
+.p-button--ghost { @apply
   hover:bg-accent
   hover:text-accent-foreground
-  active:bg-accent/90
+  active:bg-accent/60
 }
 
-.p-button--destructive{ @apply
+.p-button--destructive { @apply
   bg-destructive
   text-destructive-foreground
   hover:bg-destructive/90
   active:bg-destructive/80
 }
 
-.p-button--link{ @apply
+.p-button--link { @apply
   text-primary
   underline-offset-4
   hover:underline

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -217,7 +217,7 @@
 
     --p-primary: var(--p-primary-hue) 80.34% 44%;
     --p-primary-foreground: var(--p-primary-hue) 0.0% 100.0%;
-    --p-accent: var(--p-primary-hue) 0.0% 92%;
+    --p-accent: var(--p-primary-hue) 6% 85%;
     --p-accent-foreground: var(--p-primary-hue) 6% 9.02%;
     --p-destructive: 4 74% 49%;
     --p-destructive-foreground: 0.0 0.0% 100.0%;


### PR DESCRIPTION
Fixes an issue where light mode accent colors matched non-accent bg colors, causing button presses to be invisible to the user.

Before:

https://github.com/user-attachments/assets/3f3d6a37-b7ee-4f15-9319-87afd4c3d915

After:

https://github.com/user-attachments/assets/25456063-ddf8-4466-8a20-fdae71f7a608

