### PR TITLE
Bugfix: PButton sizing issues

### DIFF
--- a/src/components/Button/PButton.vue
+++ b/src/components/Button/PButton.vue
@@ -9,11 +9,11 @@
   >
     <div class="p-button__content">
       <template v-if="icon">
-        <PIcon :size="iconSize" :icon :solid class="p-button__icon" />
+        <PIcon :size="iconSize ?? size" :icon :solid class="p-button__icon" />
       </template>
       <slot />
       <template v-if="iconAppend">
-        <PIcon :size="iconSize" :icon="iconAppend" :solid="solidAppend ?? solid" class="p-button__icon" />
+        <PIcon :size="iconSize ?? size" :icon="iconAppend" :solid="solidAppend ?? solid" class="p-button__icon" />
       </template>
     </div>
     <template v-if="loading">
@@ -56,7 +56,7 @@
         {
           size: 'sm',
           icon: true,
-          class: 'max-h-7 max-w-7',
+          class: 'max-h-[30px] max-w-[30px]',
         },
       ],
       defaultVariants: {
@@ -232,6 +232,11 @@
   justify-center
   items-center
   font-normal
+}
+
+.p-button__icon { @apply
+  shrink-0
+  grow
 }
 
 .p-button__loading-icon {

--- a/src/components/Icon/PIcon.vue
+++ b/src/components/Icon/PIcon.vue
@@ -13,7 +13,7 @@
   const props = defineProps<{
     icon: Icon,
     solid?: boolean,
-    size?: 'small' | 'default' | 'large',
+    size?: 'small' | 'default' | 'large' | 'sm' | 'lg',
   }>()
 
   const component = computed(() => {
@@ -46,11 +46,13 @@
   h-5
 }
 
+.p-icon--sm,
 .p-icon--small { @apply
   w-4
   h-4
 }
 
+.p-icon--lg,
 .p-icon--large { @apply
   w-6
   h-6

--- a/src/components/Select/PSelectButton.vue
+++ b/src/components/Select/PSelectButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <PBaseInput ref="wrapperElement" class="p-select-button" :small="props.small">
+  <PBaseInput ref="wrapperElement" class="p-select-button" :small>
     <template v-for="(index, name) in $slots" #[name]="data">
       <slot :name="name" v-bind="data" />
     </template>
@@ -8,7 +8,6 @@
         ref="buttonElement"
         type="button"
         class="p-select-button__control"
-        aria-hidden="true"
         v-bind="attrs"
       >
         <span class="p-select-button__value" :class="classes.value">


### PR DESCRIPTION
Fixes some sizing issues with small icon-only buttons as well as an aria attribute issue that was causing errors with `PSelectButton`

Before: ( 28px height ); in order this is a `p-select`, `p-icon-button-menu`, `p-button` (text), `p-button` (icon)
<img width="829" alt="Screenshot 2024-10-17 at 12 15 19 PM" src="https://github.com/user-attachments/assets/feead058-6938-4b3a-9c47-7529b6eb2105">

After ( 30px height, same as `PSelect`)
<img width="829" alt="Screenshot 2024-10-17 at 12 15 02 PM" src="https://github.com/user-attachments/assets/4e283e88-1111-4490-8cca-12ace6edcea8">
