### PR TITLE
Add the ability to scroll an item into view in the virtual scroller

### DIFF
--- a/demo/sections/components/VirtualScroller.vue
+++ b/demo/sections/components/VirtualScroller.vue
@@ -1,30 +1,50 @@
 <template>
   <ComponentPage title="Virtual Scroller" :demos="[{ title: 'Virtual Scroller' }]">
     <template #virtual-scroller>
-      <p-number-input v-model="itemCount" />
+      <p-content>
+        <p-number-input v-model="itemCount" />
 
-      <div class="virtual-scroller_demo">
-        <p-virtual-scroller :items="items">
-          <template #default="{ item }">
-            <div>
-              {{ item }}
-            </div>
-          </template>
-        </p-virtual-scroller>
-      </div>
+        <div class="virtual-scroller_demo">
+          <p-virtual-scroller :items name="demo-scroller" :item-estimate-height="24">
+            <template #default="{ item, id }">
+              <div :id>
+                {{ item }}
+              </div>
+            </template>
+          </p-virtual-scroller>
+        </div>
+
+        <div class="flex gap-2">
+          <p-number-input v-model="itemToScrollTo" />
+          <p-button @click="scrollToItem">
+            Scroll to item
+          </p-button>
+          <p-checkbox v-model="smooth" label="smooth" />
+        </div>
+      </p-content>
     </template>
   </ComponentPage>
 </template>
 
 <script lang="ts" setup>
+  import { getVirtualScroller } from '@/components/VirtualScroller'
   import { computed, ref } from 'vue'
   import ComponentPage from '@/demo/components/ComponentPage.vue'
 
-  const itemCount = ref(100)
+  const itemCount = ref(1000)
   const items = computed(() => new Array(itemCount.value).fill(null).map((item, index) => ({
     id: index,
     label: `item #${index}`,
   })))
+
+  const itemToScrollTo = ref<number>(800)
+  const smooth = ref(true)
+
+  function scrollToItem(): void {
+    const scroller = getVirtualScroller('demo-scroller')
+
+    scroller.scrollItemIntoView(itemToScrollTo.value, { behavior: smooth.value ? 'smooth' : 'auto' })
+  }
 </script>
 
 <style>
@@ -32,6 +52,5 @@
   border
   overflow-auto
   max-h-52
-  mt-2
 }
 </style>

--- a/src/components/VirtualScroller/PVirtualScrollerChunk.vue
+++ b/src/components/VirtualScroller/PVirtualScrollerChunk.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="el" class="p-virtual-scroller-chunk" :style="styles">
-    <template v-if="visible">
+    <template v-if="forceVisible || visible">
       <slot />
     </template>
   </div>
@@ -13,6 +13,7 @@
   const props = defineProps<{
     height: number,
     observerOptions: IntersectionObserverInit,
+    forceVisible?: boolean,
   }>()
 
   const styles = computed(() => ({

--- a/src/components/VirtualScroller/index.ts
+++ b/src/components/VirtualScroller/index.ts
@@ -1,6 +1,8 @@
 import { App } from 'vue'
 import PVirtualScroller from '@/components/VirtualScroller/PVirtualScroller.vue'
 
+export * from '@/components/VirtualScroller/utilities'
+
 const install = (app: App): void => {
   app.component('PVirtualScroller', PVirtualScroller)
 }

--- a/src/components/VirtualScroller/utilities.ts
+++ b/src/components/VirtualScroller/utilities.ts
@@ -1,0 +1,57 @@
+const scrollers = new Map<string, UseVirtualScroller>()
+
+type UseVirtualScroller = {
+  makeItemVisible: (itemKey: unknown) => void,
+  scrollItemIntoView: (itemKey: unknown, options?: ScrollIntoViewOptions) => void,
+}
+
+export function registerVirtualScroller(name: string, scroller: UseVirtualScroller): void {
+  scrollers.set(name, scroller)
+}
+
+export function unregisterVirtualScroller(name: string): void {
+  scrollers.delete(name)
+}
+
+export function getVirtualScroller(name: string): UseVirtualScroller {
+
+  const makeItemVisible: UseVirtualScroller['makeItemVisible'] = (itemKey) => {
+    const scroller = scrollers.get(name)
+
+    return scroller?.makeItemVisible(itemKey)
+  }
+
+  const scrollItemIntoView: UseVirtualScroller['scrollItemIntoView'] = (itemKey, options) => {
+    const scroller = scrollers.get(name)
+
+    return scroller?.scrollItemIntoView(itemKey, options)
+  }
+
+  return {
+    makeItemVisible,
+    scrollItemIntoView,
+  }
+}
+
+export function scrollIntoView(target: Element, options?: ScrollIntoViewOptions): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>()
+
+  const observer = new IntersectionObserver((entries) => {
+    const [entry] = entries
+
+    if (entry.isIntersecting) {
+      observer.unobserve(target)
+      observer.disconnect()
+
+      setTimeout(() => {
+        resolve()
+      }, 100)
+    }
+  })
+
+  observer.observe(target)
+
+  target.scrollIntoView(options)
+
+  return promise
+}


### PR DESCRIPTION
# Description
Adds a new utility `getVirtualScroller` where you can get access to a virtual scroller instance by its given name (which is now a prop on the virtual scroller component). This way we can grab a scroller at any point in the component tree. The available actions are
- `makeItemVisible` - Accepts an itemKey and forces the chunk that item belongs to to be visible
- `scrollItemIntoView` - Accepts an itemKey and automatically scrolls to that item. 