### PR TITLE
Bugfix: Don't create dates to calculate intervals for `PDateRangeSelect`

### DIFF
--- a/demo/sections/components/DateRangeSelect.vue
+++ b/demo/sections/components/DateRangeSelect.vue
@@ -35,7 +35,7 @@
   const exampleState = ref<State>()
   const disabled = ref(false)
 
-  const value = ref({"type":"span","seconds":-604800})
+  const value = ref()
   const min = ref<Date>()
   const max = ref<Date>()
   const clearable = ref(true)

--- a/demo/sections/components/DateRangeSelect.vue
+++ b/demo/sections/components/DateRangeSelect.vue
@@ -35,7 +35,7 @@
   const exampleState = ref<State>()
   const disabled = ref(false)
 
-  const value = ref()
+  const value = ref({"type":"span","seconds":-604800})
   const min = ref<Date>()
   const max = ref<Date>()
   const clearable = ref(true)

--- a/src/components/DateRangeSelect/utilities.ts
+++ b/src/components/DateRangeSelect/utilities.ts
@@ -3,6 +3,7 @@ import {
   secondsInHour,
   secondsInMinute,
   secondsInDay,
+  secondsInWeek
 } from 'date-fns/constants'
 import { DateRangeSelectAroundValue, DateRangeSelectPeriodValue, DateRangeSelectRangeValue, DateRangeSelectSpanValue, DateRangeSelectValue } from '@/types'
 import { toPluralString } from '@/utilities'
@@ -42,7 +43,8 @@ function getDateSpanLabel({ seconds }: DateRangeSelectSpanValue): string {
   const absSeconds = Math.abs(seconds)
 
   const duration: Duration = {
-    days: Math.floor(absSeconds / secondsInDay),
+    weeks: Math.floor(absSeconds / secondsInWeek),
+    days: Math.floor(absSeconds % secondsInWeek / secondsInDay),
     hours: Math.floor(absSeconds % secondsInDay / secondsInHour),
     minutes: Math.floor(absSeconds % secondsInHour / secondsInMinute),
     seconds: Math.floor(absSeconds % secondsInMinute),

--- a/src/components/DateRangeSelect/utilities.ts
+++ b/src/components/DateRangeSelect/utilities.ts
@@ -5,7 +5,7 @@ import {
   secondsInDay,
   secondsInWeek,
   secondsInYear,
-  secondsInMonth,
+  secondsInMonth
 } from 'date-fns/constants'
 import { DateRangeSelectAroundValue, DateRangeSelectPeriodValue, DateRangeSelectRangeValue, DateRangeSelectSpanValue, DateRangeSelectValue } from '@/types'
 import { toPluralString } from '@/utilities'

--- a/src/components/DateRangeSelect/utilities.ts
+++ b/src/components/DateRangeSelect/utilities.ts
@@ -3,9 +3,6 @@ import {
   secondsInHour,
   secondsInMinute,
   secondsInDay,
-  secondsInWeek,
-  secondsInYear,
-  secondsInMonth
 } from 'date-fns/constants'
 import { DateRangeSelectAroundValue, DateRangeSelectPeriodValue, DateRangeSelectRangeValue, DateRangeSelectSpanValue, DateRangeSelectValue } from '@/types'
 import { toPluralString } from '@/utilities'
@@ -45,10 +42,7 @@ function getDateSpanLabel({ seconds }: DateRangeSelectSpanValue): string {
   const absSeconds = Math.abs(seconds)
 
   const duration: Duration = {
-    years: Math.floor(absSeconds / secondsInYear),
-    months: Math.floor(absSeconds % secondsInYear / secondsInMonth),
-    weeks: Math.floor(absSeconds % secondsInMonth / secondsInWeek),
-    days: Math.floor(absSeconds % secondsInWeek / secondsInDay),
+    days: Math.floor(absSeconds / secondsInDay),
     hours: Math.floor(absSeconds % secondsInDay / secondsInHour),
     minutes: Math.floor(absSeconds % secondsInHour / secondsInMinute),
     seconds: Math.floor(absSeconds % secondsInMinute),

--- a/src/components/DateRangeSelect/utilities.ts
+++ b/src/components/DateRangeSelect/utilities.ts
@@ -1,10 +1,5 @@
 import { format, isSameDay, startOfDay, endOfDay, Duration } from 'date-fns'
-import {
-  secondsInHour,
-  secondsInMinute,
-  secondsInDay,
-  secondsInWeek
-} from 'date-fns/constants'
+import { secondsInDay, secondsInHour, secondsInMinute, secondsInWeek } from 'date-fns/constants'
 import { DateRangeSelectAroundValue, DateRangeSelectPeriodValue, DateRangeSelectRangeValue, DateRangeSelectSpanValue, DateRangeSelectValue } from '@/types'
 import { toPluralString } from '@/utilities'
 

--- a/src/components/DateRangeSelect/utilities.ts
+++ b/src/components/DateRangeSelect/utilities.ts
@@ -1,6 +1,15 @@
-import { intervalToDuration, addSeconds, format, isSameDay, startOfDay, endOfDay } from 'date-fns'
+import { format, isSameDay, startOfDay, endOfDay, Duration } from 'date-fns'
+import {
+  secondsInHour,
+  secondsInMinute,
+  secondsInDay,
+  secondsInWeek,
+  secondsInYear,
+  secondsInMonth,
+} from 'date-fns/constants'
 import { DateRangeSelectAroundValue, DateRangeSelectPeriodValue, DateRangeSelectRangeValue, DateRangeSelectSpanValue, DateRangeSelectValue } from '@/types'
 import { toPluralString } from '@/utilities'
+
 
 type DateRange = {
   startDate: Date,
@@ -33,11 +42,17 @@ export function getDateRangeSelectValueLabel(value: DateRangeSelectValue): strin
 }
 
 function getDateSpanLabel({ seconds }: DateRangeSelectSpanValue): string {
-  const now = new Date()
-  const duration = intervalToDuration({
-    start: now,
-    end: addSeconds(now, Math.abs(seconds)),
-  })
+  const absSeconds = Math.abs(seconds)
+
+  const duration: Duration = {
+    years: Math.floor(absSeconds / secondsInYear),
+    months: Math.floor(absSeconds % secondsInYear / secondsInMonth),
+    weeks: Math.floor(absSeconds % secondsInMonth / secondsInWeek),
+    days: Math.floor(absSeconds % secondsInWeek / secondsInDay),
+    hours: Math.floor(absSeconds % secondsInDay / secondsInHour),
+    minutes: Math.floor(absSeconds % secondsInHour / secondsInMinute),
+    seconds: Math.floor(absSeconds % secondsInMinute),
+  }
 
   const reduced = Object.entries(duration).reduce<string[]>((durations, [key, value]) => {
     if (value) {


### PR DESCRIPTION
The upcoming DST switchover surfaced a bug in the way we're calculating the span labels for `PDateRangeSelect`. This results in an off-by-DST-interval (usually 1 hour but not everywhere!) label whenever the encompassing timeframe includes a DST boundary.

This PR addresses this by removing dates from the equation, instead relying on seconds to a given timeframe. To avoid needing some much more complicated calculations around DST boundaries, month seconds, and leap years, I've eliminated month and year support, with weeks as the largest interval this picker supports for now. 