### PR TITLE
Fix absolute urls when using `PLink`

### DIFF
--- a/demo/sections/components/Links.vue
+++ b/demo/sections/components/Links.vue
@@ -4,6 +4,7 @@
     :demos="[
       { title: 'Local' },
       { title: 'External' },
+      { title: 'Absolute' },
     ]"
   >
     <template #local>
@@ -17,9 +18,18 @@
         Link to prefect.io
       </p-link>
     </template>
+
+    <template #absolute>
+      <p-link :to="absolute">
+        {{ absolute }}
+      </p-link>
+    </template>
   </ComponentPage>
 </template>
 
 <script lang="ts" setup>
+  import { computed } from 'vue'
   import ComponentPage from '@/demo/components/ComponentPage.vue'
+
+  const absolute = computed(() => `${window.location.protocol}//${window.location.host}/components/links`)
 </script>

--- a/src/components/Link/PLink.vue
+++ b/src/components/Link/PLink.vue
@@ -11,14 +11,15 @@
   import { computed } from 'vue'
   import { RouteLocationRaw } from 'vue-router'
   import PIcon from '@/components/Icon/PIcon.vue'
-  import { isRouteExternal } from '@/utilities/router'
+  import { isRouteExternal, isRouteRelative } from '@/utilities/router'
 
   const props = defineProps<{
     to?: RouteLocationRaw,
   }>()
 
   const isExternal = computed(() => !!props.to && isRouteExternal(props.to))
-  const component = computed(() => !props.to || isExternal.value ? 'a' : 'router-link')
+  const isAbsolute = computed(() => !!props.to && !isRouteRelative(props.to))
+  const component = computed(() => !props.to || isExternal.value || isAbsolute.value ? 'a' : 'router-link')
   const componentProps = computed(() => {
     if (!props.to) {
       return {
@@ -26,7 +27,7 @@
       }
     }
 
-    if (isExternal.value) {
+    if (isExternal.value || isAbsolute.value) {
       return {
         href: props.to,
         target: '_blank',

--- a/src/utilities/router.ts
+++ b/src/utilities/router.ts
@@ -30,7 +30,11 @@ export function isRouteExternal(route: RouteLocationRaw): boolean {
   }
 }
 
-export function isRouteRelative(route: string): boolean {
+export function isRouteRelative(route: RouteLocationRaw): boolean {
+  if (typeof route !== 'string') {
+    return false
+  }
+
   return route.startsWith('/')
 }
 


### PR DESCRIPTION
# Description
Because `router-link` treats every string as a relative url we need to treat strings that are absolute urls the same as we treat external urls. 