### PR TITLE
Fix PDateRangeSelect height inconsistencies when using size sm

### DIFF
--- a/src/components/DateRangeSelect/PDateRangeSelect.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelect.vue
@@ -65,7 +65,7 @@
       variants: {
         size: {
           default: 'h-10',
-          sm: 'h-7',
+          sm: 'h-[30px]',
         },
       },
     })


### PR DESCRIPTION
# Description 

Before
<img width="1303" alt="image" src="https://github.com/user-attachments/assets/77ee67f6-e768-483d-97d2-4c397c37902b">

After
<img width="1294" alt="image" src="https://github.com/user-attachments/assets/aa4416ad-7f26-42c4-94a5-35cc43cc7841">
