### PR TITLE
Default the combobox search input to size small

### DIFF
--- a/src/components/Combobox/PCombobox.vue
+++ b/src/components/Combobox/PCombobox.vue
@@ -26,6 +26,7 @@
           tabindex="-1"
           aria-controls="options"
           aria-expanded="false"
+          small
           @keydown="handleTextInputKeydown"
           @focus="handleFocus"
         />


### PR DESCRIPTION
# Description
Since we're using the small size inputs more frequently the regular size search in the combobox options looks very large. Default that to small (which looks good for both size comboboxes)

Part of https://linear.app/prefect/issue/CLOUD-786/tags-input-ux-is-poor