### PR TITLE
Allow adding class to select options

### DIFF
--- a/src/components/Combobox/PCombobox.vue
+++ b/src/components/Combobox/PCombobox.vue
@@ -2,6 +2,7 @@
   <PSelect
     v-model="modelValue"
     :options="filteredSelectOptions"
+    :options-class
     :empty-message="emptyMessage"
     @update:model-value="resetTypedValue"
     @close="resetTypedValue"
@@ -71,10 +72,12 @@
     placeholder?: string,
     search?: string,
     manual?: boolean,
+    optionsClass?: string,
   }>(), {
     emptyMessage: undefined,
     placeholder: 'Search',
     search: undefined,
+    optionsClass: undefined,
   })
 
   const emit = defineEmits<{

--- a/src/components/Select/PSelect.vue
+++ b/src/components/Select/PSelect.vue
@@ -73,6 +73,7 @@
     <PSelectOptions
       v-model="modelValue"
       class="p-select__options"
+      :class="optionsClass"
       :options="options"
       :style="styles.option"
       :multiple="multiple"
@@ -117,6 +118,7 @@
     emptyMessage?: string,
     multiple?: boolean,
     small?: boolean,
+    optionsClass?: string,
   }>()
 
   const emit = defineEmits<{

--- a/src/components/TagsInput/PTagsInput.vue
+++ b/src/components/TagsInput/PTagsInput.vue
@@ -1,5 +1,12 @@
 <template>
-  <PCombobox v-model="internalValue" class="p-tags-input" allow-unknown-value :options="[]" :placeholder="placeholder">
+  <PCombobox
+    v-model="internalValue"
+    class="p-tags-input"
+    allow-unknown-value
+    :options="[]"
+    :placeholder
+    :options-class
+  >
     <template v-for="(index, name) in $slots" #[name]="data">
       <slot :name="name" v-bind="data" />
     </template>
@@ -24,8 +31,10 @@
   const props = withDefaults(defineProps<{
     modelValue: string[] | null | undefined,
     placeholder?: string,
+    optionsClass?: string,
   }>(), {
     placeholder: 'Add tag',
+    optionsClass: undefined,
   })
 
   const emit = defineEmits<{


### PR DESCRIPTION
# Description
Lets implementations add a custom class to the `p-select__options` element which is teleported. 