### PR TITLE
[PDateRangeSelect] Add the ability to add reasons for the min and max dates

### DIFF
--- a/demo/sections/components/DateRangeSelect.vue
+++ b/demo/sections/components/DateRangeSelect.vue
@@ -2,12 +2,18 @@
   <ComponentPage title="Date Range Select" :demos="[{ title: 'Date Range Select' }, { title: 'Date Range Select Small' }]">
     <template #description>
       <DemoState v-model:state="exampleState" v-model:disabled="disabled" />
-      <p-checkbox v-model="clearable" :disabled="disabled" label="Clearable" />
+      <p-content secondary>
+        <p-checkbox v-model="clearable" :disabled="disabled" label="Clearable" />
+        <div class="flex gap-2">
+          <p-date-input v-model="min" />
+          <p-date-input v-model="max" />
+        </div>
+      </p-content>
     </template>
 
     <template #date-range-select>
       <p-content>
-        <p-date-range-select v-model="value" v-bind="{ min, max, clearable, disabled }" />
+        <p-date-range-select v-model="value" v-bind="{ min, max, clearable, disabled, minReason, maxReason }" />
         <p-code inline>
           value: {{ JSON.stringify(value) }}
         </p-code>
@@ -15,7 +21,7 @@
     </template>
     <template #date-range-select-small>
       <p-content>
-        <p-date-range-select v-model="value" v-bind="{ min, max, clearable, disabled }" size="sm">
+        <p-date-range-select v-model="value" v-bind="{ min, max, clearable, disabled, minReason, maxReason }" size="sm">
           <p-code inline>
             value: {{ JSON.stringify(value) }}
           </p-code>
@@ -26,8 +32,8 @@
 </template>
 
 <script lang="ts" setup>
-  import { State } from '@/types'
-  import { format } from 'date-fns'
+  import { DateRangeSelectValue, State } from '@/types'
+  import { endOfDay, startOfWeek } from 'date-fns'
   import { ref } from 'vue'
   import ComponentPage from '@/demo/components/ComponentPage.vue'
   import DemoState from '@/demo/components/DemoState.vue'
@@ -35,8 +41,10 @@
   const exampleState = ref<State>()
   const disabled = ref(false)
 
-  const value = ref()
-  const min = ref<Date>()
-  const max = ref<Date>()
-  const clearable = ref(true)
+  const value = ref<DateRangeSelectValue>({ type: 'span', seconds: -604800 })
+  const min = ref<Date>(startOfWeek(new Date()))
+  const max = ref<Date>(endOfDay(new Date()))
+  const minReason = ref('min reason')
+  const maxReason = ref('max reason')
+  const clearable = ref(false)
 </script>

--- a/src/components/Calendar/PCalendar.vue
+++ b/src/components/Calendar/PCalendar.vue
@@ -3,7 +3,7 @@
     <PCalendarHeader v-model="viewingDate" v-model:mode="mode" v-bind="{ min, max }" />
 
     <div class="p-calendar__mode">
-      <PCalendarDatePicker v-model="selected" :class="classes" v-bind="{ viewingDate, min, max }" @mode="mode = $event">
+      <PCalendarDatePicker v-model="selected" :class="classes" v-bind="{ viewingDate, min, max, minReason, maxReason }" @mode="mode = $event">
         <template #date="scope">
           <slot name="date" v-bind="scope" />
         </template>
@@ -44,7 +44,9 @@
     viewingDate?: Date | null | undefined,
     classes?: Classes,
     min?: Date | null | undefined,
+    minReason?: string,
     max?: Date | null | undefined,
+    maxReason?: string,
   }>()
 
   const emit = defineEmits<{

--- a/src/components/Calendar/PCalendarDatePicker.vue
+++ b/src/components/Calendar/PCalendarDatePicker.vue
@@ -9,26 +9,31 @@
     </div>
     <div class="p-calendar-date-picker__dates">
       <template v-for="date in dates" :key="date.getTime()">
-        <slot name="date" v-bind="scope(date)">
-          <PButton
-            small
-            flat
-            class="p-calendar-date-picker__date"
-            :class="getDateClasses(date)"
-            :disabled="isDateDisabled(date)"
-            @click="setSelected(date)"
-          >
-            {{ date.getDate() }}
-          </PButton>
-        </slot>
+        <PTooltip :text="getReason(date)" :disabled="getReasonDisabled(date)">
+          <div class="p-calendar-date-picker__trigger">
+            <slot name="date" v-bind="scope(date)">
+              <PButton
+                small
+                flat
+                class="p-calendar-date-picker__date"
+                :class="getDateClasses(date)"
+                :disabled="isDateDisabled(date)"
+                @click="setSelected(date)"
+              >
+                {{ date.getDate() }}
+              </PButton>
+            </slot>
+          </div>
+        </PTooltip>
       </template>
     </div>
   </div>
 </template>
 
 <script lang="ts" setup>
-  import { eachDayOfInterval, endOfMonth, endOfWeek, format, isSameDay, isSameMonth, isToday, startOfMonth, startOfWeek } from 'date-fns'
+  import { eachDayOfInterval, endOfMonth, endOfWeek, format, isAfter, isBefore, isSameDay, isSameMonth, isToday, startOfMonth, startOfWeek } from 'date-fns'
   import { VNode, computed } from 'vue'
+  import { PTooltip } from '@/components/Tooltip'
   import { ClassValue } from '@/types/attributes'
   import { isDateAfter, isDateBefore, isNotNullish } from '@/utilities'
 
@@ -45,7 +50,9 @@
     modelValue: Date | null | undefined,
     viewingDate: Date,
     min?: Date | null | undefined,
+    minReason?: string,
     max?: Date | null | undefined,
+    maxReason?: string,
   }>()
 
   const emit = defineEmits<{
@@ -129,6 +136,22 @@
 
   function setSelected(date: Date): void {
     selected.value = date
+  }
+
+  function getReason(date: Date): string {
+    if (props.min && isBefore(date, props.min)) {
+      return props.minReason ?? ''
+    }
+
+    if (props.max && isAfter(date, props.max)) {
+      return props.maxReason ?? ''
+    }
+
+    return ''
+  }
+
+  function getReasonDisabled(date: Date): boolean {
+    return !getReason(date)
   }
 </script>
 

--- a/src/components/DatePicker/PDatePicker.vue
+++ b/src/components/DatePicker/PDatePicker.vue
@@ -1,6 +1,6 @@
 <template>
   <PContent class="p-date-picker" secondary>
-    <PCalendar v-model="selected" v-model:viewingDate="viewingDate" v-bind="{ min, max }">
+    <PCalendar v-model="selected" v-model:viewingDate="viewingDate" v-bind="{ min, max, minReason, maxReason }">
       <template #date="scope">
         <slot name="date" v-bind="scope" />
       </template>
@@ -37,7 +37,9 @@
     viewingDate?: Date | null | undefined,
     showTime?: boolean,
     min?: Date | null | undefined,
+    minReason?: string,
     max?: Date | null | undefined,
+    maxReason?: string,
   }>()
 
   const emit = defineEmits<{

--- a/src/components/DateRangeSelect/PDateRangeDurationInput.vue
+++ b/src/components/DateRangeSelect/PDateRangeDurationInput.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="p-date-range-duration-input">
-    <PNumberInput v-model="quantity" prepend="±" />
-    <PSelect v-model="unit" :options="units" />
+    <PNumberInput v-model="quantity" prepend="±" :small="small" />
+    <PSelect v-model="unit" :options="units" :small="small" />
   </div>
 </template>
 
@@ -15,6 +15,7 @@
   const props = defineProps<{
     quantity: number,
     unit: DateRangeSelectAroundUnit,
+    small?: boolean,
   }>()
 
   const emit = defineEmits<{

--- a/src/components/DateRangeSelect/PDateRangeSelect.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelect.vue
@@ -2,7 +2,7 @@
   <PPopOver ref="popover" class="p-date-range-select" :placement="placement" auto-close>
     <template #target="{ open }">
       <PTooltip :text="minReason" :disabled="!minReason || !previousDisabled || !modelValue">
-        <PButton class="p-date-range-select__button" icon="ArrowSmallLeftIcon" :disabled="previousDisabled" :size="size" @click="previous" />
+        <PButton class="p-date-range-select__button pointer-events-auto" icon="ArrowSmallLeftIcon" :disabled="previousDisabled" :size="size" @click="previous" />
       </PTooltip>
 
       <PButton class="p-date-range-select__button  p-date-range-select__input" :class="button({ size })" :disabled="disabled" :size="size" @click="open">
@@ -20,7 +20,7 @@
       </template>
 
       <PTooltip :text="maxReason" :disabled="!maxReason || !nextDisabled || !modelValue">
-        <PButton class="p-date-range-select__button" icon="ArrowSmallRightIcon" :disabled="nextDisabled" :size="size" @click="next" />
+        <PButton class="p-date-range-select__button pointer-events-auto" icon="ArrowSmallRightIcon" :disabled="nextDisabled" :size="size" @click="next" />
       </PTooltip>
     </template>
 

--- a/src/components/DateRangeSelect/PDateRangeSelectAround.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelectAround.vue
@@ -3,7 +3,7 @@
     <template #after-controls>
       <PLabel label="Duration">
         <template #default="{ id }">
-          <PDateRangeDurationInput :id="id" v-model:quantity="quantity" v-model:unit="unit" />
+          <PDateRangeDurationInput :id="id" v-model:quantity="quantity" v-model:unit="unit" small />
         </template>
       </PLabel>
     </template>

--- a/src/components/DateRangeSelect/PDateRangeSelectRange.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelectRange.vue
@@ -3,7 +3,7 @@
     v-model:start-date="startDate"
     v-model:end-date="endDate"
     class="p-date-range-select-range"
-    v-bind="{ min, max }"
+    v-bind="{ min, max, minReason, maxReason }"
     show-time
     @close="close"
     @apply="apply"
@@ -16,7 +16,9 @@
 
   defineProps<{
     min?: Date,
+    minReason?: string,
     max?: Date,
+    maxReason?: string,
   }>()
 
   const emit = defineEmits<{

--- a/src/components/DateRangeSelect/PDateRangeSelectRelative.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelectRelative.vue
@@ -2,7 +2,7 @@
   <PSelectOptions v-model="selected" :options="options" class="p-date-range-select-relative" @update:model-value="apply">
     <template #pre-options>
       <div class="p-1">
-        <PTextInput ref="input" v-model="search" placeholder="Relative time (15m, 1h, 1d, 1w)" />
+        <PTextInput ref="input" v-model="search" small placeholder="Relative time (15m, 1h, 1d, 1w)" />
       </div>
     </template>
     <template #option="{ option }">

--- a/src/components/DateTimeInputGroup/PDateTimeInputGroup.vue
+++ b/src/components/DateTimeInputGroup/PDateTimeInputGroup.vue
@@ -10,10 +10,10 @@
     </template>
 
     <PContent secondary>
-      <PNativeDateInput v-model="startDate" disable-picker />
+      <PNativeDateInput v-model="startDate" disable-picker small />
 
       <template v-if="showTime">
-        <PNativeTimeInput v-model="startTime" disable-picker />
+        <PNativeTimeInput v-model="startTime" disable-picker small />
       </template>
     </PContent>
   </PLabel>


### PR DESCRIPTION
# Description
In service of https://linear.app/prefect/issue/ENG-1502/prevent-users-from-selecting-dates-outside-of-their-retention-window this pr adds the ability to add reasons for min and max dates. This allows showing the user a tooltip if they hover over a date that has been disabled or on the previous/next buttons if they have been disabled because of the min/max dates. 

Side Quest: I also updated some of the buttons and inputs within the date select's popover to be size small

<img width="410" alt="image" src="https://github.com/user-attachments/assets/c1157934-2aa6-43ce-86df-703b73a17b01" />

<img width="514" alt="image" src="https://github.com/user-attachments/assets/509216a6-e9c3-441b-b82a-79bb77fd5327" />
