### PR TITLE
PDateRangeSelect - Omit year from label when it is the current year

### DIFF
--- a/demo/sections/components/DateRangeSelect.vue
+++ b/demo/sections/components/DateRangeSelect.vue
@@ -33,7 +33,6 @@
 
 <script lang="ts" setup>
   import { DateRangeSelectValue, State } from '@/types'
-  import { endOfDay, startOfWeek } from 'date-fns'
   import { ref } from 'vue'
   import ComponentPage from '@/demo/components/ComponentPage.vue'
   import DemoState from '@/demo/components/DemoState.vue'
@@ -42,8 +41,8 @@
   const disabled = ref(false)
 
   const value = ref<DateRangeSelectValue>({ type: 'span', seconds: -604800 })
-  const min = ref<Date>(startOfWeek(new Date()))
-  const max = ref<Date>(endOfDay(new Date()))
+  const min = ref<Date>()
+  const max = ref<Date>()
   const minReason = ref('min reason')
   const maxReason = ref('max reason')
   const clearable = ref(false)

--- a/src/components/DateRangeSelect/utilities.ts
+++ b/src/components/DateRangeSelect/utilities.ts
@@ -1,4 +1,4 @@
-import { format, isSameDay, startOfDay, endOfDay, Duration } from 'date-fns'
+import { format, isSameDay, startOfDay, endOfDay, Duration, isSameYear } from 'date-fns'
 import { secondsInDay, secondsInHour, secondsInMinute, secondsInWeek } from 'date-fns/constants'
 import { DateRangeSelectAroundValue, DateRangeSelectPeriodValue, DateRangeSelectRangeValue, DateRangeSelectSpanValue, DateRangeSelectValue } from '@/types'
 import { toPluralString } from '@/utilities'
@@ -9,9 +9,11 @@ type DateRange = {
   endDate: Date,
 }
 
-const dateFormat = 'MMM do, yyyy'
+const dateFormat = 'MMM do'
+const dateAndYearFormat = 'MMM do, yyyy'
 const timeFormat = 'hh:mm a'
 const dateTimeFormat = `${dateFormat} 'at' ${timeFormat}`
+const dateTimeAndYearFormat = `${dateAndYearFormat} 'at' ${timeFormat}`
 
 export function getDateRangeSelectValueLabel(value: DateRangeSelectValue): string | null {
   if (!value) {
@@ -66,18 +68,26 @@ function getDateSpanLabel({ seconds }: DateRangeSelectSpanValue): string {
 
 function getDateRangeLabel({ startDate, endDate }: DateRangeSelectRangeValue): string {
   if (isPickerSingleDayRange({ startDate, endDate })) {
-    return format(startDate, dateFormat)
+    const startDateFormat = isSameYear(startDate, new Date()) ? dateFormat : dateAndYearFormat
+
+    return format(startDate, startDateFormat)
   }
 
   if (isFullDateRange({ startDate, endDate })) {
-    return `${format(startDate, dateFormat)} - ${format(endDate, dateFormat)}`
+    const startDateFormat = isSameYear(startDate, new Date()) ? dateFormat : dateAndYearFormat
+    const endDateFormat = isSameYear(endDate, new Date()) ? dateFormat : dateAndYearFormat
+
+    return `${format(startDate, startDateFormat)} - ${format(endDate, endDateFormat)}`
   }
 
-  return `${format(startDate, dateTimeFormat)} - ${format(endDate, dateTimeFormat)}`
+  const startDateFormat = isSameYear(startDate, new Date()) ? dateTimeFormat : dateTimeAndYearFormat
+  const endDateFormat = isSameYear(endDate, new Date()) ? dateTimeFormat : dateTimeAndYearFormat
+
+  return `${format(startDate, startDateFormat)} - ${format(endDate, endDateFormat)}`
 }
 
 function getDateAroundLabel({ date, quantity, unit }: DateRangeSelectAroundValue): string {
-  const dateString = isStartOfDay(date) ? format(date, dateFormat) : format(date, dateTimeFormat)
+  const dateString = isStartOfDay(date) ? format(date, dateAndYearFormat) : format(date, dateTimeAndYearFormat)
 
   return `${quantity} ${toPluralString(unit, quantity)} around ${dateString}`
 }


### PR DESCRIPTION
# Description
The input's description of the selected date range can be very long. Omitting the year when its the current year makes it more concise and also a little easier to read. 

Before
<img width="503" alt="image" src="https://github.com/user-attachments/assets/036db742-3361-45de-8406-0f6387f22382" />

After
<img width="614" alt="image" src="https://github.com/user-attachments/assets/6399c5a6-c925-471b-b522-40a58b09ffba" />
