### PR TITLE
PTooltip - Add a max-width to tooltip content

### DIFF
--- a/demo/sections/components/Tooltip.vue
+++ b/demo/sections/components/Tooltip.vue
@@ -5,7 +5,9 @@
         This is a sentence with a
         <p-tooltip text="This is a Tooltip component">
           <p-link>tooltip</p-link>
-        </p-tooltip> in it.
+        </p-tooltip> in it. And this is another with a longer <p-tooltip open text="Yep, this is a longer tooltip alright. It just keeps on going. A bit to long probably.">
+          <p-link>tooltip</p-link>
+        </p-tooltip>.
       </p>
     </template>
 

--- a/src/components/Tooltip/PTooltipContent.vue
+++ b/src/components/Tooltip/PTooltipContent.vue
@@ -28,7 +28,7 @@
 </script>
 
 <style>
-.p-tooltip{@apply
+.p-tooltip { @apply
   z-50
   overflow-hidden
   rounded-md
@@ -50,5 +50,6 @@
   data-[side=left]:slide-in-from-right-2
   data-[side=right]:slide-in-from-left-2
   data-[side=top]:slide-in-from-bottom-2
+  max-w-[var(--p-tooltip-max-width,300px)]
 }
 </style>


### PR DESCRIPTION
# Description
Longer tooltips don't break into multiple lines automatically. Adding a max with (that can be overridden via a css property) makes longer tooltips more readable without needing to customize each implementation's width. 