### PR TITLE
fix: Fixes docker fill color

### DIFF
--- a/src/components/Icon/icons/docker.svg
+++ b/src/components/Icon/icons/docker.svg
@@ -3,7 +3,7 @@
   <defs>
     <style>
       .cls-1 {
-        fill: "currentColor";
+        fill: currentColor;
         stroke-width: 0px;
       }
     </style>


### PR DESCRIPTION
Fixes docker fill color.
If its in a css class, need to remove the `""`

https://github.com/user-attachments/assets/8829636b-e27c-4450-a038-9889ad4e26b3

