### PR TITLE
Enhancement: `PMarkdownRenderer` anchors

### DIFF
--- a/src/components/Heading/PHeading.vue
+++ b/src/components/Heading/PHeading.vue
@@ -6,9 +6,10 @@
 
 <script lang="ts" setup>
   import { computed } from 'vue'
+  import { HeadingLevel } from '@/components/Heading/utilities'
 
   const props = defineProps<{
-    heading?: 1 | 2 | 3 | 4 | 5 | 6 | '1' | '2' | '3' | '4' | '5' | '6',
+    heading?: HeadingLevel,
     element?: string,
   }>()
 

--- a/src/components/Heading/utilities.ts
+++ b/src/components/Heading/utilities.ts
@@ -1,0 +1,5 @@
+export type HeadingLevel = 1 | 2 | 3 | 4 | 5 | 6 | '1' | '2' | '3' | '4' | '5' | '6'
+
+export function isHeadingLevel(value: unknown): value is HeadingLevel {
+  return typeof value === 'number' && [1, 2, 3, 4, 5, 6].includes(value) || typeof value === 'string' && ['1', '2', '3', '4', '5', '6'].includes(value)
+}

--- a/src/components/MarkdownRenderer/parser.ts
+++ b/src/components/MarkdownRenderer/parser.ts
@@ -120,7 +120,14 @@ const getVNode = (token: Token, options: ParserOptions): VNode | VNode[] => {
   if (isHeading(token)) {
     const { depth, text } = token
     const classList = [headingClasses[depth], `${baseClass}__heading`, `${baseClass}__heading--h${depth}`]
-    const heading = h(PHashLink, { hash: text, depth, class: [...classList, `${baseClass}__heading-wrapper`] }, { default: () => children })
+
+    let heading
+
+    if (options.headerAnchors) {
+      heading = h(PHashLink, { hash: text, depth, class: [...classList, `${baseClass}__heading-wrapper`] }, { default: () => children })
+    } else {
+      heading = h(baseElement, { class: classList }, children)
+    }
 
     if (depth < 2) {
       return [heading, h(PDivider)]

--- a/src/components/MarkdownRenderer/parser.ts
+++ b/src/components/MarkdownRenderer/parser.ts
@@ -1,7 +1,8 @@
 import { marked } from 'marked'
 
 import { VNode, h, createTextVNode as t } from 'vue'
-import { PCheckbox, PCode, PCodeHighlight, PDivider, PLink, PSanitizeHtml, PHashLink, PTable } from '@/components'
+import { PCheckbox, PCode, PCodeHighlight, PDivider, PSanitizeHtml, PHashLink, PTable, PHeading } from '@/components'
+import { HeadingLevel, isHeadingLevel } from '@/components/Heading/utilities'
 import { isSupportedLanguage } from '@/types/codeHighlight'
 import {
   Token,
@@ -31,7 +32,6 @@ import { unescapeHtml } from '@/utilities/strings'
 const baseElement = 'div'
 const baseClass = 'markdown-renderer'
 const defaultHeadingClasses = ['text-4xl', 'text-3xl', 'text-2xl', 'text-lg', 'text-base', 'text-sm']
-
 
 const mapChildTokens = (tokens: Token[], options: ParserOptions): VNodeChildren => tokens.flatMap((token) => getVNode(token, options))
 
@@ -119,12 +119,14 @@ const getVNode = (token: Token, options: ParserOptions): VNode | VNode[] => {
 
   if (isHeading(token)) {
     const { depth, text } = token
-    const classList = [headingClasses[depth], `${baseClass}__heading`, `${baseClass}__heading--h${depth}`]
+    const classList = [headingClasses[depth], `${baseClass}__heading`, `${baseClass}__heading--h${depth}`, `${baseClass}__heading-wrapper`]
 
     let heading
 
     if (options.headerAnchors) {
-      heading = h(PHashLink, { hash: text, depth, class: [...classList, `${baseClass}__heading-wrapper`] }, { default: () => children })
+      heading = h(PHashLink, { hash: text, depth, class: classList }, { default: () => children })
+    } else if (isHeadingLevel(depth)) {
+      heading = h(PHeading, { class: classList, heading: depth }, { default: () => children })
     } else {
       heading = h(baseElement, { class: classList }, children)
     }

--- a/src/components/MarkdownRenderer/parser.ts
+++ b/src/components/MarkdownRenderer/parser.ts
@@ -2,7 +2,7 @@ import { marked } from 'marked'
 
 import { VNode, h, createTextVNode as t } from 'vue'
 import { PCheckbox, PCode, PCodeHighlight, PDivider, PSanitizeHtml, PHashLink, PTable, PHeading } from '@/components'
-import { HeadingLevel, isHeadingLevel } from '@/components/Heading/utilities'
+import { isHeadingLevel } from '@/components/Heading/utilities'
 import { isSupportedLanguage } from '@/types/codeHighlight'
 import {
   Token,

--- a/src/types/markdownRenderer.ts
+++ b/src/types/markdownRenderer.ts
@@ -16,6 +16,7 @@ export type ParseMessagePayload = {
 
 export type ParserOptions = {
   headingClasses?: string[],
+  headerAnchors?: boolean,
 }
 
 export function isToken(token: unknown): token is Token {


### PR DESCRIPTION
Removes the default anchor elements used in the markdown renderer in favor of a more straightforward heading element in most cases.