### PR TITLE
feat: Re-orders date range with new Past 7 and 30 day options

### DIFF
--- a/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
+++ b/src/components/DateRangeSelect/PDateRangeSelectOptions.vue
@@ -3,9 +3,10 @@
 </template>
 
 <script lang="ts" setup>
-  import { secondsInDay, secondsInHour, secondsInMonth, secondsInWeek } from 'date-fns/constants'
+  import { secondsInDay, secondsInHour } from 'date-fns/constants'
   import { computed } from 'vue'
   import { DateRangeSelectMode } from '@/components/DateRangeSelect/PDateRangeSelect.vue'
+  import { PAST_7_DAYS_SECONDS, PAST_30_DAYS_SECONDS } from '@/components/DateRangeSelect/utilities'
   import PSelectOptions from '@/components/Select/PSelectOptions.vue'
   import { DateRangeSelectPeriod, DateRangeSelectPeriodValue, DateRangeSelectSpanValue, SelectOption, isDateRangeSelectPeriod } from '@/types'
 
@@ -40,8 +41,8 @@
   const options: (SelectOption & { value: DateRangeSelectMode | DateRangeSelectPeriod | number })[] = [
     { label: 'Past hour', value: secondsInHour * -1 },
     { label: 'Past day', value: secondsInDay * -1 },
-    { label: 'Past week', value: secondsInWeek * -1 },
-    { label: 'Past month', value: secondsInMonth * -1 },
+    { label: 'Past 7 days', value: PAST_7_DAYS_SECONDS * -1 },
+    { label: 'Past 30 days', value: PAST_30_DAYS_SECONDS * -1 },
     { label: 'Today', value: 'Today' },
     { label: 'Relative time', value: 'span' },
     { label: 'Around a time', value: 'around' },

--- a/src/components/DateRangeSelect/utilities.ts
+++ b/src/components/DateRangeSelect/utilities.ts
@@ -9,6 +9,9 @@ type DateRange = {
   endDate: Date,
 }
 
+export const PAST_7_DAYS_SECONDS = secondsInDay * 7
+export const PAST_30_DAYS_SECONDS = secondsInDay * 30
+
 const dateFormat = 'MMM do'
 const dateAndYearFormat = 'MMM do, yyyy'
 const timeFormat = 'hh:mm a'
@@ -39,9 +42,13 @@ export function getDateRangeSelectValueLabel(value: DateRangeSelectValue): strin
 function getDateSpanLabel({ seconds }: DateRangeSelectSpanValue): string {
   const absSeconds = Math.abs(seconds)
 
-  // nb: Because secondsInMonth is an average, just return Past month label when option is selected
-  if (absSeconds === secondsInMonth) {
-    return 'Past month'
+  // nb: Edge case to specifically diplay Past 7 days and Past 30 days options
+  if (absSeconds === PAST_7_DAYS_SECONDS) {
+    return 'Past 7 days'
+  }
+
+  if (absSeconds === PAST_30_DAYS_SECONDS) {
+    return 'Past 30 days'
   }
 
   const duration: Duration = {


### PR DESCRIPTION
Based on recent feedback, have the following options:

> Past hour
Past day
Past 7 days
Past 30 days

https://github.com/user-attachments/assets/cfd5fac1-c0e7-4293-8f38-673996a941ac

