### PR TITLE
Configure dependabot to consolidate npm updates into single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Updated dependabot configuration to group all npm dependency updates into a single weekly PR
- This reduces PR noise and makes it easier to review and merge dependency updates
- Future dependabot runs will create one consolidated PR instead of individual PRs per dependency
