### PR TITLE
allow controls inside of PBaseInput to receive listeners as well

### DIFF
--- a/src/components/BaseInput/PBaseInput.vue
+++ b/src/components/BaseInput/PBaseInput.vue
@@ -60,6 +60,7 @@
 
   const attrsForControl = computed(() => ({
     ...attrs.value,
+    ...listeners.value,
     disabled: props.disabled,
     class: {
       'p-base-input__control': true,

--- a/src/components/TextInput/PTextInput.vue
+++ b/src/components/TextInput/PTextInput.vue
@@ -10,7 +10,6 @@
         type="text"
         class="p-text-input__control"
         v-bind="attrs"
-        @focus="handleFocus"
       >
     </template>
   </PBaseInput>
@@ -26,7 +25,6 @@
 
   const emits = defineEmits<{
     (event: 'update:modelValue', value: string | null): void,
-    (event: 'focus'): void,
   }>()
 
   const wrapperElement = ref<typeof PBaseInput>()
@@ -44,10 +42,6 @@
       emits('update:modelValue', value)
     },
   })
-
-  const handleFocus = (): void => {
-    emits('focus')
-  }
 </script>
 
 <style>


### PR DESCRIPTION
When `p-base-input` separates `attrs, listeners, styles, classes` from `useAttrs` it only ever sends the `attrs` through to the underlying #control slot element. This separation makes sense for things like class/style to prevent doubling up of class names or styles on both the parent element and the control. However, for listeners I think having them apply to both the parent and the control is a better design. 

With this PR, the control now has the option of consuming these events without having to explicitly "forward" listeners, which you're currently doing for `focus` but there are hundreds of native events across all components that build off `p-base-input`.

```ts
<!-- not possible without fix -->
<PTextInput @blur="handleBlurEvent"/>
```